### PR TITLE
Fix missing Colemak module

### DIFF
--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -35,6 +35,7 @@
           {
             home-manager.sharedModules = [
               inputs.catppuccin.homeModules.default
+              inputs.colemak.homeModules.default
               inputs.devlib.homeModules.default
               inputs.sops-nix.homeModules.default
             ];
@@ -58,6 +59,7 @@
                 {
                   home-manager.sharedModules = [
                     inputs.catppuccin.homeModules.default
+                    inputs.colemak.homeModules.default
                     inputs.devlib.homeModules.default
                   ];
                 }
@@ -82,6 +84,7 @@
                 {
                   home-manager.sharedModules = [
                     inputs.catppuccin.homeModules.default
+                    inputs.colemak.homeModules.default
                     inputs.devlib.homeModules.default
                   ];
                 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #751

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I4de81d259143578ed789ae7c3a01a4846a6a6964