### PR TITLE
Fix PDM missing virtualenv

### DIFF
--- a/modules/home/profiles/python.nix
+++ b/modules/home/profiles/python.nix
@@ -1,5 +1,10 @@
 { pkgs, ... }:
 
+let
+  python = pkgs.python3Minimal.withPackages (ps: [
+    ps.virtualenv
+  ]);
+in
 {
   programs.neovim.withPython3 = true;
 
@@ -9,7 +14,7 @@
   ];
 
   home.packages = [
-    pkgs.python3Minimal
+    python
     pkgs.poetry
     pkgs.pdm
     pkgs.pipx

--- a/modules/home/profiles/python.nix
+++ b/modules/home/profiles/python.nix
@@ -12,5 +12,6 @@
     pkgs.python3Minimal
     pkgs.poetry
     pkgs.pdm
+    pkgs.pipx
   ];
 }


### PR DESCRIPTION
Fix PDM missing virtualenv

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/shikanime/shikanime/pull/44).
* __->__ #44
* #43