### PR TITLE
Fix Ghostty missing Frappe theme

### DIFF
--- a/modules/home/ghostty.nix
+++ b/modules/home/ghostty.nix
@@ -12,6 +12,6 @@ with lib;
     };
   };
 
-  xdg.configFile."ghostty/themes/catppuccin-latte".source =
-    "${config.catppuccin.sources.ghostty}/catppuccin-latte.conf";
+  xdg.configFile."ghostty/themes/catppuccin-frappe".source =
+    "${config.catppuccin.sources.ghostty}/catppuccin-frappe.conf";
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #730

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I738b1213adc82a89946e7981f8e2a5c86a6a6964