### PR TITLE
Fix default disk path syntax

### DIFF
--- a/modules/nixos/rke2/longhorn.nix
+++ b/modules/nixos/rke2/longhorn.nix
@@ -143,7 +143,7 @@ with lib;
           longhornDefaultDisksConfig="$(
             {
               ${pkgs.jq}/bin/jq -nc '{
-                path: "/var/lib/longhorn",
+                path: "/var/lib/longhorn/",
                 allowScheduling: true
               }'
               for mount_path in ${mountRoot}/*; do


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #828
* #827

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: I19d2610192cc5a8ca32d939478a540716a6a6964