### PR TITLE
Fix ghstack checkout depth

### DIFF
--- a/.github/workflows/land.yaml
+++ b/.github/workflows/land.yaml
@@ -14,6 +14,7 @@ jobs:
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
+          fetch-depth: 0
           token: ${{ steps.createGithubAppToken.outputs.token }}
       - uses: DeterminateSystems/nix-installer-action@v13
         with:


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Fixed the GitHub Actions checkout step to fetch all history.

- Added `fetch-depth: 0` to ensure complete repository history.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>land.yaml</strong><dd><code>Adjusted checkout depth in GitHub Actions workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/land.yaml

<li>Added <code>fetch-depth: 0</code> to the <code>actions/checkout</code> step.<br> <li> Ensures the full repository history is fetched during the workflow.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/290/files#diff-d7299ef3b0de3347af2e5799b92ac8baece4224257e2fd6455d52b675e6e1592">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>