### PR TITLE
Expose devenv modules

### DIFF
--- a/modules/flake/devenv.nix
+++ b/modules/flake/devenv.nix
@@ -1,4 +1,12 @@
+{ self, ... }:
+
 {
+  flake.devenvModules.default = [
+    ../devenv/air.nix
+    ../devenv/github.nix
+    ../devenv/gitignore.nix
+  ];
+
   perSystem =
     { pkgs, ... }:
     {
@@ -18,11 +26,7 @@
         ];
       };
       devenv = {
-        modules = [
-          ../devenv/air.nix
-          ../devenv/github.nix
-          ../devenv/gitignore.nix
-        ];
+        modules = self.devenvModules.default;
         shells.default = {
           cachix = {
             enable = true;


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #411
* __->__ #410


___

### **PR Type**
Enhancement


___

### **Description**
- Expose devenv modules as flake output

- Refactor module references to use exposed modules


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["devenv modules"] --> B["flake.devenvModules.default"]
  B --> C["perSystem devenv.modules"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>devenv.nix</strong><dd><code>Expose devenv modules as flake output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/flake/devenv.nix

<ul><li>Added <code>flake.devenvModules.default</code> exposing three devenv modules<br> <li> Refactored <code>perSystem.devenv.modules</code> to reference the exposed modules<br> <li> Improved module organization and reusability</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/410/files#diff-d3f5e0ef01406b8239e61290d7d022b68229999ea6f5ba0d99ece6f92bd2fcbd">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

