### PR TITLE
Simplify sops age config on darwin hosts

### DIFF
--- a/hosts/kaltashar/darwin-configuration.nix
+++ b/hosts/kaltashar/darwin-configuration.nix
@@ -17,11 +17,7 @@
   '';
 
   sops = {
-    age = {
-      generateKey = true;
-      keyFile = "/var/lib/sops-nix/key.txt";
-      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
-    };
+    age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
     defaultSopsFile = ../../secrets/kaltashar.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets.nix-access-token = { };

--- a/hosts/telsha/darwin-configuration.nix
+++ b/hosts/telsha/darwin-configuration.nix
@@ -17,11 +17,7 @@
   '';
 
   sops = {
-    age = {
-      generateKey = true;
-      keyFile = "/var/lib/sops-nix/key.txt";
-      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
-    };
+    age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
     defaultSopsFile = ../../secrets/telsha.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets.nix-access-token = { };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #851

Replace the redundant age.generateKey + age.keyFile + age.sshKeyPaths
block with just age.sshKeyPaths on both telsha and kaltashar.

The generateKey + keyFile pattern is intended for NixOS headless servers
without SSH host keys. On nix-darwin, the SSH host ed25519 key already
serves as the machine identity for sops decryption.

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>