### PR TITLE
Open RKE2 ports

### DIFF
--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -126,8 +126,13 @@ with lib;
       '';
       interfaces.${cfg.interface} = {
         allowedTCPPorts = [
+          2379
+          2380
+          2381
           6443
+          9099
           9345
+          10250
         ];
         allowedUDPPorts = [
           8472


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #822

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: I6cb60e50ae8dbe54f8b8ff9f8c8dc8336a6a6964