### PR TITLE
Fix missing gouv-signing-key in sops secrets def

### DIFF
--- a/hosts/nixtar/users/shika/home-configuration.nix
+++ b/hosts/nixtar/users/shika/home-configuration.nix
@@ -61,6 +61,7 @@ in
       github-token = { };
       gitlab-token = { };
       gouv-email = { };
+      gouv-signing-key = { };
       shikanime-studio-email = { };
       nix-access-token = { };
     };

--- a/hosts/telsha/users/shikanimedeva/home-configuration.nix
+++ b/hosts/telsha/users/shikanimedeva/home-configuration.nix
@@ -85,6 +85,7 @@ in
       github-token = { };
       gitlab-token = { };
       gouv-email = { };
+      gouv-signing-key = { };
       shikanime-studio-email = { };
       nix-access-token = { };
     };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #799

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: I3c11a9bb0fd45be4ed4cf13507cc1d536a6a6964