### PR TITLE
Add Docker config in Nix

### DIFF
--- a/hosts/kaltashar/users/shikanimedeva/home-configuration.nix
+++ b/hosts/kaltashar/users/shikanimedeva/home-configuration.nix
@@ -18,6 +18,11 @@ with lib;
     ../../../../modules/home/workstation.nix
   ];
 
+  programs.docker-cli.settings = {
+    credsStore = "osxkeychain";
+    currentContext = "rancher-desktop";
+  };
+
   programs.zsh = {
     enable = true;
     initContent = mkAfter ''

--- a/hosts/telsha/users/shikanimedeva/home-configuration.nix
+++ b/hosts/telsha/users/shikanimedeva/home-configuration.nix
@@ -18,6 +18,11 @@ with lib;
     ../../../../modules/home/workstation.nix
   ];
 
+  programs.docker-cli.settings = {
+    credsStore = "osxkeychain";
+    currentContext = "rancher-desktop";
+  };
+
   programs.zsh = {
     enable = true;
     initContent = mkAfter ''

--- a/modules/home/cloud.nix
+++ b/modules/home/cloud.nix
@@ -7,9 +7,10 @@
 {
   home.packages = [
     pkgs.glab
-    pkgs.k9s
     pkgs.tea
   ];
+
+  programs.docker-cli.enable = true;
 
   programs.gh.enable = true;
 
@@ -20,6 +21,8 @@
     docker-compose-language-server.command = "${pkgs.docker-compose-language-service}/bin/docker-compose-langserver";
     dockerfile-langserver.command = "${pkgs.dockerfile-language-server-nodejs}/bin/dockerfile-language-server-nodejs";
   };
+
+  programs.k9s.enable = true;
 
   programs.nushell.extraConfig = ''
     use ${pkgs.nu_scripts}/share/nu_scripts/modules/kubernetes *

--- a/modules/home/ghostty.nix
+++ b/modules/home/ghostty.nix
@@ -33,7 +33,7 @@
     };
     settings = {
       theme = "catppuccin-latte";
-      command = "${pkgs.zsh}/bin/zsh -c ${pkgs.nushell}/bin/nu --login --interactive";
+      command = "${pkgs.zsh}/bin/zsh -c ${pkgs.nushell}/bin/nu --login";
     };
   };
 }


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #421


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Configure Docker CLI with osxkeychain credentials and rancher-desktop context

- Enable `docker-cli` and `k9s` programs in cloud module

- Update Ghostty terminal command to use `--login` flag only

- Remove `k9s` from direct package installation, now managed via program


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cloud.nix module"] --> B["Enable docker-cli & k9s programs"]
  C["Host configurations"] --> D["Add Docker CLI settings"]
  D --> E["Set credsStore to osxkeychain"]
  D --> F["Set context to rancher-desktop"]
  G["ghostty.nix"] --> H["Simplify nushell command"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>home-configuration.nix</strong><dd><code>Configure Docker CLI for kaltashar host</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/kaltashar/users/shikanimedeva/home-configuration.nix

<ul><li>Add Docker CLI configuration with osxkeychain credentials store<br> <li> Set default Docker context to rancher-desktop</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/421/files#diff-25e0697cc88e65c0efaf3a6823689c35e7f2a5466c889b31c9d8cb9c7aaeb550">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>home-configuration.nix</strong><dd><code>Configure Docker CLI for telsha host</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/telsha/users/shikanimedeva/home-configuration.nix

<ul><li>Add Docker CLI configuration with osxkeychain credentials store<br> <li> Set default Docker context to rancher-desktop</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/421/files#diff-6960de20c99a392115e8c6ec8d8c4ec0dc33960b493c09e0b37d53af6904b315">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ghostty.nix</strong><dd><code>Simplify Ghostty terminal shell command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/home/ghostty.nix

<ul><li>Simplify nushell command by removing <code>--interactive</code> flag<br> <li> Keep only <code>--login</code> flag for shell initialization</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/421/files#diff-69bab45baf7cc7f62b2324357fb381c0a0d5805344bb93f79f49e620612afcf6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cloud.nix</strong><dd><code>Enable Docker and Kubernetes tools via programs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/home/cloud.nix

<ul><li>Enable <code>docker-cli</code> program declaratively<br> <li> Enable <code>k9s</code> program declaratively<br> <li> Remove <code>k9s</code> from direct package installation list</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/421/files#diff-a51cacacb1658b723882168f76e45cd302a24cb2031f30f00814544c29e94018">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

