### PR TITLE
Remove libnotify

### DIFF
--- a/hosts/nixtar/configuration.nix
+++ b/hosts/nixtar/configuration.nix
@@ -85,7 +85,6 @@ in
     pkgs.docker-credential-helpers
     pkgs.pass
     pkgs.wl-clipboard
-    pkgs.libnotify
   ];
 
   hardware = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #597
* #596

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ieb7171c0c2cc8d07387101c3f56a0c966a6a6964