### PR TITLE
Remove old RKE2 config

### DIFF
--- a/hosts/nixtar/configuration.nix
+++ b/hosts/nixtar/configuration.nix
@@ -171,8 +171,4 @@ in
       generateResolvConf = false;
     };
   };
-
-  systemd.tmpfiles.rules = [
-    "L+ /var/lib/rancher/rke2/server/manifests/tailscale-operator-config.yaml - - - - ${config.sops.secrets.tailscale-operator-config-manifest.path}"
-  ];
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #753

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I692e22dd16429085b18799844dad5aa56a6a6964