### PR TITLE
Fix deprecated JJ config

### DIFF
--- a/modules/home/vcs.nix
+++ b/modules/home/vcs.nix
@@ -101,10 +101,8 @@
         ds = [ "describe" ];
         sq = [ "squash" ];
       };
-      git = {
-        private-commits = "description(glob:'secret:*')";
-        push-bookmark-prefix = "trunks/shikanime/push-";
-      };
+      git.private-commits = "description(glob:'secret:*')";
+      templates.git_push_bookmark = "'\"trunks/shikanime/push-\" ++ change_id.short()'";
       merge-tools.trae = {
         merge-args = [
           "--wait"


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #470


___

### **PR Type**
Bug fix


___

### **Description**
- Replace deprecated `git.push-bookmark-prefix` config with `templates.git_push_bookmark`

- Flatten nested `git` configuration structure for compatibility

- Update Jujutsu settings to use current configuration schema


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old nested git config"] -- "flatten & migrate" --> B["New flat git config"]
  C["Deprecated push-bookmark-prefix"] -- "replace with" --> D["templates.git_push_bookmark"]
  B --> E["Updated jujutsu settings"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vcs.nix</strong><dd><code>Migrate Jujutsu config to non-deprecated schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/home/vcs.nix

<ul><li>Removed nested <code>git</code> configuration block containing <code>private-commits</code> and <br><code>push-bookmark-prefix</code><br> <li> Flattened <code>git.private-commits</code> to top level of settings<br> <li> Replaced deprecated <code>git.push-bookmark-prefix</code> with new <br><code>templates.git_push_bookmark</code> configuration<br> <li> Updated template value to use Jujutsu's template syntax with <br><code>change_id.short()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/470/files#diff-a43abc5432ca1ecc9e8ceed32b107e9b2cc1a08d3c7edf7edd94d5f297cbd609">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

