### PR TITLE
Migrate from vxlan to wireguard

### DIFF
--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -90,7 +90,10 @@ with lib;
               namespace = "kube-system";
             };
             spec.valuesContent = builtins.toJSON {
-              flannel.iface = cfg.interface;
+              flannel = {
+                backend = "wireguard";
+                iface = cfg.interface;
+              };
             };
           };
 
@@ -161,7 +164,7 @@ with lib;
           10250
         ];
         allowedUDPPorts = [
-          8472
+          51820
         ];
       };
       allowedTCPPortRanges = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #843

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: Ibca895e94260fd592a6cbdf844c683326a6a6964