### PR TITLE
Fix container boot errors

### DIFF
--- a/hosts/nixtar/configuration.nix
+++ b/hosts/nixtar/configuration.nix
@@ -32,6 +32,11 @@ in
     ../../modules/nixos/workstation.nix
   ];
 
+  # Enable cross compilation
+  boot.binfmt.emulatedSystems = [
+    "aarch64-linux"
+  ];
+
   home-manager.users.shika.imports = [
     ./users/shika/home-configuration.nix
   ];

--- a/hosts/oceando/configuration.nix
+++ b/hosts/oceando/configuration.nix
@@ -44,6 +44,16 @@
             containerEnv = {
               USER = "shika";
             };
+            mounts = [
+              {
+                source = "/sys/kernel/debug";
+                target = "/sys/kernel/debug";
+              }
+              {
+                source = "/sys/kernel/tracing";
+                target = "/sys/kernel/tracing";
+              }
+            ];
             overrideCommand = false;
             privileged = true;
             remoteUser = "shika";

--- a/modules/nixos/workstation.nix
+++ b/modules/nixos/workstation.nix
@@ -1,11 +1,6 @@
 { pkgs, ... }:
 
 {
-  # Enable cross compilation
-  boot.binfmt.emulatedSystems = [
-    "aarch64-linux"
-  ];
-
   programs.gnupg.agent = {
     enable = true;
     enableExtraSocket = true;


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)


___

### **PR Type**
Bug fix


___

### **Description**
- Move cross-compilation config from workstation to nixtar host

- Add kernel debug and tracing mounts to devcontainer

- Fix container boot errors by enabling required capabilities


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["workstation.nix<br/>Remove binfmt config"] -->|Move to| B["nixtar/configuration.nix<br/>Add binfmt emulation"]
  C["oceando/configuration.nix<br/>Add kernel mounts"] -->|Enable| D["Container debug access<br/>sys/kernel paths"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Enable cross-compilation for ARM architecture</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/nixtar/configuration.nix

<ul><li>Add <code>boot.binfmt.emulatedSystems</code> configuration for aarch64-linux <br>cross-compilation support<br> <li> Enable container to run ARM binaries on x86_64 systems</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/449/files#diff-99b78460120ad78c50be3f04ec46278adf7b2a7f8404c1c227e6885e50c52934">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Add kernel debug mounts to devcontainer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/oceando/configuration.nix

<ul><li>Add kernel debug and tracing mount points to devcontainer metadata<br> <li> Mount <code>/sys/kernel/debug</code> and <code>/sys/kernel/tracing</code> for container access<br> <li> Enable debugging capabilities within the container environment</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/449/files#diff-a54ca7b1573a791d67849a728e40e286299cf6476e215c2e818637ad2a3742b3">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>workstation.nix</strong><dd><code>Remove binfmt config from workstation module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/nixos/workstation.nix

<ul><li>Remove <code>boot.binfmt.emulatedSystems</code> configuration block<br> <li> Move cross-compilation setup to host-specific configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/449/files#diff-8d1d6e107a1f62e1ad79766b0ad662ffa1c996ea2bc5c7d41f1c2525a4631631">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

