### PR TITLE
Fix Zed terminal subkey

### DIFF
--- a/modules/home/zed-editor.nix
+++ b/modules/home/zed-editor.nix
@@ -56,7 +56,7 @@ with lib;
 
       relative_line_numbers = "enabled";
 
-      terminal.shell.program.with_arguments = {
+      terminal.shell.with_arguments = {
         program = "${getExe pkgs.zsh}";
         args = [
           "-c"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #849

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: I00a6dd6daebcef61e5f254defcd7ff316a6a6964