### PR TITLE
Enforce ssh-agent keys with IdentitiesOnly

### DIFF
--- a/modules/home/identities/sfeir.nix
+++ b/modules/home/identities/sfeir.nix
@@ -5,6 +5,7 @@
     "gitlab.sfeir.internal" = {
       hostname = "gitlab.com";
       identityFile = [ "${config.home.homeDirectory}/.ssh/sfeir_ed25519" ];
+      identitiesOnly = true;
     };
   };
 


### PR DESCRIPTION
Enforce ssh-agent keys with IdentitiesOnly
