### PR TITLE
Fix multiarch race condition

### DIFF
--- a/build.nu
+++ b/build.nu
@@ -49,7 +49,7 @@ def get_platforms []: nothing -> string {
         print $"No PLATFORMS specified, detected host platform: ($detected)"
         $detected
     } else {
-        $env.PLATFORMS
+        $env.PLATFORMS | split row ","
     }
 }
 
@@ -125,19 +125,6 @@ def push_image [ctx: record]: record -> nothing {
     }
 }
 
-def build_all_platform_images [ctx: record]: nothing -> list<record> {
-    $ctx.platforms
-        | split row ","
-        | par-each { |platform|
-            $platform | build_platform_image $ctx
-        }
-}
-
-def push_all_images [ctx: record, images: list<record>]: nothing -> list<nothing> {
-    $images
-    | par-each { |image| $image | push_image $ctx }
-}
-
 def remove_manifest [ctx: record]: nothing -> nothing {
     try {
         docker manifest rm $ctx.image
@@ -166,8 +153,8 @@ def push_manifest [ctx: record]: nothing -> nothing {
 }
 
 def build_multiplatform_image [ctx: record]: nothing -> nothing {
-    let images = build_all_platform_images $ctx
-    push_all_images $ctx $images
+    let images = $ctx.platforms | each { |platform| $platform | build_platform_image $ctx }
+    $images | par-each { |image| $image | push_image $ctx }
     create_manifest $ctx $images
     push_manifest $ctx
 }


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)


___

### **PR Type**
Bug fix


___

### **Description**
- Move platform splitting from `build_all_platform_images` to `get_platforms`

- Replace parallel execution with sequential build, parallel push

- Eliminate race condition in multiarch image building

- Remove unused helper functions `build_all_platform_images` and `push_all_images`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["get_platforms"] -->|"split platforms"| B["build_multiplatform_image"]
  B -->|"sequential each"| C["build_platform_image"]
  C -->|"parallel par-each"| D["push_image"]
  D --> E["create_manifest"]
  E --> F["push_manifest"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.nu</strong><dd><code>Refactor multiarch build to fix race condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build.nu

<ul><li>Move platform string splitting from <code>build_all_platform_images</code> to <br><code>get_platforms</code> function<br> <li> Inline <code>build_all_platform_images</code> logic with sequential <code>each</code> instead of <br>parallel <code>par-each</code> for builds<br> <li> Inline <code>push_all_images</code> logic with parallel <code>par-each</code> for pushes in <br><code>build_multiplatform_image</code><br> <li> Remove unused helper functions <code>build_all_platform_images</code> and <br><code>push_all_images</code></ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/460/files#diff-b658bedf5ee63484323438e4c1e0cf66f85b553bdd48444c0a307fbdec6c5d89">+3/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

