### PR TITLE
Update disk location

### DIFF
--- a/hosts/fushi/configuration.nix
+++ b/hosts/fushi/configuration.nix
@@ -11,21 +11,13 @@
     ../../modules/nixos/tailscale.nix
   ];
 
-  fileSystems = {
-    "/mnt/remilia" = {
-      device = "/dev/disk/by-label/remilia";
-      options = [
-        "defaults"
-        "nofail"
-      ];
-    };
-    "/mnt/reimu" = {
-      device = "/dev/disk/by-label/reimu";
-      options = [
-        "defaults"
-        "nofail"
-      ];
-    };
+  fileSystems."/mnt/reimu" = {
+    device = "/dev/disk/by-label/reimu";
+    options = [
+      "defaults"
+      "nofail"
+      "x-systemd.automount"
+    ];
   };
 
   # Enable accelerator

--- a/hosts/minish/configuration.nix
+++ b/hosts/minish/configuration.nix
@@ -11,21 +11,13 @@
     ../../modules/nixos/tailscale.nix
   ];
 
-  fileSystems = {
-    "/mnt/flandre" = {
-      device = "/dev/disk/by-label/flandre";
-      options = [
-        "defaults"
-        "nofail"
-      ];
-    };
-    "/mnt/marisa" = {
-      device = "/dev/disk/by-label/marisa";
-      options = [
-        "defaults"
-        "nofail"
-      ];
-    };
+  fileSystems."/mnt/marisa" = {
+    device = "/dev/disk/by-label/marisa";
+    options = [
+      "defaults"
+      "nofail"
+      "x-systemd.automount"
+    ];
   };
 
   # Enable accelerator

--- a/hosts/nishir/configuration.nix
+++ b/hosts/nishir/configuration.nix
@@ -11,12 +11,31 @@
     ../../modules/nixos/tailscale.nix
   ];
 
-  fileSystems."/mnt/nishir" = {
-    device = "/dev/nvme0n1";
-    options = [
-      "defaults"
-      "nofail"
-    ];
+  fileSystems = {
+    "/mnt/flandre" = {
+      device = "/dev/disk/by-label/flandre";
+      options = [
+        "defaults"
+        "nofail"
+        "x-systemd.automount"
+      ];
+    };
+    "/mnt/nishir" = {
+      device = "/dev/nvme0n1";
+      options = [
+        "defaults"
+        "nofail"
+        "x-systemd.automount"
+      ];
+    };
+    "/mnt/remilia" = {
+      device = "/dev/disk/by-label/remilia";
+      options = [
+        "defaults"
+        "nofail"
+        "x-systemd.automount"
+      ];
+    };
   };
 
   home-manager.users.nishir.imports = [


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #451
* #450


___

### **PR Type**
Enhancement


___

### **Description**
- Consolidate disk mount configurations across hosts

- Remove redundant mount points from fushi and minish

- Add systemd automount option to all disk mounts

- Reorganize nishir configuration to include additional mounts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multiple host configs<br/>with separate mounts"] -->|Remove redundant| B["fushi: reimu only"]
  A -->|Remove redundant| C["minish: marisa only"]
  A -->|Consolidate| D["nishir: flandre,<br/>nishir, remilia"]
  B -->|Add automount| E["All mounts with<br/>x-systemd.automount"]
  C -->|Add automount| E
  D -->|Add automount| E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Remove remilia mount, add automount option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/fushi/configuration.nix

<ul><li>Removed redundant <code>/mnt/remilia</code> mount point<br> <li> Kept only <code>/mnt/reimu</code> mount configuration<br> <li> Added <code>x-systemd.automount</code> option to remaining mount<br> <li> Simplified <code>fileSystems</code> from object notation to direct assignment</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/451/files#diff-757d4eba42058adba9524ff0f5ae6a40012d3fb8abf2feed9075e90b767fa84f">+7/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Remove flandre mount, add automount option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/minish/configuration.nix

<ul><li>Removed redundant <code>/mnt/flandre</code> mount point<br> <li> Kept only <code>/mnt/marisa</code> mount configuration<br> <li> Added <code>x-systemd.automount</code> option to remaining mount<br> <li> Simplified <code>fileSystems</code> from object notation to direct assignment</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/451/files#diff-b793858c49904912d56966fe07d496aef098455eb57c98478273993ce8bf35d8">+7/-15</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Add flandre and remilia mounts with automount</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/nishir/configuration.nix

<ul><li>Added <code>/mnt/flandre</code> and <code>/mnt/remilia</code> mount points<br> <li> Converted from single mount to multi-mount configuration<br> <li> Added <code>x-systemd.automount</code> option to all three mounts<br> <li> Reorganized <code>fileSystems</code> to object notation with multiple entries</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/451/files#diff-a5eb5f25b2b4827abb1c95f07249aec0d9a5fa5e2c27cbf6be23682fdd40241e">+25/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

