### PR TITLE
Add missing Flux instance hash

### DIFF
--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -169,6 +169,7 @@
       flux = {
         repo = "oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance";
         name = "flux-instance";
+        hash = "sha256-A7ojoUGwSKt+Vi+kFFroNroUxrJzHdLdbrYidHgg8gs=";
         version = "0.46.0";
         targetNamespace = "flux-system";
         createNamespace = true;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #744

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Idf9347b79694ee79f3328b857837453b6a6a6964