### PR TITLE
Remove docker credentials helper on Darwin

### DIFF
--- a/hosts/kaltashar/darwin-configuration.nix
+++ b/hosts/kaltashar/darwin-configuration.nix
@@ -6,11 +6,6 @@
     ../../modules/darwin/workstation.nix
   ];
 
-  # Required for Docker credential management
-  environment.systemPackages = [
-    pkgs.docker-credential-helpers
-  ];
-
   home-manager.users.shikanimedeva.imports = [
     ./users/shikanimedeva/home-configuration.nix
   ];

--- a/hosts/telsha/darwin-configuration.nix
+++ b/hosts/telsha/darwin-configuration.nix
@@ -6,11 +6,6 @@
     ../../modules/darwin/workstation.nix
   ];
 
-  # Required for Docker credential management
-  environment.systemPackages = [
-    pkgs.docker-credential-helpers
-  ];
-
   home-manager.users.shikanimedeva.imports = [
     ./users/shikanimedeva/home-configuration.nix
   ];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #611
* __->__ #609
* #608

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ie618b2f7e2bea2e020ddcf7018477e396a6a6964