### PR TITLE
Back out "Enforce ssh-agent keys with IdentitiesOnly (#99)"

### DIFF
--- a/modules/home/identities/sfeir.nix
+++ b/modules/home/identities/sfeir.nix
@@ -5,7 +5,6 @@
     "gitlab.sfeir.internal" = {
       hostname = "gitlab.com";
       identityFile = [ "${config.home.homeDirectory}/.ssh/sfeir_ed25519" ];
-      identitiesOnly = true;
     };
   };
 


### PR DESCRIPTION
Back out "Enforce ssh-agent keys with IdentitiesOnly (#99)"

Original commit changeset: 50db50c2be14
