### PR TITLE
Remove old configs

### DIFF
--- a/infra/shikanime-github/actions.tf
+++ b/infra/shikanime-github/actions.tf
@@ -10,13 +10,6 @@ resource "github_actions_secret" "wakatime_api_key" {
   plaintext_value = var.wakabox.wakatime_api_key
 }
 
-resource "github_actions_secret" "cachix_auth_token" {
-  for_each        = var.repositories
-  repository      = each.value
-  secret_name     = "CACHIX_AUTH_TOKEN"
-  plaintext_value = var.nix.cachix_auth_token
-}
-
 resource "github_actions_secret" "gpg_passphrase" {
   for_each        = var.repositories
   repository      = each.value

--- a/infra/shikanime-github/variable.tf
+++ b/infra/shikanime-github/variable.tf
@@ -32,10 +32,8 @@ variable "repositories" {
 
 variable "nix" {
   type = object({
-    cachix_auth_token = string
-    gpg_passphrase    = string
-    gpg_private_key   = string
-    github_token      = string
+    gpg_passphrase  = string
+    gpg_private_key = string
   })
   description = "Nix configuration secrets"
   sensitive   = true


### PR DESCRIPTION
### **User description**
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #481


___

### **PR Type**
Enhancement


___

### **Description**
- Remove unused `cachix_auth_token` GitHub Actions secret resource

- Remove `cachix_auth_token` and `github_token` from nix variable configuration

- Simplify nix secrets object to only required fields


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Actions Secrets"] -->|remove| B["cachix_auth_token resource"]
  C["Nix Variables"] -->|remove| D["cachix_auth_token field"]
  C -->|remove| E["github_token field"]
  F["Simplified Config"] -.->|result| G["Only essential secrets retained"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>actions.tf</strong><dd><code>Remove Cachix auth token secret resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infra/shikanime-github/actions.tf

<ul><li>Removed <code>github_actions_secret</code> resource for <code>CACHIX_AUTH_TOKEN</code><br> <li> Eliminated the <code>for_each</code> loop that was provisioning this secret across <br>all repositories</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/481/files#diff-7013e80f0e62d546baa3853fa43311ad9a4b549b83976f0770574cb0d4950f3d">+0/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variable.tf</strong><dd><code>Remove unused nix configuration variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

infra/shikanime-github/variable.tf

<ul><li>Removed <code>cachix_auth_token</code> field from nix variable object<br> <li> Removed <code>github_token</code> field from nix variable object<br> <li> Retained only <code>gpg_passphrase</code> and <code>gpg_private_key</code> fields</ul>


</details>


  </td>
  <td><a href="https://github.com/shikanime/shikanime/pull/481/files#diff-6f5aacf1142020508228677d990ea8f11539325cd03a1486dc7299f28a9158c6">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

