### PR TITLE
Fix missing mergiraf

### DIFF
--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -58,7 +58,11 @@ with lib;
 
     gpg.enable = true;
 
-    mergiraf.enable = true;
+    mergiraf = {
+      enable = true;
+      enableGitIntegration = true;
+      enableJujutsuIntegration = true;
+    };
 
     mise.enable = true;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #794

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I280cbfd2111947e66d14bd6a4cbe714a6a6a6964