### PR TITLE
Remove gitnr from update

### DIFF
--- a/update.nu
+++ b/update.nu
@@ -31,20 +31,6 @@ def update_skaffold_artifacts []: record -> record {
     )
 }
 
-# Update gitignore
-(
-    gitnr create
-        repo:github/gitignore/refs/heads/main/Nix.gitignore
-        repo:shikanime/gitignore/refs/heads/main/Devenv.gitignore
-        tt:jetbrains+all
-        tt:linux
-        tt:macos
-        tt:vim
-        tt:visualstudiocode
-        tt:windows
-    | save --force .gitignore
-)
-
 # Update workflows
 print "[workflows] Updating GitHub Actions workflows..."
 nu $"($env.FILE_PWD)/.github/workflows/update.nu"


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #438
* #437
* __->__ #436


___

### **PR Type**
Enhancement


___

### **Description**
- Remove gitignore update logic from main update script

- Simplify update process by eliminating gitnr dependency

- Streamline workflow to focus on core updates only


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["update.nu script"] -->|removed| B["gitnr gitignore generation"]
  A -->|kept| C["update_skaffold_artifacts"]
  A -->|kept| D["GitHub Actions workflows update"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update.nu</strong><dd><code>Remove gitnr gitignore generation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

update.nu

<ul><li>Removed entire gitignore update block that used gitnr tool<br> <li> Eliminated dependencies on external gitignore templates from <br>github/gitignore and shikanime/gitignore repositories<br> <li> Removed template tags for jetbrains, linux, macos, vim, <br>visualstudiocode, and windows<br> <li> Preserved skaffold artifacts update and GitHub Actions workflows <br>update functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/436/files#diff-04818797378eba29965141e2b222fbfbcd0e7a28a9b63dcb5354759e082181d3">+0/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

