### PR TITLE
Remove Nixtar's k3s

### DIFF
--- a/modules/nixos/hosts/nixtar.nix
+++ b/modules/nixos/hosts/nixtar.nix
@@ -12,10 +12,5 @@
 
   networking.hostName = "nixtar";
 
-  services.k3s = {
-    enable = true;
-    role = "server";
-  };
-
   wsl.defaultUser = "shika";
 }


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #338
* __->__ #337
* #336


___

### **PR Type**
Enhancement


___

### **Description**
- Removed the `k3s` service configuration from `nixtar.nix`.

- Simplified the configuration by eliminating unnecessary service settings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nixtar.nix</strong><dd><code>Removed `k3s` service configuration block</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/nixos/hosts/nixtar.nix

<li>Removed the <code>k3s</code> service configuration block.<br> <li> Simplified the file by eliminating <code>k3s</code> service settings.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/337/files#diff-feb7758af1cd5472c58426cf760f79173569d488447cc270113831dff5b49c6f">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>