### PR TITLE
Fix git credential manager

### DIFF
--- a/modules/home/hosts/ishtar-base.nix
+++ b/modules/home/hosts/ishtar-base.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 
 {
   imports = [
@@ -32,7 +32,7 @@
   targets.genericLinux.enable = true;
 
   programs.git.extraConfig.credential.helper =
-    "/mnt/c/Users/willi/scoop/shims/git-credential-manager.exe";
+    "/mnt/c/Users/${config.home.username}/scoop/shims/git-credential-manager.exe";
 
   # CUDA support
   home.sessionVariables.LD_LIBRARY_PATH = "/usr/lib/wsl/lib";


### PR DESCRIPTION
Fix git credential manager

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/shikanime/shikanime/pull/123).
* #124
* __->__ #123