### PR TITLE
Remove Davinci and WhatsApp

### DIFF
--- a/modules/darwin/workstation.nix
+++ b/modules/darwin/workstation.nix
@@ -48,9 +48,7 @@ with lib;
     masApps = {
       Amphetamine = 937984704;
       Bitwarden = 1352778147;
-      "DaVinci Resolve" = 571213070;
       Velja = 1607635845;
-      "WhatsApp Messenger" = 310633997;
       Xcode = 497799835;
     };
   };


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)


___

### **PR Type**
Other


___

### **Description**
- Remove DaVinci Resolve and WhatsApp Messenger from macOS App Store installations

- Clean up workstation configuration by removing unused applications


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workstation.nix</strong><dd><code>Remove two Mac App Store applications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/darwin/workstation.nix

<ul><li>Removed "DaVinci Resolve" (ID: 571213070) from masApps<br> <li> Removed "WhatsApp Messenger" (ID: 310633997) from masApps</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/418/files#diff-7e8d8316b64bf2749efc529df1671d8a9f635eb6e6dbe84627a8721b7e81f95c">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

