### PR TITLE
Add cross platform nix builder on Darwin

### DIFF
--- a/modules/darwin/workstation.nix
+++ b/modules/darwin/workstation.nix
@@ -51,7 +51,14 @@
     };
   };
 
-  nix.linux-builder.enable = true;
+  nix.linux-builder = {
+    enable = true;
+    systems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    config.boot.binfmt.emulatedSystems = [ "x86_64-linux" ];
+  };
 
   programs.zsh = {
     enable = true;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #650

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>