### PR TITLE
Update Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -68,11 +68,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1739003866,
-        "narHash": "sha256-Uxc5JYTB9Dij4t8SBQmfs6Gh5DDsGRS37v3uPQfNvAg=",
+        "lastModified": 1739444039,
+        "narHash": "sha256-J7PLowc4pCdEkXEWtm72bC6gNNlT7sgNAq5YMZmvvkg=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "ebaa7440666d6aadea574b723c9188cf6f56447f",
+        "rev": "1235cd13f47df6ad19c8a183c6eabc1facb7c399",
         "type": "github"
       },
       "original": {
@@ -338,11 +338,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1739051380,
-        "narHash": "sha256-p1QSLO8DJnANY+ppK7fjD8GqfCrEIDjso1CSRHsXL7Y=",
+        "lastModified": 1739658904,
+        "narHash": "sha256-2o/JuD6qD0CtPNVvdPNL3bEDFITaSfSLceajHcIzmw4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5af1b9a0f193ab6138b89a8e0af8763c21bbf491",
+        "rev": "45c07fcf7d28b5fb3ee189c260dee0a2e4d14317",
         "type": "github"
       },
       "original": {
@@ -442,11 +442,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1739034224,
-        "narHash": "sha256-Mj/8jDzh1KNmUhWqEeVlW3hO9MZkxqioJGnmR7rivaE=",
+        "lastModified": 1739548217,
+        "narHash": "sha256-rlv64erpr36xdmMDPgf9rhRXBYZ0BZb5nrw2ZPSk1sQ=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "0b6f96a6b9efcfa8d3cc8023008bcbcd1b9bc1a4",
+        "rev": "678b22642abde2ee77ae2218ab41d802f010e5b0",
         "type": "github"
       },
       "original": {
@@ -513,11 +513,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1736095716,
-        "narHash": "sha256-csysw/Szu98QDiA2lhWk9seYOyCebeVEWL89zh1cduM=",
+        "lastModified": 1739577062,
+        "narHash": "sha256-u/trdPzJO8UotNq48RbG7m6Pe8761IEMCOY0QidNjY4=",
         "owner": "nix-community",
         "repo": "NixOS-WSL",
-        "rev": "63c3b4ed1712a3a0621002cd59bfdc80875ecbb0",
+        "rev": "0b2b8b31f69f24e9a75b4b18a32c771a48612d5e",
         "type": "github"
       },
       "original": {
@@ -584,27 +584,27 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1733384649,
-        "narHash": "sha256-K5DJ2LpPqht7K76bsxetI+YHhGGRyVteTPRQaIIKJpw=",
+        "lastModified": 1739357830,
+        "narHash": "sha256-9xim3nJJUFbVbJCz48UP4fGRStVW5nv4VdbimbKxJ3I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "190c31a89e5eec80dd6604d7f9e5af3802a58a13",
+        "rev": "0ff09db9d034a04acd4e8908820ba0b410d7a33a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_12": {
       "locked": {
-        "lastModified": 1739019272,
-        "narHash": "sha256-7Fu7oazPoYCbDzb9k8D/DdbKrC3aU1zlnc39Y8jy/s8=",
+        "lastModified": 1739451785,
+        "narHash": "sha256-3ebRdThRic9bHMuNi2IAA/ek9b32bsy8F5R4SvGTIog=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fa35a3c8e17a3de613240fea68f876e5b4896aec",
+        "rev": "1128e89fd5e11bb25aedbfc287733c6502202ea9",
         "type": "github"
       },
       "original": {
@@ -664,11 +664,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1738680400,
-        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
+        "lastModified": 1739020877,
+        "narHash": "sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
+        "rev": "a79cfe0ebd24952b580b1cf08cd906354996d547",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #289
* __->__ #288

Flake lock file updates:

• Updated input 'devenv':
    'github:cachix/devenv/ebaa7440666d6aadea574b723c9188cf6f56447f?narHash=sha256-Uxc5JYTB9Dij4t8SBQmfs6Gh5DDsGRS37v3uPQfNvAg%3D' (2025-02-08)
  → 'github:cachix/devenv/1235cd13f47df6ad19c8a183c6eabc1facb7c399?narHash=sha256-J7PLowc4pCdEkXEWtm72bC6gNNlT7sgNAq5YMZmvvkg%3D' (2025-02-13)
• Updated input 'home-manager':
    'github:nix-community/home-manager/5af1b9a0f193ab6138b89a8e0af8763c21bbf491?narHash=sha256-p1QSLO8DJnANY%2BppK7fjD8GqfCrEIDjso1CSRHsXL7Y%3D' (2025-02-08)
  → 'github:nix-community/home-manager/45c07fcf7d28b5fb3ee189c260dee0a2e4d14317?narHash=sha256-2o/JuD6qD0CtPNVvdPNL3bEDFITaSfSLceajHcIzmw4%3D' (2025-02-15)
• Updated input 'home-manager/nixpkgs':
    'github:NixOS/nixpkgs/799ba5bffed04ced7067a91798353d360788b30d?narHash=sha256-ooLh%2BXW8jfa%2B91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U%3D' (2025-02-04)
  → 'github:NixOS/nixpkgs/a79cfe0ebd24952b580b1cf08cd906354996d547?narHash=sha256-mIvECo/NNdJJ/bXjNqIh8yeoSjVLAuDuTUzAo7dzs8Y%3D' (2025-02-08)
• Updated input 'nix-darwin':
    'github:LnL7/nix-darwin/0b6f96a6b9efcfa8d3cc8023008bcbcd1b9bc1a4?narHash=sha256-Mj/8jDzh1KNmUhWqEeVlW3hO9MZkxqioJGnmR7rivaE%3D' (2025-02-08)
  → 'github:LnL7/nix-darwin/678b22642abde2ee77ae2218ab41d802f010e5b0?narHash=sha256-rlv64erpr36xdmMDPgf9rhRXBYZ0BZb5nrw2ZPSk1sQ%3D' (2025-02-14)
• Updated input 'nixos-wsl':
    'github:nix-community/NixOS-WSL/63c3b4ed1712a3a0621002cd59bfdc80875ecbb0?narHash=sha256-csysw/Szu98QDiA2lhWk9seYOyCebeVEWL89zh1cduM%3D' (2025-01-05)
  → 'github:nix-community/NixOS-WSL/0b2b8b31f69f24e9a75b4b18a32c771a48612d5e?narHash=sha256-u/trdPzJO8UotNq48RbG7m6Pe8761IEMCOY0QidNjY4%3D' (2025-02-14)
• Updated input 'nixos-wsl/nixpkgs':
    'github:NixOS/nixpkgs/190c31a89e5eec80dd6604d7f9e5af3802a58a13?narHash=sha256-K5DJ2LpPqht7K76bsxetI%2BYHhGGRyVteTPRQaIIKJpw%3D' (2024-12-05)
  → 'github:NixOS/nixpkgs/0ff09db9d034a04acd4e8908820ba0b410d7a33a?narHash=sha256-9xim3nJJUFbVbJCz48UP4fGRStVW5nv4VdbimbKxJ3I%3D' (2025-02-12)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/fa35a3c8e17a3de613240fea68f876e5b4896aec?narHash=sha256-7Fu7oazPoYCbDzb9k8D/DdbKrC3aU1zlnc39Y8jy/s8%3D' (2025-02-08)
  → 'github:nixos/nixpkgs/1128e89fd5e11bb25aedbfc287733c6502202ea9?narHash=sha256-3ebRdThRic9bHMuNi2IAA/ek9b32bsy8F5R4SvGTIog%3D' (2025-02-13)