### PR TITLE
Remove cluster default encryption

### DIFF
--- a/modules/nixos/profiles/cluster.nix
+++ b/modules/nixos/profiles/cluster.nix
@@ -24,7 +24,6 @@
     enable = true;
     extraFlags = [
       "--protect-kernel-defaults"
-      "--secrets-encryption"
     ];
   };
 }


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)


___

### **PR Type**
Enhancement


___

### **Description**
- Removed the `--secrets-encryption` flag from K3s configuration.

- Simplified cluster configuration by eliminating default encryption.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cluster.nix</strong><dd><code>Removed `--secrets-encryption` flag from K3s configuration</code></dd></summary>
<hr>

modules/nixos/profiles/cluster.nix

<li>Removed the <code>--secrets-encryption</code> flag from the K3s <code>extraFlags</code>.<br> <li> Simplified the cluster configuration by removing default encryption.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/338/files#diff-33fc5c8e5ef0ff710e894c8c3ee0cbcb4bc07b02e6081ad6e8b6ed6780b8c909">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>