### PR TITLE
Refactor dynamic env to static for better shell compats

### DIFF
--- a/hosts/devcontainer/users/vscode/home-configuration.nix
+++ b/hosts/devcontainer/users/vscode/home-configuration.nix
@@ -18,18 +18,14 @@ with lib;
     ../../../../modules/home/workstation.nix
   ];
 
-  home.packages = [ pkgs.iputils ];
+  home = {
+    packages = [ pkgs.iputils ];
+    sessionVariables.USER = "vscode";
+  };
 
   nix.package = pkgs.nix;
 
-  programs.bash = {
-    enable = true;
-    initExtra = mkAfter ''
-      # Check if user environment variables are set because containers doesn't set
-      # them by default and Home Manager needs them to work properly
-      test -n "$USER" || export USER=$(whoami)
-    '';
-  };
+  programs.bash.enable = true;
 
   targets.genericLinux.enable = true;
 }

--- a/hosts/kaltashar/users/shikanimedeva/home-configuration.nix
+++ b/hosts/kaltashar/users/shikanimedeva/home-configuration.nix
@@ -18,20 +18,19 @@ with lib;
     ../../../../modules/home/workstation.nix
   ];
 
+  home = {
+    sessionPath = [
+      "${config.home.homeDirectory}/.rd/bin"
+    ];
+    sessionVariables.SSH_AUTH_SOCK = "${config.home.homeDirectory}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock";
+  };
+
+  programs.bash.enable = true;
+
   programs.docker-cli.settings = {
     credsStore = "osxkeychain";
     currentContext = "rancher-desktop";
   };
 
-  programs.zsh = {
-    enable = true;
-    initContent = mkAfter ''
-      if test -d "${config.home.homeDirectory}/.rd"; then
-        export PATH="${config.home.homeDirectory}/.rd/bin:$PATH"
-      fi
-      if test -e "${config.home.homeDirectory}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock"; then
-        export SSH_AUTH_SOCK="${config.home.homeDirectory}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock"
-      fi
-    '';
-  };
-}
+  programs.zsh.enable = true;
+ }

--- a/hosts/kaltashar/users/shikanimedeva/home-configuration.nix
+++ b/hosts/kaltashar/users/shikanimedeva/home-configuration.nix
@@ -33,4 +33,4 @@ with lib;
   };
 
   programs.zsh.enable = true;
- }
+}

--- a/hosts/oceando/users/vscode/home-configuration.nix
+++ b/hosts/oceando/users/vscode/home-configuration.nix
@@ -17,12 +17,7 @@ with lib;
     ../../../../modules/home/workstation.nix
   ];
 
-  programs.bash = {
-    enable = true;
-    initExtra = mkAfter ''
-      # Check if user environment variables are set because containers doesn't set
-      # them by default and Home Manager needs them to work properly
-      test -n "$USER" || export USER=$(whoami)
-    '';
-  };
+  home.sessionVariables.USER = "vscode";
+
+  programs.bash.enable = true;
 }

--- a/hosts/telsha/users/shikanimedeva/home-configuration.nix
+++ b/hosts/telsha/users/shikanimedeva/home-configuration.nix
@@ -18,20 +18,19 @@ with lib;
     ../../../../modules/home/workstation.nix
   ];
 
+  home = {
+    sessionPath = [
+      "${config.home.homeDirectory}/.rd/bin"
+    ];
+    sessionVariables.SSH_AUTH_SOCK = "${config.home.homeDirectory}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock";
+  };
+
+  programs.bash.enable = true;
+
   programs.docker-cli.settings = {
     credsStore = "osxkeychain";
     currentContext = "rancher-desktop";
   };
 
-  programs.zsh = {
-    enable = true;
-    initContent = mkAfter ''
-      if test -d "${config.home.homeDirectory}/.rd"; then
-        export PATH="${config.home.homeDirectory}/.rd/bin:$PATH"
-      fi
-      if test -e "${config.home.homeDirectory}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock"; then
-        export SSH_AUTH_SOCK="${config.home.homeDirectory}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock"
-      fi
-    '';
-  };
+  programs.zsh.enable = true;
 }

--- a/modules/darwin/workstation.nix
+++ b/modules/darwin/workstation.nix
@@ -56,10 +56,7 @@ with lib;
   programs.zsh = {
     enable = true;
     shellInit = mkAfter ''
-      if test -f /opt/homebrew/bin/brew; then
-        eval "$(/opt/homebrew/bin/brew shellenv)"
-      fi
-    '';
+      test -f /opt/homebrew/bin/brew && eval "$(/opt/homebrew/bin/brew shellenv)"; '';
   };
 
   programs.gnupg.agent = {

--- a/modules/darwin/workstation.nix
+++ b/modules/darwin/workstation.nix
@@ -55,8 +55,7 @@ with lib;
 
   programs.zsh = {
     enable = true;
-    shellInit = mkAfter ''
-      test -f /opt/homebrew/bin/brew && eval "$(/opt/homebrew/bin/brew shellenv)"; '';
+    shellInit = mkAfter ''test -f /opt/homebrew/bin/brew && eval "$(/opt/homebrew/bin/brew shellenv)";'';
   };
 
   programs.gnupg.agent = {


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #422


___

### **PR Type**
Enhancement


___

### **Description**
- Replace dynamic shell initialization with static session variables

- Consolidate environment variable declarations in `home.sessionVariables`

- Move PATH modifications to `home.sessionPath` configuration

- Simplify shell configuration by removing conditional exports


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Shell init scripts"] -- "removed" --> B["Dynamic exports"]
  C["home.sessionVariables"] -- "added" --> D["Static USER variable"]
  E["home.sessionPath"] -- "added" --> F["Static PATH entries"]
  G["Conditional checks"] -- "simplified" --> H["Direct assignments"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>home-configuration.nix</strong><dd><code>Replace dynamic USER export with static session variable</code>&nbsp; </dd></summary>
<hr>

hosts/devcontainer/users/vscode/home-configuration.nix

<ul><li>Removed dynamic <code>USER</code> variable export from bash <code>initExtra</code><br> <li> Added static <code>USER</code> session variable set to "vscode"<br> <li> Simplified bash configuration to only enable the program</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/422/files#diff-3722323d57a182105d32c4217d4a46c89ff05920c8e174acdf90d69537b2bcb3">+5/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>home-configuration.nix</strong><dd><code>Convert dynamic zsh exports to static session configuration</code></dd></summary>
<hr>

hosts/kaltashar/users/shikanimedeva/home-configuration.nix

<ul><li>Removed conditional PATH and SSH_AUTH_SOCK exports from zsh <br><code>initContent</code><br> <li> Added static <code>sessionPath</code> for Rancher Desktop bin directory<br> <li> Added static <code>sessionVariables.SSH_AUTH_SOCK</code> for Bitwarden SSH agent<br> <li> Simplified zsh configuration to only enable the program</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/422/files#diff-25e0697cc88e65c0efaf3a6823689c35e7f2a5466c889b31c9d8cb9c7aaeb550">+11/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>home-configuration.nix</strong><dd><code>Replace dynamic USER export with static session variable</code>&nbsp; </dd></summary>
<hr>

hosts/oceando/users/vscode/home-configuration.nix

<ul><li>Removed dynamic <code>USER</code> variable export from bash <code>initExtra</code><br> <li> Added static <code>USER</code> session variable set to "vscode"<br> <li> Simplified bash configuration structure</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/422/files#diff-ddf49b33bda1083be3d326ca45bfd238d8f859056fa30655e9926f3a6ca9b316">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>home-configuration.nix</strong><dd><code>Convert dynamic zsh exports to static session configuration</code></dd></summary>
<hr>

hosts/telsha/users/shikanimedeva/home-configuration.nix

<ul><li>Removed conditional PATH and SSH_AUTH_SOCK exports from zsh <br><code>initContent</code><br> <li> Added static <code>sessionPath</code> for Rancher Desktop bin directory<br> <li> Added static <code>sessionVariables.SSH_AUTH_SOCK</code> for Bitwarden SSH agent<br> <li> Simplified zsh configuration to only enable the program</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/422/files#diff-6960de20c99a392115e8c6ec8d8c4ec0dc33960b493c09e0b37d53af6904b315">+10/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workstation.nix</strong><dd><code>Simplify Homebrew shell initialization to one-liner</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/darwin/workstation.nix

<ul><li>Simplified Homebrew initialization to single-line conditional<br> <li> Removed multi-line conditional check for brew binary</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/422/files#diff-7e8d8316b64bf2749efc529df1671d8a9f635eb6e6dbe84627a8721b7e81f95c">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

