### PR TITLE
Fix missing docker creds

### DIFF
--- a/hosts/kaltashar/darwin-configuration.nix
+++ b/hosts/kaltashar/darwin-configuration.nix
@@ -1,9 +1,14 @@
-{ config, ... }:
+{ config, pkgs, ... }:
 
 {
   imports = [
     ../../modules/darwin/base.nix
     ../../modules/darwin/workstation.nix
+  ];
+
+  # Required for Docker credential management
+  environment.systemPackages = [
+    pkgs.docker-credential-helpers
   ];
 
   home-manager.users.shikanimedeva.imports = [

--- a/hosts/telsha/darwin-configuration.nix
+++ b/hosts/telsha/darwin-configuration.nix
@@ -1,9 +1,14 @@
-{ config, ... }:
+{ config, pkgs, ... }:
 
 {
   imports = [
     ../../modules/darwin/base.nix
     ../../modules/darwin/workstation.nix
+  ];
+
+  # Required for Docker credential management
+  environment.systemPackages = [
+    pkgs.docker-credential-helpers
   ];
 
   home-manager.users.shikanimedeva.imports = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #611
* #609
* #608

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I8d05f8b4b26ecf9669a2724074fc08816a6a6964