### PR TITLE
Fix Oceando networking

### DIFF
--- a/hosts/oceando/configuration.nix
+++ b/hosts/oceando/configuration.nix
@@ -16,6 +16,8 @@
     ./users/vscode/home-configuration.nix
   ];
 
+  networking.resolvconf.dnsExtensionMechanism = false;
+
   security.sudo.wheelNeedsPassword = false;
 
   users.users.vscode = {


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)


___

### **PR Type**
Bug fix


___

### **Description**
- Disable DNS extension mechanism in networking configuration for Oceando host


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Oceando Host"] --> B["Networking Config"]
  B --> C["DNS Resolution Fixed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Disable DNS extension mechanism for networking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/oceando/configuration.nix

<ul><li>Added <code>networking.resolvconf.dnsExtensionMechanism = false</code> to disable <br>DNS extension mechanism</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/427/files#diff-a54ca7b1573a791d67849a728e40e286299cf6476e215c2e818637ad2a3742b3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

