### PR TITLE
Disable MagicDNS on Nixtar

### DIFF
--- a/hosts/nixtar/configuration.nix
+++ b/hosts/nixtar/configuration.nix
@@ -208,6 +208,7 @@ in
       openFirewall = true;
       authKeyFile = config.sops.secrets.tailscale-authkey.path;
       extraUpFlags = [
+        "--accept-dns=false"
         "--advertise-routes 10.42.0.0/16,2001:cafe:42::/56"
         "--ssh"
       ];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #577
* __->__ #576
* #575

