### PR TITLE
Fix missing pkgs in zed editor module

### DIFF
--- a/modules/home/zed-editor.nix
+++ b/modules/home/zed-editor.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 
 with lib;
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #839

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: I55b3bec9258cc3fd924377f0f8dcbd0e6a6a6964