### PR TITLE
Fix Zed editor terminal

### DIFF
--- a/modules/home/zed-editor.nix
+++ b/modules/home/zed-editor.nix
@@ -56,7 +56,13 @@ with lib;
 
       relative_line_numbers = "enabled";
 
-      terminal.shell.program = "${getExe pkgs.zsh} -c ${getExe pkgs.nushell}";
+      terminal.shell.program.with_arguments = {
+        program = "${getExe pkgs.zsh}";
+        args = [
+          "-c"
+          "${getExe pkgs.nushell}"
+        ];
+      };
 
       theme = {
         mode = "system";


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #848

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: I412f57338bb771d50059b72e671900a76a6a6964