### PR TITLE
Remove useless boilerplate

### DIFF
--- a/modules/flake/darwin.nix
+++ b/modules/flake/darwin.nix
@@ -1,36 +1,30 @@
-{ inputs, withSystem, ... }:
+{ inputs, ... }:
 
 {
   flake.darwinConfigurations = {
-    kaltashar = withSystem "x86_64-darwin" (
-      { system, ... }:
-      inputs.nix-darwin.lib.darwinSystem {
-        pkgs = import inputs.nixpkgs {
-          inherit system;
-          config.allowUnfree = true;
-        };
-        modules = [
-          ../../hosts/kaltashar/darwin-configuration.nix
-          inputs.home-manager.darwinModules.home-manager
-          inputs.identities.darwinModules.kaltashar
-          inputs.sops-nix.darwinModules.sops
-        ];
-      }
-    );
-    telsha = withSystem "aarch64-darwin" (
-      { system, ... }:
-      inputs.nix-darwin.lib.darwinSystem {
-        pkgs = import inputs.nixpkgs {
-          inherit system;
-          config.allowUnfree = true;
-        };
-        modules = [
-          ../../hosts/telsha/darwin-configuration.nix
-          inputs.home-manager.darwinModules.home-manager
-          inputs.identities.darwinModules.telsha
-          inputs.sops-nix.darwinModules.sops
-        ];
-      }
-    );
+    kaltashar = inputs.nix-darwin.lib.darwinSystem {
+      pkgs = import inputs.nixpkgs {
+        system = "x86_64-darwin";
+        config.allowUnfree = true;
+      };
+      modules = [
+        ../../hosts/kaltashar/darwin-configuration.nix
+        inputs.home-manager.darwinModules.home-manager
+        inputs.identities.darwinModules.kaltashar
+        inputs.sops-nix.darwinModules.sops
+      ];
+    };
+    telsha = inputs.nix-darwin.lib.darwinSystem {
+      pkgs = import inputs.nixpkgs {
+        system = "aarch64-darwin";
+        config.allowUnfree = true;
+      };
+      modules = [
+        ../../hosts/telsha/darwin-configuration.nix
+        inputs.home-manager.darwinModules.home-manager
+        inputs.identities.darwinModules.telsha
+        inputs.sops-nix.darwinModules.sops
+      ];
+    };
   };
 }

--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -1,86 +1,72 @@
 {
   inputs,
   self,
-  withSystem,
   ...
 }:
 
 {
   flake = {
     nixosConfigurations = {
-      fushi = withSystem "aarch64-linux" (
-        { system, ... }:
-        inputs.nixpkgs.lib.nixosSystem {
-          pkgs = import inputs.nixpkgs {
-            inherit system;
-            config.allowUnfree = true;
-          };
-          modules = [
-            ../../hosts/fushi/configuration.nix
-            inputs.home-manager.nixosModules.home-manager
-            inputs.identities.nixosModules.fushi
-            inputs.nixos-hardware.nixosModules.raspberry-pi-4
-            inputs.sops-nix.nixosModules.sops
-          ];
-        }
-      );
-      minish = withSystem "aarch64-linux" (
-        { system, ... }:
-        inputs.nixpkgs.lib.nixosSystem {
-          pkgs = import inputs.nixpkgs {
-            inherit system;
-            config.allowUnfree = true;
-          };
-          modules = [
-            ../../hosts/minish/configuration.nix
-            inputs.home-manager.nixosModules.home-manager
-            inputs.identities.nixosModules.minish
-            inputs.nixos-hardware.nixosModules.raspberry-pi-4
-            inputs.sops-nix.nixosModules.sops
-          ];
-        }
-      );
-      nishir = withSystem "aarch64-linux" (
-        { system, ... }:
-        inputs.nixpkgs.lib.nixosSystem {
-          pkgs = import inputs.nixpkgs {
-            inherit system;
-            config.allowUnfree = true;
-          };
-          modules = [
-            ../../hosts/nishir/configuration.nix
-            inputs.home-manager.nixosModules.home-manager
-            inputs.identities.nixosModules.nishir
-            inputs.nixos-hardware.nixosModules.raspberry-pi-5
-            inputs.sops-nix.nixosModules.sops
-          ];
-        }
-      );
-      nixtar = withSystem "x86_64-linux" (
-        { system, ... }:
-        inputs.nixpkgs.lib.nixosSystem {
-          pkgs = import inputs.nixpkgs {
-            inherit system;
-            config.allowUnfree = true;
-          };
-          modules = [
-            ../../hosts/nixtar/configuration.nix
-            inputs.home-manager.nixosModules.home-manager
-            inputs.identities.nixosModules.nixtar
-            inputs.nixos-wsl.nixosModules.default
-            inputs.sops-nix.nixosModules.sops
-          ];
-        }
-      );
+      fushi = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/fushi/configuration.nix
+          inputs.home-manager.nixosModules.home-manager
+          inputs.identities.nixosModules.fushi
+          inputs.nixos-hardware.nixosModules.raspberry-pi-4
+          inputs.sops-nix.nixosModules.sops
+        ];
+      };
+      minish = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/minish/configuration.nix
+          inputs.home-manager.nixosModules.home-manager
+          inputs.identities.nixosModules.minish
+          inputs.nixos-hardware.nixosModules.raspberry-pi-4
+          inputs.sops-nix.nixosModules.sops
+        ];
+      };
+      nishir = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nishir/configuration.nix
+          inputs.home-manager.nixosModules.home-manager
+          inputs.identities.nixosModules.nishir
+          inputs.nixos-hardware.nixosModules.raspberry-pi-5
+          inputs.sops-nix.nixosModules.sops
+        ];
+      };
+      nixtar = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nixtar/configuration.nix
+          inputs.home-manager.nixosModules.home-manager
+          inputs.identities.nixosModules.nixtar
+          inputs.nixos-wsl.nixosModules.default
+          inputs.sops-nix.nixosModules.sops
+        ];
+      };
     };
 
     packages = {
-      x86_64-linux.oceando = withSystem "x86_64-linux" (
-        { system, ... }:
+      x86_64-linux.oceando =
         let
           oceando = inputs.nixpkgs.lib.nixosSystem {
             pkgs = import inputs.nixpkgs {
-              inherit system;
+              system = "x86_64-linux";
               config.allowUnfree = true;
             };
             modules = [
@@ -91,14 +77,12 @@
             ];
           };
         in
-        oceando.config.system.build.buildLayeredImage
-      );
-      aarch64-linux.oceando = withSystem "aarch64-linux" (
-        { system, ... }:
+        oceando.config.system.build.buildLayeredImage;
+      aarch64-linux.oceando =
         let
           oceando = inputs.nixpkgs.lib.nixosSystem {
             pkgs = import inputs.nixpkgs {
-              inherit system;
+              system = "aarch64-linux";
               config.allowUnfree = true;
             };
             modules = [
@@ -109,8 +93,7 @@
             ];
           };
         in
-        oceando.config.system.build.buildLayeredImage
-      );
+        oceando.config.system.build.buildLayeredImage;
     };
   };
 }


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #463
* __->__ #462
* #461


___

### **PR Type**
Enhancement


___

### **Description**
- Remove `withSystem` wrapper function calls from Darwin and NixOS configurations

- Inline system values directly into `nixpkgs` imports instead of inheriting from function parameters

- Simplify function signatures by removing unused `withSystem` parameter

- Reduce code duplication and nesting levels across configuration definitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["withSystem wrapper<br/>with system parameter"] -->|Remove wrapper| B["Direct system value<br/>in nixpkgs import"]
  C["Nested function<br/>structure"] -->|Flatten| D["Simplified<br/>configuration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>darwin.nix</strong><dd><code>Inline system values in Darwin configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/flake/darwin.nix

<ul><li>Remove <code>withSystem</code> parameter from function signature<br> <li> Eliminate <code>withSystem</code> wrapper around <code>kaltashar</code> and <code>telsha</code> <br>configurations<br> <li> Replace <code>inherit system</code> with explicit <code>system = "x86_64-darwin"</code> and <br><code>system = "aarch64-darwin"</code> values<br> <li> Reduce nesting by 2 levels, making configurations more readable</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/462/files#diff-4d45b9fd81ced7fa9e07860e2f667c025d00f1d062e7fc4501b68a4f6b32958e">+25/-31</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>nixos.nix</strong><dd><code>Inline system values in NixOS configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/flake/nixos.nix

<ul><li>Remove <code>withSystem</code> parameter from function signature<br> <li> Eliminate <code>withSystem</code> wrapper around all four <code>nixosConfigurations</code> <br>entries (<code>fushi</code>, <code>minish</code>, <code>nishir</code>, <code>nixtar</code>)<br> <li> Replace <code>inherit system</code> with explicit system values for each <br>configuration<br> <li> Simplify <code>packages</code> section by removing <code>withSystem</code> wrappers from <code>oceando</code> <br>package definitions for both <code>x86_64-linux</code> and <code>aarch64-linux</code><br> <li> Reduce overall code nesting and improve readability</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/462/files#diff-bf3ec620b298e48e8f495c0dcca74262c32d0404869f4d3e2ddca046ec484bac">+58/-75</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

