### PR TITLE
Fix nixtar sops keyFile typo

### DIFF
--- a/hosts/nixtar/configuration.nix
+++ b/hosts/nixtar/configuration.nix
@@ -111,7 +111,7 @@ in
   sops = {
     age = {
       generateKey = true;
-      keyFile = "/var/lib/spos-nix/key.txt";
+      keyFile = "/var/lib/sops-nix/key.txt";
       sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
     };
     defaultSopsFile = ../../secrets/nixtar.enc.yaml;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #853

spos-nix -> sops-nix in age.keyFile path.

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>