### PR TITLE
Fix Ghostty missing dark theme

### DIFF
--- a/modules/home/ghostty.nix
+++ b/modules/home/ghostty.nix
@@ -11,4 +11,7 @@ with lib;
       command = "${getExe pkgs.zsh} -c ${getExe pkgs.nushell}";
     };
   };
+
+  xdg.configFile."ghostty/themes/catppuccin-latte".source =
+    "${sources.ghostty}/catppuccin-latte.conf";
 }

--- a/modules/home/ghostty.nix
+++ b/modules/home/ghostty.nix
@@ -1,4 +1,4 @@
-{ lib, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 with lib;
 
@@ -13,5 +13,5 @@ with lib;
   };
 
   xdg.configFile."ghostty/themes/catppuccin-latte".source =
-    "${sources.ghostty}/catppuccin-latte.conf";
+    "${config.catppuccin.sources.ghostty}/catppuccin-latte.conf";
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #729

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I5d3b29d49d92225fdf6cfc508c3992076a6a6964