### PR TITLE
Fix missing dev dri

### DIFF
--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -1,13 +1,11 @@
 {
   config,
   pkgs,
-  modulesPath,
   ...
 }:
 
 {
   imports = [
-    "${modulesPath}/profiles/headless.nix"
     ../../modules/nixos/base.nix
     ../../modules/nixos/longhorn.nix
   ];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #789

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ib6d97f460d4dada6763ba4ab68375fa26a6a6964