### PR TITLE
Fix submap in select mode missing keys

### DIFF
--- a/modules/home/helix.nix
+++ b/modules/home/helix.nix
@@ -78,6 +78,8 @@
         g = {
           n = "extend_to_line_start";
           i = "extend_to_line_end";
+          u = "goto_file_start";
+          e = "goto_file_end";
         };
       };
       theme = "catppuccin_latte";


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #717
* __->__ #716
* #715

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I7202d65943989c2e790b5d94f93d008f6a6a6964