### PR TITLE
Fix ZSH darwin

### DIFF
--- a/modules/darwin/workstation.nix
+++ b/modules/darwin/workstation.nix
@@ -57,7 +57,7 @@ with lib;
 
   programs.zsh = {
     enable = true;
-    initContent = mkAfter ''
+    shellInit = mkAfter ''
       if [[ -f /opt/homebrew/bin/brew ]]; then
         eval "$(/opt/homebrew/bin/brew shellenv)"
       fi


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #417


___

### **PR Type**
Bug fix


___

### **Description**
- Changed ZSH initialization hook from `initContent` to `shellInit`

- Fixes Homebrew environment setup on Darwin systems


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ZSH Configuration"] -- "changed hook" --> B["shellInit"]
  B --> C["Homebrew Environment Setup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workstation.nix</strong><dd><code>Fix ZSH initialization hook for Homebrew</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/darwin/workstation.nix

<ul><li>Replaced <code>initContent</code> with <code>shellInit</code> for ZSH Homebrew initialization<br> <li> Maintains the same Homebrew environment setup logic</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/417/files#diff-7e8d8316b64bf2749efc529df1671d8a9f635eb6e6dbe84627a8721b7e81f95c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

