### PR TITLE
Refactor exit node config from network profile

### DIFF
--- a/modules/nixos/hosts/fushi.nix
+++ b/modules/nixos/hosts/fushi.nix
@@ -24,4 +24,9 @@
   networking.hostName = "fushi";
 
   services.k3s.serverAddr = "https://nishir.taila659a.ts.net:6443";
+
+  services.tailscale = {
+    extraUpFlags = [ "--ssh" ];
+    useRoutingFeatures = "server";
+  };
 }

--- a/modules/nixos/hosts/nishir.nix
+++ b/modules/nixos/hosts/nishir.nix
@@ -24,4 +24,9 @@
   networking.hostName = "nishir";
 
   services.k3s.role = "server";
+
+  services.tailscale = {
+    extraUpFlags = [ "--ssh" ];
+    useRoutingFeatures = "server";
+  };
 }

--- a/modules/nixos/hosts/nixtar.nix
+++ b/modules/nixos/hosts/nixtar.nix
@@ -18,5 +18,9 @@
     role = "server";
   };
 
+  services.tailscale.extraUpFlags = [
+    "--ssh"
+  ];
+
   wsl.defaultUser = "shika";
 }

--- a/modules/nixos/profiles/network.nix
+++ b/modules/nixos/profiles/network.nix
@@ -2,18 +2,11 @@
   # Enable Tailscale traffic optimizations
   boot.kernel.sysctl = {
     "net.core.rmem_default" = 7340032;
-    "net.ipv4.ip_forward" = 1;
-    "net.ipv6.conf.all.forwarding" = 1;
   };
 
   # Enable VPN access
   services.tailscale = {
     enable = true;
     openFirewall = true;
-    useRoutingFeatures = "server";
-    extraUpFlags = [
-      "--ssh"
-      "--advertise-exit-node"
-    ];
   };
 }


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #329


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored Tailscale configuration for multiple host files.

- Removed redundant Tailscale settings from `network.nix`.

- Added `extraUpFlags` and `useRoutingFeatures` to individual host configurations.

- Improved modularity by moving exit node configurations out of `network.nix`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fushi.nix</strong><dd><code>Add Tailscale configuration to `fushi.nix`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/nixos/hosts/fushi.nix

<li>Added <code>services.tailscale</code> configuration.<br> <li> Included <code>extraUpFlags</code> with <code>--ssh</code>.<br> <li> Set <code>useRoutingFeatures</code> to <code>server</code>.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/329/files#diff-6dadec0fc5111b18d413eb9a8cfeaabdb633f978ebc6e08de0f21ab095ecb5a6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nishir.nix</strong><dd><code>Add Tailscale configuration to `nishir.nix`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/nixos/hosts/nishir.nix

<li>Added <code>services.tailscale</code> configuration.<br> <li> Included <code>extraUpFlags</code> with <code>--ssh</code>.<br> <li> Set <code>useRoutingFeatures</code> to <code>server</code>.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/329/files#diff-137993a4e1532e3a66e2fcc8de71a7b3558b4ecfebadb1b0122cd1c5a3222a48">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nixtar.nix</strong><dd><code>Add Tailscale `extraUpFlags` to `nixtar.nix`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/nixos/hosts/nixtar.nix

- Added `services.tailscale.extraUpFlags` with `--ssh`.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/329/files#diff-feb7758af1cd5472c58426cf760f79173569d488447cc270113831dff5b49c6f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>network.nix</strong><dd><code>Remove redundant Tailscale settings from `network.nix`</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/nixos/profiles/network.nix

<li>Removed <code>useRoutingFeatures</code> and <code>extraUpFlags</code> from Tailscale <br>configuration.<br> <li> Simplified Tailscale settings by removing exit node configurations.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/329/files#diff-9bb6d9023bcbd8581dd9842a03fd871504756a1363a455313b7db7507791f097">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>