### PR TITLE
Fix broken aarch64 image

### DIFF
--- a/build.nu
+++ b/build.nu
@@ -34,8 +34,7 @@ def format_arch []: string -> string {
 }
 
 def format_image [ctx: record, platform: record]: nothing -> string {
-    let formatted_arch = $platform.arch | format_arch
-    $"($ctx.image)-($formatted_arch)"
+    $"($ctx.image)-($platform.arch)"
 }
 
 def format_nix_flake [ctx: record, image: string, platform: record]: nothing -> string {
@@ -112,8 +111,8 @@ def build_platform_image [ctx: record]: string -> record {
 
     let flake_url = format_nix_flake $ctx $image $platform
     let loaded_image = $flake_url | build_flake | load_docker_image
-
     let image = format_image $ctx $platform
+
     docker tag $loaded_image $image
 
     {name: $image, platform: $platform}

--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -7,21 +7,6 @@
 
 {
   flake.nixosConfigurations = {
-    oceando = withSystem "x86_64-linux" (
-      { system, ... }:
-      inputs.nixpkgs.lib.nixosSystem {
-        pkgs = import inputs.nixpkgs {
-          inherit system;
-          config.allowUnfree = true;
-        };
-        modules = [
-          ../../hosts/oceando/configuration.nix
-          inputs.home-manager.nixosModules.home-manager
-          inputs.identities.nixosModules.oceando
-          inputs.sops-nix.nixosModules.sops
-        ];
-      }
-    );
     fushi = withSystem "aarch64-linux" (
       { system, ... }:
       inputs.nixpkgs.lib.nixosSystem {
@@ -88,7 +73,24 @@
     );
   };
 
-  perSystem = _: {
-    packages.oceando = self.nixosConfigurations.oceando.config.system.build.buildLayeredImage;
-  };
+  perSystem =
+    { system, ... }:
+    {
+      packages.oceando =
+        let
+          oceando = inputs.nixpkgs.lib.nixosSystem {
+            pkgs = import inputs.nixpkgs {
+              inherit system;
+              config.allowUnfree = true;
+            };
+            modules = [
+              ../../hosts/oceando/configuration.nix
+              inputs.home-manager.nixosModules.home-manager
+              inputs.identities.nixosModules.oceando
+              inputs.sops-nix.nixosModules.sops
+            ];
+          };
+        in
+        oceando.config.system.build.buildLayeredImage;
+    };
 }


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #463
* #462
* __->__ #461


___

### **PR Type**
Bug fix


___

### **Description**
- Moved `oceando` configuration from flake-level to per-system scope

- Fixed aarch64 image building by removing incorrect arch formatting

- Refactored `perSystem` to dynamically build layered image per system

- Removed unused `format_arch` call in `format_image` function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["oceando config<br/>flake-level"] -->|move| B["oceando config<br/>per-system scope"]
  C["format_image<br/>with arch formatting"] -->|simplify| D["format_image<br/>raw arch string"]
  B -->|enable| E["Dynamic layered<br/>image building"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nixos.nix</strong><dd><code>Refactor oceando config to per-system scope</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/flake/nixos.nix

<ul><li>Removed <code>oceando</code> from top-level <code>flakeConfigurations</code> (was x86_64-linux <br>only)<br> <li> Moved <code>oceando</code> configuration into <code>perSystem</code> function for per-system <br>evaluation<br> <li> Changed <code>perSystem</code> from simple reference to dynamic <code>nixosSystem</code> builder<br> <li> Enables proper aarch64 image building by allowing system-specific <br>package imports</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/461/files#diff-bf3ec620b298e48e8f495c0dcca74262c32d0404869f4d3e2ddca046ec484bac">+20/-18</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>build.nu</strong><dd><code>Simplify image formatting and remove arch conversion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build.nu

<ul><li>Removed <code>format_arch</code> call from <code>format_image</code> function<br> <li> Changed to use raw <code>$platform.arch</code> instead of formatted architecture <br>string<br> <li> Reordered variable assignment and docker tag operations for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/461/files#diff-b658bedf5ee63484323438e4c1e0cf66f85b553bdd48444c0a307fbdec6c5d89">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

