### PR TITLE
Fix Ghostty missing env

### DIFF
--- a/modules/home/ghostty.nix
+++ b/modules/home/ghostty.nix
@@ -33,7 +33,7 @@
     };
     settings = {
       theme = "catppuccin-latte";
-      command = "${pkgs.nushell}/bin/nu --login --interactive";
+      command = "${pkgs.zsh}/bin/zsh -c ${pkgs.nushell}/bin/nu --login --interactive";
     };
   };
 }


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #420


___

### **PR Type**
Bug fix


___

### **Description**
- Changed Ghostty terminal command to launch Nushell through Zsh wrapper

- Ensures proper environment variable initialization for Nushell shell


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Ghostty Terminal"] --> B["Zsh Wrapper"]
  B --> C["Nushell Shell"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ghostty.nix</strong><dd><code>Wrap Nushell command with Zsh for proper environment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/home/ghostty.nix

<ul><li>Modified <code>command</code> setting to wrap Nushell execution with Zsh<br> <li> Changed from direct Nushell invocation to Zsh-wrapped launch command</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/420/files#diff-69bab45baf7cc7f62b2324357fb381c0a0d5805344bb93f79f49e620612afcf6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

