### PR TITLE
Add Sapling compat layer to Jujutsu

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -360,11 +360,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1742557097,
-        "narHash": "sha256-L6YM0KDl7IY2cj9oAK/G9zldQQA8iBbbputEVCwzciY=",
+        "lastModified": 1742830035,
+        "narHash": "sha256-tCPI5f3XDxeb+qiXHNQvg5RRb4VlVjtJIOruMV+ogyo=",
         "owner": "shikanime",
         "repo": "identities",
-        "rev": "857a3efe73eb36ed76d6f7b5ae563797783f8a4a",
+        "rev": "576a9c0c33dbacc194b25cf8163575373f564cdd",
         "type": "github"
       },
       "original": {

--- a/modules/home/profiles/vcs.nix
+++ b/modules/home/profiles/vcs.nix
@@ -96,7 +96,12 @@
         bo = [ "bookmark" ];
         am = [ "squash" ];
         ci = [ "commit" ];
-        push = ["git" "push" "-r" "((trunk..@): & remote_branches()) & ~author(me)"];
+        push = [
+          "git"
+          "push"
+          "-r"
+          "((trunk..@): & remote_branches()) & ~author(me)"
+        ];
       };
       git = {
         private-commits = "description(glob:'secret:*')";

--- a/modules/home/profiles/vcs.nix
+++ b/modules/home/profiles/vcs.nix
@@ -96,7 +96,7 @@
         bo = [ "bookmark" ];
         am = [ "squash" ];
         ci = [ "commit" ];
-        push = ["git", "push", "-r", "((trunk..@): & remote_branches()) & ~author(me)"]
+        push = ["git" "push" "-r" "((trunk..@): & remote_branches()) & ~author(me)"];
       };
       git = {
         private-commits = "description(glob:'secret:*')";

--- a/modules/home/profiles/vcs.nix
+++ b/modules/home/profiles/vcs.nix
@@ -93,8 +93,10 @@
     settings = {
       aliases = {
         ab = [ "absorb" ];
+        bo = [ "bookmark" ];
+        am = [ "squash" ];
         ci = [ "commit" ];
-        sq = [ "squash" ];
+        push = ["git", "push", "-r", "((trunk..@): & remote_branches()) & ~author(me)"]
       };
       git = {
         private-commits = "description(glob:'secret:*')";


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #334


___

### **PR Type**
enhancement


___

### **Description**
- Added new aliases for `jujutsu` commands.

- Updated the `push` alias with a specific command.

- Enhanced compatibility layer for Sapling in `jujutsu`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vcs.nix</strong><dd><code>Updated `jujutsu` aliases and settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/home/profiles/vcs.nix

<li>Added new aliases <code>bo</code> for <code>bookmark</code> and <code>am</code> for <code>squash</code>.<br> <li> Replaced <code>sq</code> alias with a new <code>push</code> command.<br> <li> Enhanced <code>jujutsu</code> settings with updated configurations.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/334/files#diff-e299851741c16a7d22022ea7bf11a2b86cf0e575178f1f3bb41cd5b7cd7a7271">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>