### PR TITLE
Enable transparent k9s

### DIFF
--- a/modules/home/cloud.nix
+++ b/modules/home/cloud.nix
@@ -1,8 +1,13 @@
 { pkgs, ... }:
 
 {
+  catppuccin.k9s.enable = false;
+
   programs = {
-    k9s.enable = true;
+    k9s = {
+      enable = true;
+      settings.k9s.ui.skin = "transparent";
+    };
 
     ssh.settings."ssh.dev.azure.com" = {
       HostkeyAlgorithms = "+ssh-rsa";


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #847

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: Ib4150b7f7f932603e6b5d4839560e1a16a6a6964