### PR TITLE
Add missing Tofu controller hash

### DIFF
--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -256,6 +256,7 @@
       tofu-controller = {
         repo = "https://flux-iac.github.io/tofu-controller";
         name = "tofu-controller";
+        hash = "sha256-YQRWHQwNn+Du9LNcveCBzTnacRDtWNJHwvXxeIxtKcc=";
         version = "0.16.2";
         targetNamespace = "flux-system";
         createNamespace = true;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #743

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I76b3d6031c604220bbbb39bb79ee7a126a6a6964