### PR TITLE
Reintroduce kaltashar host based on telsha config

### DIFF
--- a/hosts/kaltashar/darwin-configuration.nix
+++ b/hosts/kaltashar/darwin-configuration.nix
@@ -1,0 +1,42 @@
+{ config, ... }:
+
+{
+  imports = [
+    ../../modules/darwin/base.nix
+    ../../modules/darwin/workstation.nix
+  ];
+
+  home-manager.users.shikanimedeva.imports = [
+    ./users/shikanimedeva/home-configuration.nix
+  ];
+
+  networking.hostName = "kaltashar";
+
+  nix.extraOptions = ''
+    !include ${config.sops.templates.nix-config.path}
+  '';
+
+  sops = {
+    age = {
+      generateKey = true;
+      keyFile = "/var/lib/sops-nix/key.txt";
+      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    };
+    defaultSopsFile = ../../secrets/kaltashar.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets.nix-access-token = { };
+    templates.nix-config.content = ''
+      extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";
+    '';
+  };
+
+  system.primaryUser = "shikanimedeva";
+
+  users.users.shikanimedeva = {
+    home = "/Users/shikanimedeva";
+    name = "shikanimedeva";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+}

--- a/hosts/kaltashar/users/shikanimedeva/home-configuration.nix
+++ b/hosts/kaltashar/users/shikanimedeva/home-configuration.nix
@@ -1,0 +1,189 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  toDhall = generators.toDhall { };
+
+  gitIni = pkgs.formats.gitIni { };
+  ini = pkgs.formats.ini { };
+  toml = pkgs.formats.toml { };
+  yaml = pkgs.formats.yaml { };
+
+  name = "William Phetsinorath";
+  signingKey = "09CA52A835C14157";
+in
+{
+  imports = [
+    ../../../../modules/home/base.nix
+    ../../../../modules/home/cloud.nix
+    ../../../../modules/home/fontconfig.nix
+    ../../../../modules/home/ghostty.nix
+    ../../../../modules/home/helix.nix
+    ../../../../modules/home/starship.nix
+    ../../../../modules/home/vcs.nix
+    ../../../../modules/home/workstation.nix
+    ../../../../modules/home/zed-editor.nix
+  ];
+
+  home = {
+    file."Library/Preferences/sapling/sapling.conf".source =
+      config.lib.file.mkOutOfStoreSymlink config.sops.templates.sapling-config.path;
+    sessionVariables = {
+      GHSTACKRC_PATH = config.lib.file.mkOutOfStoreSymlink config.sops.templates.ghstack-config.path;
+      SSH_AUTH_SOCK = "${config.home.homeDirectory}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock";
+    };
+  };
+
+  nix.extraOptions = ''
+    !include ${config.sops.templates.nix-config.path}
+  '';
+
+  programs = {
+    bash.enable = true;
+
+    docker-cli = {
+      contexts.rancher-desktop = {
+        Endpoints = {
+          docker = {
+            Host = "unix://${config.home.homeDirectory}/.rd/docker.sock";
+            SkipTLSVerify = false;
+          };
+        };
+        Metadata.Description = "Rancher Desktop moby context";
+      };
+      settings = {
+        credsStore = "osxkeychain";
+        currentContext = "rancher-desktop";
+      };
+    };
+
+    git = {
+      includes = [
+        { path = config.lib.file.mkOutOfStoreSymlink config.sops.templates.git-config.path; }
+      ];
+      signing = {
+        format = "openpgp";
+        signByDefault = true;
+      };
+    };
+
+    zsh.enable = true;
+  };
+
+  sops = {
+    age.keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
+    defaultSopsFile = ../../../../secrets/kaltashar.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      cachix-token = { };
+      github-token = { };
+      gitlab-token = { };
+      gouv-email = { };
+      gouv-signing-key = { };
+      shikanime-studio-email = { };
+      nix-access-token = { };
+    };
+    templates = {
+      cachix-config.content = toDhall {
+        authToken = config.sops.placeholder.cachix-token;
+        hostname = "https://cachix.org";
+      };
+      ghstack-config = {
+        file = ini.generate "ghstackrc" {
+          ghstack = {
+            github_oauth = config.sops.placeholder.github-token;
+            github_url = "github.com";
+            github_username = "shikanime";
+          };
+        };
+        mode = "0640";
+      };
+      glab-cli-config.file = yaml.generate "config.yaml" {
+        git_protocol = "https";
+        hosts.gitlab.com = {
+          api_host = "gitlab.com";
+          api_protocol = "https";
+          token = config.sops.placeholder.gitlab-token;
+        };
+      };
+      git-config.file = gitIni.generate "config" {
+        user = {
+          inherit name;
+          inherit signingKey;
+          email = config.sops.placeholder.shikanime-studio-email;
+        };
+      };
+      jujutsu-config.file = toml.generate "config.toml" {
+        "--scope" = [
+          {
+            "--when.repositories" = [ "~/Source/Repos/github.com/cloud-pi-native" ];
+            signing.key = config.sops.placeholder.gouv-signing-key;
+            user = {
+              email = config.sops.placeholder.gouv-email;
+              inherit name;
+            };
+          }
+        ];
+        signing = {
+          backend = "gpg";
+          behavior = "own";
+          key = signingKey;
+        };
+        user = {
+          inherit name;
+          email = config.sops.placeholder.shikanime-studio-email;
+        };
+      };
+      nix-config.content = ''
+        extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";
+      '';
+      sapling-config.file = ini.generate "sapling.conf" {
+        alias = {
+          ci = "ci --message-field Signed-off-by=\"${name} <${config.sops.placeholder.shikanime-studio-email}>\"";
+          commit = "commit --message-field Signed-off-by=\"${name} <${config.sops.placeholder.shikanime-studio-email}>\"";
+          push = "push --force";
+        };
+        committemplate = {
+          commit-message-fields = "Summary,Fixes,Signed-off-by";
+          emptymsg = "{if(title, title, defaulttitle)}\\n\\nSummary: {summary}\\n\\nFixes: {fixes}\\n\\nSigned-off-by: {author}";
+        };
+        diff-tools = {
+          "zed.args" = "--wait --diff $local $other";
+          "zed.gui" = true;
+          "zed.priority" = 20;
+        };
+        gpg.key = signingKey;
+        hooks = {
+          "precommit.git-hooks" = "test -f .git/hooks/pre-commit && .git/hooks/pre-commit || true";
+          "preoutgoing.git-hooks" = "test -f .git/hooks/pre-push && .git/hooks/pre-push || true";
+          "update.git-hooks" = "test -f .git/hooks/post-rewrite && .git/hooks/post-rewrite || true";
+        };
+        merge-tools = {
+          "mergiraf.args" = "merge --git $base $local $other -o $output";
+          "mergiraf.priority" = 30;
+        };
+        ui = {
+          editor = "hx";
+          username = "${name} <${config.sops.placeholder.shikanime-studio-email}>";
+        };
+      };
+    };
+  };
+
+  xdg.configFile = {
+    "cachix/cachix.dhall".source =
+      config.lib.file.mkOutOfStoreSymlink config.sops.templates.cachix-config.path;
+    "glab-cli/config.yml" = {
+      force = true;
+      source = config.lib.file.mkOutOfStoreSymlink config.sops.templates.glab-cli-config.path;
+    };
+    "jj/conf.d/default.toml".source =
+      config.lib.file.mkOutOfStoreSymlink config.sops.templates.jujutsu-config.path;
+  };
+}

--- a/modules/flake/darwin.nix
+++ b/modules/flake/darwin.nix
@@ -3,24 +3,45 @@
 
 {
   flake = {
-    darwinConfigurations.telsha = inputs.nix-darwin.lib.darwinSystem {
-      pkgs = import inputs.nixpkgs {
-        system = "aarch64-darwin";
-        config.allowUnfree = true;
+    darwinConfigurations = {
+      kaltashar = inputs.nix-darwin.lib.darwinSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-darwin";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/kaltashar/darwin-configuration.nix
+          inputs.home-manager.darwinModules.default
+          inputs.sops-nix.darwinModules.default
+          {
+            home-manager.sharedModules = [
+              inputs.catppuccin.homeModules.default
+              inputs.colemak.homeModules.default
+              inputs.devlib.homeModules.default
+              inputs.sops-nix.homeModules.default
+            ];
+          }
+        ];
       };
-      modules = [
-        ../../hosts/telsha/darwin-configuration.nix
-        inputs.home-manager.darwinModules.default
-        inputs.sops-nix.darwinModules.default
-        {
-          home-manager.sharedModules = [
-            inputs.catppuccin.homeModules.default
-            inputs.colemak.homeModules.default
-            inputs.devlib.homeModules.default
-            inputs.sops-nix.homeModules.default
-          ];
-        }
-      ];
+      telsha = inputs.nix-darwin.lib.darwinSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-darwin";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/telsha/darwin-configuration.nix
+          inputs.home-manager.darwinModules.default
+          inputs.sops-nix.darwinModules.default
+          {
+            home-manager.sharedModules = [
+              inputs.catppuccin.homeModules.default
+              inputs.colemak.homeModules.default
+              inputs.devlib.homeModules.default
+              inputs.sops-nix.homeModules.default
+            ];
+          }
+        ];
+      };
     };
     packages.aarch64-darwin.telsha = self.darwinConfigurations.telsha.system;
   };

--- a/modules/flake/devenv.nix
+++ b/modules/flake/devenv.nix
@@ -130,6 +130,16 @@
                 ];
               }
               {
+                path_regex = "secrets/kaltashar.enc.yaml";
+                key_groups = [
+                  {
+                    age = age ++ [
+                      "age16pkwna5hq4hh03xfj6j5uew3wq6wfr5xgqgdmg6t3a27uz2dhuqsslh56c"
+                    ];
+                  }
+                ];
+              }
+              {
                 path_regex = "secrets/telsha.enc.yaml";
                 key_groups = [
                   {

--- a/secrets/kaltashar.enc.yaml
+++ b/secrets/kaltashar.enc.yaml
@@ -1,0 +1,31 @@
+nix-access-token: ENC[AES256_GCM,data:1d1obJU8KoUc4yX7qTfZhrTiZ48ClG1L3VJcx7rjSzpYHQ==,iv:1auW6H1goHJJ37EVJPwS0n2PsR9kkeGt5Jev4IgTtmQ=,tag:/PPLOMI9LOy3WT0ElqzvLQ==,type:str]
+cachix-token: ENC[AES256_GCM,data:wdepC24vBBaeqVwsyX+e6u9sVAUbUO+F27ShEYd4oN/7fmyNVw==,iv:pv9vbPYuYH+ZV2w0hAKO8zhaSBD5IHeS2PHvqPoZCi4=,tag:8r225139J2YkoFYNJRxujA==,type:str]
+github-token: ENC[AES256_GCM,data:VIO0y0pIAc8rjkH1dk3nidSkW4jddk2c9jPImJrsKF2HP7eUQQ==,iv:KpciHaovFbBRAKBHXTI+LHj8lFcxJj7Y4PWUeQq6zCs=,tag:FXVV5QtPhjSEBkwi/rC32g==,type:str]
+gitlab-token: ENC[AES256_GCM,data:n9YB+m52Zzf8/11VBl9DAsnFCdJAoqkAW1NyaEV7+4R99F04YA==,iv:j1Hsu7JdjRFSvX4b8S1tVzkzUx7ZEDa1NR3zrn9nV70=,tag:Ni9AyGXtJNXOITt7ergd7A==,type:str]
+gouv-email: ENC[AES256_GCM,data:f+6p9o1Q35SrPJMlAf9eg1VORalJsw4Pxt8Ro4QN,iv:REqC3+arrzxI7kBlB7wo11HP1kyBe3gqIfEQvX/tQRg=,tag:MuKZz3a5eNXIR9yEffukRA==,type:str]
+gouv-signing-key: ENC[AES256_GCM,data:k6xx57BhGCfYtoD3cSsjnMZKVamG/PAvz+gJtQ==,iv:8uPGPDg2Bsmb5OOrSI3US/l/ep12S7XI5r7cyXXk1jw=,tag:lLacfPBxAN6mC6DeYLEDGQ==,type:str]
+shikanime-studio-email: ENC[AES256_GCM,data:bKTmkhK965EorEb3sPk95coYGAvy35ukkYCsKv2b,iv:IyKPbzXVArYGVQr9XvlxQXyZAHuw8JXcheGW8aoU0qU=,tag:XFSkMyiWK+emOu8p3uyUFg==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBManVHTmVUUFowTkVnclVr
+            ZjluZDAxcEVBWUxNeWpCZXdMVnVraE1tWUZjCjkyYWNKRXMxR1pOdUZibkxSY1Iy
+            Tk1nZlcyL2JVUXRkTlJKU0VKN1pPL1UKLS0tIGVsWmJjQzd1TjMxaXVWckFvbUZz
+            eGZPWFhXYTZ3aENIRm9ydjEzT0dBUTAKxp57x2YWLm9oHBPJ59YHJ7R04vSAQ/ql
+            qghZgm0+04LNBQ6d313HFcV7fmgow7Qjb9+eZpFMV0lC6BodNERpCA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSeVVGSDJicFpDckxyMnlQ
+            Q2kxODE1RnZOSHdrWGpwVjNmV0RtQUpqMEdVClBIR2dMUEtrOTI3QklTa0o0Vk1w
+            VUxwZDNiMjc3NndzNXJTa05SNDBYUHMKLS0tIEFMNDRQRC9nZXRoYTh3cHdYSTlr
+            cFRMWnpocFhYbExyQ1hBbW83UEx4Zk0KUrcaBJTor44luQOOaH8ci4T23CM9tG3y
+            Pqmt/qcz2tS7Y+Myir/25gghxtt+tCaXna8jHSJfl1rCOIuHIqIIpQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay
+    lastmodified: "2026-06-12T20:05:48Z"
+    mac: ENC[AES256_GCM,data:Bjs9mxcydeULGNhTQjKlJlIopH9y19/8bJplEm9pDhMXUXxYpJgFT7b5J0XgdDp/0NUKNV43ZiLsddCvR3fcdoQOS+a0Ou1TDxqRDqOXyevm3QyBNQ5l1/zoXR2PSGUFylL9yCtttXEQs4H4BO9CrjvveFvFhiPruYOJb+18PTw=,iv:bmufmPGe+x+ebnFjAizsHjDvlVM93XHlUr43J1DYJ3U=,tag:+33cxSTyvJBSTWaQSQbGLg==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #850

----

- Add hosts/kaltashar/darwin-configuration.nix (x86_64-darwin, adapted from telsha)
- Add hosts/kaltashar/users/shikanimedeva/home-configuration.nix (modern template pattern)
- Add secrets/kaltashar.enc.yaml with placeholder credentials (encrypted with telsha+nixtar age keys)
- Register kaltashar in modules/flake/darwin.nix darwinConfigurations
- Add kaltashar.enc.yaml to modules/flake/devenv.nix sops creation_rules

kaltashar is an old Intel MacBook being reintroduced after decommission.
Secrets contain PLACEHOLDER values and must be replaced with real credentials.
The kaltashar host age key recipient is the original key from the retired config.

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: I44456824215b073d7018ff9da0a321b96a6a6964