### PR TITLE
Fix Ghostty missing parent env

### DIFF
--- a/modules/home/ghostty.nix
+++ b/modules/home/ghostty.nix
@@ -5,7 +5,7 @@ with lib;
 {
   programs.ghostty = {
     enable = true;
-    package = if pkgs.stdenv.hostPlatform.isLinux then pkgs.ghostty else pkgs.ghostty-bin;
+    package = if pkgs.stdenv.isLinux then pkgs.ghostty else pkgs.ghostty-bin;
     themes = {
       catppuccin-latte = {
         palette = [
@@ -35,7 +35,7 @@ with lib;
     };
     settings = {
       theme = "catppuccin-latte";
-      command = "${getExe pkgs.zsh} -c ${getExe pkgs.nushell} --login";
+      command = "${getExe pkgs.zsh} -c ${getExe pkgs.nushell}";
     };
   };
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #683
* __->__ #684
* #682
* #685

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ib216b4730d194bb27f8c195baf8dc4b76a6a6964