### PR TITLE
Fix iscsi required name

### DIFF
--- a/modules/nixos/longhorn.nix
+++ b/modules/nixos/longhorn.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 
 {
   # Enable iscsi protocol support at kernel level
@@ -7,16 +7,19 @@
     "iscsi_tcp"
   ];
 
-  services.openiscsi.enable = true;
+  services.openiscsi = {
+    enable = true;
+    name = "iqn.2026-06.io.shikanime:${config.networking.hostName}";
+  };
 
   # Enable NFS support at kernel level
   boot.supportedFilesystems = [ "nfs" ];
 
-  environment.systemPackages = [
-    pkgs.cryptsetup
-    pkgs.lvm2
-    pkgs.nfs-utils
-    pkgs.openiscsi
+  environment.systemPackages = with pkgs; [
+    cryptsetup
+    lvm2
+    nfs-utils
+    openiscsi
   ];
 
   # FIXME: https://github.com/longhorn/longhorn/issues/2166


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #785

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Icb1324448571f36e932b7f78c3490bd66a6a6964