### PR TITLE
Remove old useless airgap

### DIFF
--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -226,13 +226,6 @@
     enable = true;
     role = "server";
     cisHardening = true;
-    images = with config.services.rke2.package; [
-      # Keep RKE2 off live registry pulls during bootstrap; this node has been
-      # failing while fetching the runtime image from Docker Hub.
-      images-core-linux-amd64-tar-zst
-      images-canal-linux-amd64-tar-zst
-      images-multus-linux-amd64-tar-zst
-    ];
     nodeLabel = [ "node.longhorn.io/create-default-disk=config" ];
     extraFlags = [
       "--cluster-cidr=10.244.0.0/16,fd00::/108"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #783

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I67cc3055270d373410b257cf4edc34796a6a6964