### PR TITLE
Add missing Flux operator hash

### DIFF
--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -211,6 +211,7 @@
       flux-operator = {
         repo = "oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator";
         name = "flux-operator";
+        hash = "sha256-gt8bZ5oLw05lbUXGTzf6NBppAVuuKl9L9LH4jeROpkM=";
         version = "0.46.0";
         targetNamespace = "flux-system";
         createNamespace = true;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #745

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I09bab85cb3e64eecb680c259737269e06a6a6964