### PR TITLE
Update cache config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,13 +16,15 @@
   };
 
   nixConfig = {
-    extra-public-keys = [
-      "shikanime.cachix.org-1:OrpjVTH6RzYf2R97IqcTWdLRejF6+XbpFNNZJxKG8Ts="
-      "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
-    ];
     extra-substituters = [
-      "https://shikanime.cachix.org"
+      "https://cachix.cachix.org"
       "https://devenv.cachix.org"
+      "https://shikanime.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
+      "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
+      "shikanime.cachix.org-1:OrpjVTH6RzYf2R97IqcTWdLRejF6+XbpFNNZJxKG8Ts="
     ];
   };
 

--- a/modules/darwin/base.nix
+++ b/modules/darwin/base.nix
@@ -21,6 +21,16 @@
   # Allow admin users to interact with the daemon
   nix.settings = {
     download-buffer-size = 524288000;
+    substituters = [
+      "https://cachix.cachix.org"
+      "https://devenv.cachix.org"
+      "https://shikanime.cachix.org"
+    ];
+    trusted-public-keys = [
+      "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
+      "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
+      "shikanime.cachix.org-1:OrpjVTH6RzYf2R97IqcTWdLRejF6+XbpFNNZJxKG8Ts="
+    ];
     trusted-users = [
       "root"
       "@admin"

--- a/modules/home/base.nix
+++ b/modules/home/base.nix
@@ -6,12 +6,12 @@
       "nix-command"
     ];
     substituters = [
-      "https://cache.nixos.org"
+      "https://cachix.cachix.org"
       "https://devenv.cachix.org"
       "https://shikanime.cachix.org"
     ];
     trusted-public-keys = [
-      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
       "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
       "shikanime.cachix.org-1:OrpjVTH6RzYf2R97IqcTWdLRejF6+XbpFNNZJxKG8Ts="
     ];


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #472
* #471


___

### **PR Type**
Enhancement


___

### **Description**
- Unified Nix cache configuration across flake and modules

- Added cachix.cachix.org as primary cache substituter

- Renamed extra-public-keys to extra-trusted-public-keys in flake.nix

- Replaced nixos cache with cachix in home module configuration

- Synchronized cache settings between darwin and home modules


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["flake.nix<br/>Cache Config"] -->|"unified settings"| B["modules/darwin/base.nix<br/>Darwin Cache"]
  A -->|"unified settings"| C["modules/home/base.nix<br/>Home Cache"]
  B -->|"substituters &<br/>trusted-public-keys"| D["Cachix<br/>Configuration"]
  C -->|"substituters &<br/>trusted-public-keys"| D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flake.nix</strong><dd><code>Update flake cache configuration with cachix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

flake.nix

<ul><li>Renamed <code>extra-public-keys</code> to <code>extra-trusted-public-keys</code> for consistency<br> <li> Added <code>cachix.cachix.org</code> as primary substituter<br> <li> Reordered substituters list with cachix first<br> <li> Added corresponding cachix public key to trusted keys</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/472/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>base.nix</strong><dd><code>Add cache substituters and keys to darwin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/darwin/base.nix

<ul><li>Added <code>substituters</code> list with cachix, devenv, and shikanime caches<br> <li> Added <code>trusted-public-keys</code> list with corresponding public keys<br> <li> Aligned cache configuration with flake and home module settings</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/472/files#diff-d0230e95224e19046705d8cbb0d763c5d63718633c20bdf1b691276f29b5174b">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>base.nix</strong><dd><code>Replace nixos cache with cachix in home</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

modules/home/base.nix

<ul><li>Replaced <code>cache.nixos.org</code> with <code>cachix.cachix.org</code> as primary cache<br> <li> Updated corresponding public key from nixos cache to cachix<br> <li> Maintained devenv and shikanime cache entries</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/472/files#diff-e6d5f728ee884dda79104976a806b4cc4f63d94a3c659b36fa52064de8d305fe">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

