### PR TITLE
Fix Ishtar networking conflict

### DIFF
--- a/modules/nixos/hosts/nixtar.nix
+++ b/modules/nixos/hosts/nixtar.nix
@@ -5,7 +5,6 @@
     "${modulesPath}/profiles/headless.nix"
     ../profiles/base.nix
     ../profiles/cluster.nix
-    ../profiles/network.nix
     ../profiles/workstation.nix
     ../profiles/wsl.nix
     ../users/shika.nix
@@ -17,10 +16,6 @@
     enable = true;
     role = "server";
   };
-
-  services.tailscale.extraUpFlags = [
-    "--ssh"
-  ];
 
   wsl.defaultUser = "shika";
 }


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #338
* #337
* __->__ #336


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Removed conflicting `network.nix` profile from imports.

- Deleted `tailscale.extraUpFlags` configuration to resolve networking conflict.

- Simplified and cleaned up the `nixtar.nix` configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nixtar.nix</strong><dd><code>Fix networking conflict and simplify configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/nixos/hosts/nixtar.nix

<li>Removed <code>network.nix</code> from imports to avoid conflict.<br> <li> Deleted <code>tailscale.extraUpFlags</code> configuration.<br> <li> Simplified the configuration for better maintainability.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/336/files#diff-feb7758af1cd5472c58426cf760f79173569d488447cc270113831dff5b49c6f">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>