### PR TITLE
Fix missing Wayland clipboard

### DIFF
--- a/hosts/nixtar/configuration.nix
+++ b/hosts/nixtar/configuration.nix
@@ -43,6 +43,8 @@ in
   # Required for Docker credential management
   environment.systemPackages = [
     pkgs.docker-credential-helpers
+    pkgs.wl-clipboard
+    pkgs.libnotify
   ];
 
   # NVIDIA driver is provided by Windows host


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #516

