### PR TITLE
Remove invalid Zed config

### DIFF
--- a/modules/home/zed-editor.nix
+++ b/modules/home/zed-editor.nix
@@ -8,7 +8,6 @@ with lib;
 
     userSettings = {
       agent = {
-        new_thread_location = "new_worktree";
         default_model = {
           provider = "Hermes Agent";
           model = "hermes-agent";


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #840

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: I67bc94f0789e3025a2c0aa31fdf18e9f6a6a6964