### PR TITLE
Remove RKE2 OOM panic conflict

### DIFF
--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -74,7 +74,6 @@
       "vm.dirty_ratio" = 10;
       "vm.dirty_writeback_centisecs" = 500;
       "vm.max_map_count" = 262144;
-      "vm.overcommit_memory" = 0;
       "vm.page-cluster" = 0;
       "vm.swappiness" = 10;
       "vm.vfs_cache_pressure" = 200;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #741

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I415a0a8b9cd359d45853125785332fb56a6a6964