### PR TITLE
Fix missing Catppuccin module

### DIFF
--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -34,6 +34,7 @@
           inputs.sops-nix.nixosModules.sops
           {
             home-manager.sharedModules = [
+              inputs.catppuccin.homeModules.default
               inputs.devlib.homeModules.default
               inputs.sops-nix.homeModules.default
             ];
@@ -56,7 +57,8 @@
                 inputs.home-manager.nixosModules.home-manager
                 {
                   home-manager.sharedModules = [
-                    inputs.devlib.homeManagerModule
+                    inputs.catppuccin.homeModules.default
+                    inputs.devlib.homeModules.default
                   ];
                 }
               ];
@@ -79,7 +81,8 @@
                 inputs.home-manager.nixosModules.home-manager
                 {
                   home-manager.sharedModules = [
-                    inputs.devlib.homeManagerModule
+                    inputs.catppuccin.homeModules.default
+                    inputs.devlib.homeModules.default
                   ];
                 }
               ];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #750

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ie19f38cea3cadaae1fea1e24342dfcaa6a6a6964