### PR TITLE
Remove unused apps

### DIFF
--- a/modules/darwin/workstation.nix
+++ b/modules/darwin/workstation.nix
@@ -15,7 +15,6 @@ with lib;
       "pkg-config"
     ];
     casks = [
-      "adobe-creative-cloud"
       "android-studio"
       "appcleaner"
       "dbeaver-community"
@@ -34,14 +33,12 @@ with lib;
       "signal"
       "slack"
       "spotify"
-      "steam"
       "stolendata-mpv"
       "syncthing-app"
       "tailscale-app"
       "trae"
       "transmission"
       "visual-studio-code"
-      "whatsapp"
       "windows-app"
       "wireshark-app"
       "xquartz"


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #415


___

### **PR Type**
Other


___

### **Description**
- Remove three unused Homebrew cask applications from workstation configuration

- Cleaned up `adobe-creative-cloud`, `steam`, and `whatsapp` from installed apps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Darwin Workstation Config"] --> B["Homebrew Casks"]
  B --> C["Remove adobe-creative-cloud"]
  B --> D["Remove steam"]
  B --> E["Remove whatsapp"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workstation.nix</strong><dd><code>Remove three unused cask applications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/darwin/workstation.nix

<ul><li>Removed <code>adobe-creative-cloud</code> cask from Homebrew configuration<br> <li> Removed <code>steam</code> cask from Homebrew configuration<br> <li> Removed <code>whatsapp</code> cask from Homebrew configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/415/files#diff-7e8d8316b64bf2749efc529df1671d8a9f635eb6e6dbe84627a8721b7e81f95c">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

