### PR TITLE
Fix Oceando permissions

### DIFF
--- a/hosts/oceando/configuration.nix
+++ b/hosts/oceando/configuration.nix
@@ -16,6 +16,8 @@
     ./users/vscode/home-configuration.nix
   ];
 
+  security.sudo.wheelNeedsPassword = false;
+
   users.users.vscode = {
     initialHashedPassword = "";
     isNormalUser = true;


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)


___

### **PR Type**
Enhancement


___

### **Description**
- Disable password requirement for sudo access for wheel group members

- Configure passwordless sudo for the vscode user in Oceando host


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Oceando Host Config"] --> B["Security Settings"]
  B --> C["Passwordless Sudo for Wheel Group"]
  C --> D["vscode User Access"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Configure passwordless sudo for wheel group</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/oceando/configuration.nix

<ul><li>Added <code>security.sudo.wheelNeedsPassword = false</code> configuration<br> <li> Enables passwordless sudo access for wheel group members</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/424/files#diff-a54ca7b1573a791d67849a728e40e286299cf6476e215c2e818637ad2a3742b3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

