### PR TITLE
Fix release workflow missing write packages permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,9 @@ permissions:
         required: true
 jobs:
   nix:
+    permissions:
+      contents: read
+      packages: write
     secrets:
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}

--- a/flake.lock
+++ b/flake.lock
@@ -201,11 +201,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776562544,
-        "narHash": "sha256-oFeU7cr8h7p2v2oHuuD1zu060lh8YsX8uLm1X/b91T4=",
+        "lastModified": 1776563171,
+        "narHash": "sha256-eEHHQFwvFDCUMUPrSeLBw9SmX8r9SlI+M7ed7+3Ygs8=",
         "owner": "shikanime-studio",
         "repo": "devlib",
-        "rev": "7bb46e2335ad118949b6e8a7be2787b802a8c1a3",
+        "rev": "ad209a37137febb1ee34898a9d5a776396857a7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #709

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I19efbeb9d285274d909ed15092d6047e6a6a6964