### PR TITLE
Fix Oceando password conflict

### DIFF
--- a/hosts/oceando/configuration.nix
+++ b/hosts/oceando/configuration.nix
@@ -59,7 +59,6 @@
   ];
 
   users.users.shika = {
-    initialHashedPassword = "";
     isNormalUser = true;
     extraGroups = [ "wheel" ];
     home = "/home/shika";


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #451
* #450
* __->__ #452


___

### **PR Type**
Bug fix


___

### **Description**
- Remove empty initialHashedPassword from shika user configuration

- Resolves password conflict in Oceando host setup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Oceando configuration.nix"] -- "Remove initialHashedPassword" --> B["Clean user configuration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>configuration.nix</strong><dd><code>Remove empty password hash from user config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hosts/oceando/configuration.nix

<ul><li>Removed empty <code>initialHashedPassword</code> field from <code>users.users.shika</code> <br>configuration<br> <li> Eliminates password conflict by not setting an empty password hash</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/452/files#diff-a54ca7b1573a791d67849a728e40e286299cf6476e215c2e818637ad2a3742b3">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

