### PR TITLE
Upstream Nishir cluster configs

### DIFF
--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -32,6 +32,21 @@
         ];
       }
     );
+    minish = withSystem "aarch64-linux" (
+      { system, ... }:
+      inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../nixos/hosts/minish.nix
+          inputs.home-manager.nixosModules.home-manager
+          inputs.nixos-hardware.nixosModules.raspberry-pi-4
+          inputs.sops-nix.nixosModules.sops
+        ];
+      }
+    );
     nishir = withSystem "aarch64-linux" (
       { system, ... }:
       inputs.nixpkgs.lib.nixosSystem {

--- a/modules/nixos/hosts/fushi.nix
+++ b/modules/nixos/hosts/fushi.nix
@@ -14,7 +14,7 @@
   ];
 
   fileSystems."/mnt/nishir" = {
-    device = "/dev/disk/by-label/flandre";
+    device = "/dev/disk/by-label/remilia";
     options = [
       "defaults"
       "nofail"

--- a/modules/nixos/hosts/minish.nix
+++ b/modules/nixos/hosts/minish.nix
@@ -14,16 +14,16 @@
   ];
 
   fileSystems."/mnt/nishir" = {
-    device = "/dev/nvme0n1";
+    device = "/dev/disk/by-label/flandre";
     options = [
       "defaults"
       "nofail"
     ];
   };
 
-  networking.hostName = "nishir";
+  networking.hostName = "minish";
 
-  services.k3s.role = "server";
+  services.k3s.serverAddr = "https://nishir.taila659a.ts.net:6443";
 
   services.tailscale = {
     extraUpFlags = [ "--ssh" ];


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #339


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new NixOS configuration for `minish` host.

- Updated disk device labels in `fushi` and `nishir` configurations.

- Enhanced cluster configurations with new system definitions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nixos.nix</strong><dd><code>Add `minish` system definition in flake configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/flake/nixos.nix

<li>Added a new system definition for <code>minish</code>.<br> <li> Reused existing modules and configurations for <code>minish</code>.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/339/files#diff-bf3ec620b298e48e8f495c0dcca74262c32d0404869f4d3e2ddca046ec484bac">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fushi.nix</strong><dd><code>Update disk device label for `fushi`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/nixos/hosts/fushi.nix

- Updated disk device label from `flandre` to `remilia`.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/339/files#diff-6dadec0fc5111b18d413eb9a8cfeaabdb633f978ebc6e08de0f21ab095ecb5a6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>minish.nix</strong><dd><code>Add new NixOS host configuration for `minish`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/nixos/hosts/minish.nix

<li>Introduced a new host configuration for <code>minish</code>.<br> <li> Configured file systems, networking, and services.<br> <li> Added Tailscale and k3s server settings.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/339/files#diff-259d2ad226f133f663d758f767d7fb9f19eca51af946d81dca40bc35389392d0">+32/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nishir.nix</strong><dd><code>Update disk device label for `nishir`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/nixos/hosts/nishir.nix

- Updated disk device label from `remilia` to `/dev/nvme0n1`.


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/339/files#diff-137993a4e1532e3a66e2fcc8de71a7b3558b4ecfebadb1b0122cd1c5a3222a48">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>