### PR TITLE
Migrate to vanilla Kubernetes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -550,11 +550,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1760699396,
-        "narHash": "sha256-thZAx/sisk5kXU3AD2FZuJkhwgoLt94XdvdiRj+sq9Q=",
+        "lastModified": 1762302790,
+        "narHash": "sha256-OjM2qFYW6/iUjzSejmJMI0hZgLJPIcKAnXJvjCMh670=",
         "owner": "shikanime",
         "repo": "identities",
-        "rev": "42b7c5b4f1f93ac65a6ae74ee2ae3d1cb81ff82a",
+        "rev": "039eb0fd8b4d5cfdb1b6dd485f1b5dad3175a2f8",
         "type": "github"
       },
       "original": {

--- a/hosts/fushi/configuration.nix
+++ b/hosts/fushi/configuration.nix
@@ -5,7 +5,7 @@
     "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
     "${modulesPath}/profiles/headless.nix"
     ../../modules/nixos/base.nix
-    ../../modules/nixos/k3s.nix
+    ../../modules/nixos/kubernetes.nix
     ../../modules/nixos/longhorn.nix
     ../../modules/nixos/machine.nix
     ../../modules/nixos/tailscale.nix
@@ -47,7 +47,13 @@
     })
   ];
 
-  services.k3s.serverAddr = "https://nishir.taila659a.ts.net:6443";
+  services.kubernetes = {
+    addons.dns.enable = true;
+    apiserverAddress = "https://nishir.taila659a.ts.net:6443";
+    easyCerts = true;
+    kubelet.kubeconfig.server = "https://nishir.taila659a.ts.net:6443";
+    masterAddress = "nishir.taila659a.ts.net";
+  };
 
   services.tailscale = {
     extraUpFlags = [ "--ssh" ];

--- a/hosts/minish/configuration.nix
+++ b/hosts/minish/configuration.nix
@@ -5,7 +5,7 @@
     "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
     "${modulesPath}/profiles/headless.nix"
     ../../modules/nixos/base.nix
-    ../../modules/nixos/k3s.nix
+    ../../modules/nixos/kubernetes.nix
     ../../modules/nixos/longhorn.nix
     ../../modules/nixos/machine.nix
     ../../modules/nixos/tailscale.nix
@@ -47,7 +47,13 @@
     })
   ];
 
-  services.k3s.serverAddr = "https://nishir.taila659a.ts.net:6443";
+  services.kubernetes = {
+    addons.dns.enable = true;
+    apiserverAddress = "https://nishir.taila659a.ts.net:6443";
+    easyCerts = true;
+    kubelet.kubeconfig.server = "https://nishir.taila659a.ts.net:6443";
+    masterAddress = "nishir.taila659a.ts.net";
+  };
 
   services.tailscale = {
     extraUpFlags = [ "--ssh" ];

--- a/hosts/nishir/configuration.nix
+++ b/hosts/nishir/configuration.nix
@@ -38,7 +38,10 @@
     apiserverAddress = "https://nishir.taila659a.ts.net:6443";
     easyCerts = true;
     masterAddress = "nishir.taila659a.ts.net";
-    roles = ["master" "node"];
+    roles = [
+      "master"
+      "node"
+    ];
   };
 
   services.tailscale = {

--- a/hosts/nishir/configuration.nix
+++ b/hosts/nishir/configuration.nix
@@ -5,7 +5,7 @@
     "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
     "${modulesPath}/profiles/headless.nix"
     ../../modules/nixos/base.nix
-    ../../modules/nixos/k3s.nix
+    ../../modules/nixos/kubernetes.nix
     ../../modules/nixos/longhorn.nix
     ../../modules/nixos/machine.nix
     ../../modules/nixos/tailscale.nix
@@ -32,7 +32,14 @@
     })
   ];
 
-  services.k3s.role = "server";
+  services.kubernetes = {
+    addons.dns.enable = true;
+    apiserver.advertiseAddress = "100.117.159.56";
+    apiserverAddress = "https://nishir.taila659a.ts.net:6443";
+    easyCerts = true;
+    masterAddress = "nishir.taila659a.ts.net";
+    roles = ["master" "node"];
+  };
 
   services.tailscale = {
     extraUpFlags = [ "--ssh" ];

--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -27,6 +27,7 @@
         modules = [
           ../../hosts/fushi/configuration.nix
           inputs.home-manager.nixosModules.home-manager
+          inputs.identities.nixosModules.fushi
           inputs.nixos-hardware.nixosModules.raspberry-pi-4
           inputs.sops-nix.nixosModules.sops
         ];
@@ -42,6 +43,7 @@
         modules = [
           ../../hosts/minish/configuration.nix
           inputs.home-manager.nixosModules.home-manager
+          inputs.identities.nixosModules.minish
           inputs.nixos-hardware.nixosModules.raspberry-pi-4
           inputs.sops-nix.nixosModules.sops
         ];
@@ -57,6 +59,7 @@
         modules = [
           ../../hosts/nishir/configuration.nix
           inputs.home-manager.nixosModules.home-manager
+          inputs.identities.nixosModules.nishir
           inputs.nixos-hardware.nixosModules.raspberry-pi-5
           inputs.sops-nix.nixosModules.sops
         ];

--- a/modules/nixos/kubernetes.nix
+++ b/modules/nixos/kubernetes.nix
@@ -20,10 +20,5 @@
     "cgroup_memory=1"
   ];
 
-  services.k3s = {
-    enable = true;
-    extraFlags = [
-      "--protect-kernel-defaults"
-    ];
-  };
+  services.kubernetes.kubelet.extraOpts = "--fail-swap-on=false";
 }


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #451
* __->__ #450


___

### **PR Type**
Enhancement


___

### **Description**
- Replace K3s with vanilla Kubernetes across cluster nodes

- Update Kubernetes service configuration with apiserver and kubelet settings

- Add identity modules for each host in NixOS flake configuration

- Simplify kernel parameters and kubelet options for vanilla Kubernetes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  K3s["K3s Configuration"] -- "Replace with" --> VanillaK8s["Vanilla Kubernetes"]
  VanillaK8s -- "Configure" --> APIServer["API Server Settings"]
  VanillaK8s -- "Configure" --> Kubelet["Kubelet Configuration"]
  VanillaK8s -- "Define" --> Roles["Master/Node Roles"]
  Identities["Identity Modules"] -- "Add to" --> Hosts["Host Configurations"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Migrate fushi host to vanilla Kubernetes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/fushi/configuration.nix

<ul><li>Replace k3s module import with kubernetes module<br> <li> Update services.k3s.serverAddr to services.kubernetes configuration<br> <li> Add apiserver address, kubelet kubeconfig, master address, and node <br>role</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/450/files#diff-757d4eba42058adba9524ff0f5ae6a40012d3fb8abf2feed9075e90b767fa84f">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Migrate minish host to vanilla Kubernetes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/minish/configuration.nix

<ul><li>Replace k3s module import with kubernetes module<br> <li> Update services.k3s.serverAddr to services.kubernetes configuration<br> <li> Add apiserver address, kubelet kubeconfig, master address, and node <br>role</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/450/files#diff-b793858c49904912d56966fe07d496aef098455eb57c98478273993ce8bf35d8">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Migrate nishir master host to vanilla Kubernetes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/nishir/configuration.nix

<ul><li>Replace k3s module import with kubernetes module<br> <li> Update services.k3s.role to services.kubernetes with master and node <br>roles<br> <li> Add apiserver advertise address, apiserver address, and master address</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/450/files#diff-a5eb5f25b2b4827abb1c95f07249aec0d9a5fa5e2c27cbf6be23682fdd40241e">+10/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nixos.nix</strong><dd><code>Add identity modules to host configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/flake/nixos.nix

<ul><li>Add identities.nixosModules for fushi, minish, and nishir hosts<br> <li> Integrate identity modules into respective host configurations</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/450/files#diff-bf3ec620b298e48e8f495c0dcca74262c32d0404869f4d3e2ddca046ec484bac">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kubernetes.nix</strong><dd><code>Replace K3s with vanilla Kubernetes configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/nixos/kubernetes.nix

<ul><li>Remove K3s service configuration and extraFlags<br> <li> Replace with vanilla Kubernetes kubelet configuration<br> <li> Set kubelet option to disable swap requirement check</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/450/files#diff-f068eb17b54bf5421ef67ac26c9519fef91d42c3cb5e8e2c514db3118cff7b6f">+1/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

