### PR TITLE
Refactor Oceando build to stream docker load

### DIFF
--- a/packages/oceando/default.nix
+++ b/packages/oceando/default.nix
@@ -1,9 +1,7 @@
 { pkgs, nixosConfiguration, ... }:
 
-pkgs.dockerTools.buildLayeredImage {
+pkgs.dockerTools.streamLayeredImage {
   name = "ghcr.io/shikanime/shikanime/devcontainer";
-  tag = "latest";
-  created = "now";
   contents = [
     nixosConfiguration.config.system.build.toplevel
     pkgs.coreutils
@@ -25,11 +23,8 @@ pkgs.dockerTools.buildLayeredImage {
         {
           overrideCommand = false;
           privileged = true;
-          containerEnv = {
-            USER = "vscode";
-          };
           remoteUser = "vscode";
-          updateRemoteUserUID = false;
+          updateRemoteUserUID = true;
         }
       ];
     };


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #427
* __->__ #426


___

### **PR Type**
Enhancement


___

### **Description**
- Switched from `buildLayeredImage` to `streamLayeredImage` for Docker image creation

- Removed static `tag` and `created` fields to enable dynamic tagging

- Updated devcontainer metadata: removed `containerEnv` and enabled `updateRemoteUserUID`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["buildLayeredImage"] -- "replaced with" --> B["streamLayeredImage"]
  B --> C["Dynamic tagging enabled"]
  D["Static metadata"] -- "simplified" --> E["Updated devcontainer config"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>default.nix</strong><dd><code>Switch to streaming Docker build with updated metadata</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/oceando/default.nix

<ul><li>Changed Docker build function from <code>buildLayeredImage</code> to <br><code>streamLayeredImage</code><br> <li> Removed <code>tag</code> and <code>created</code> fields for dynamic image tagging<br> <li> Removed <code>containerEnv.USER</code> from devcontainer metadata<br> <li> Changed <code>updateRemoteUserUID</code> from <code>false</code> to <code>true</code></ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/426/files#diff-53cc934aff9ea3a37c817a1d2994b80f15a8793398bcf3364535f6d5e2fbe4b3">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

