### PR TITLE
Fix missing iscsi daemon

### DIFF
--- a/modules/nixos/longhorn.nix
+++ b/modules/nixos/longhorn.nix
@@ -7,6 +7,8 @@
     "iscsi_tcp"
   ];
 
+  services.openiscsi.enable = true;
+
   # Enable NFS support at kernel level
   boot.supportedFilesystems = [ "nfs" ];
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #784

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ib1c3aa2a02749c618dacee9b8eec7bf16a6a6964