### PR TITLE
Drop Drawin x86 support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,6 @@
           ];
         systems = [
           "x86_64-linux"
-          "x86_64-darwin"
           "aarch64-linux"
           "aarch64-darwin"
         ];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #675
* __->__ #674

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ib5768f3f7efe29e31491dcf525ab641f6a6a6964