### PR TITLE
Fix Darwin deprecated config

### DIFF
--- a/modules/darwin/profiles/base.nix
+++ b/modules/darwin/profiles/base.nix
@@ -24,12 +24,9 @@
     "@admin"
   ];
 
-  # Enable daemon service
-  nix.useDaemon = true;
-
   # This value determines the Darwin release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken It‘s perfectly fine and recommended to leave
   # this value at the release version of the first install of this system
-  system.stateVersion = 5;
+  system.stateVersion = 6;
 }

--- a/modules/home/profiles/base.nix
+++ b/modules/home/profiles/base.nix
@@ -17,9 +17,6 @@
     ];
   };
 
-  # Allow unfree software such as Cloudflared or CUDA
-  nixpkgs.config.allowUnfree = true;
-
   # Let Home Manager install and manage itself
   programs.home-manager.enable = true;
 


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #294


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Removed deprecated `nix.useDaemon` configuration in Darwin profile.

- Updated `system.stateVersion` from 5 to 6 in Darwin profile.

- Removed `nixpkgs.config.allowUnfree` configuration in Home profile.

- Simplified and modernized Nix configuration for better compatibility.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.nix</strong><dd><code>Updated and removed deprecated Darwin configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/darwin/profiles/base.nix

<li>Removed <code>nix.useDaemon</code> configuration.<br> <li> Updated <code>system.stateVersion</code> from 5 to 6.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/294/files#diff-a1d835f7873401409bb7aa3a434013670d03bb8e485ee403f01096ffedebfade">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>base.nix</strong><dd><code>Removed unfree software configuration in Home profile</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/home/profiles/base.nix

<li>Removed <code>nixpkgs.config.allowUnfree</code> configuration.<br> <li> Simplified Nix configuration for Home profile.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/294/files#diff-508e4df48bc87d038c26537a2b88ee83de4e21fa02ec16c41328aa509a18e090">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>