### PR TITLE
Migrate CNI from Canal to Cilium with Gateway API enabled

### DIFF
--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -9,12 +9,10 @@ with lib;
 let
   cfg = config.shikanime.rke2;
 
-  clusterCidrs = lib.concatStringsSep "," (
-    lib.filter (cidr: cidr != null) [
-      cfg.clusterCidrIPv4
-      cfg.clusterCidrIPv6
-    ]
-  );
+  clusterCidrs = lib.filter (cidr: cidr != null) [
+    cfg.clusterCidrIPv4
+    cfg.clusterCidrIPv6
+  ];
 
   rke2ApiServerPort = 6443;
   rke2SupervisorPort = 9345;

--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -13,9 +13,11 @@ let
   etcdClientPort = 2379;
   etcdPeerPort = 2380;
   etcdMetricsPort = 2381;
-  canalHealthCheckPort = 9099;
-  wireguardPort = 51820;
-  wireguardIPv6Port = 51821;
+  ciliumHealthPort = 9890;
+  ciliumVXLANPort = 8472;
+  ciliumHubblePort = 4244;
+  ciliumHubblePeerPort = 4245;
+  gatewayAPIPort = 8443;
 
   nodePortRange = {
     from = 30000;
@@ -44,7 +46,7 @@ with lib;
           type = types.listOf types.str;
           default = [
             "multus"
-            "canal"
+            "cilium"
           ];
           description = "The CNI plugins passed to RKE2.";
         };
@@ -97,19 +99,50 @@ with lib;
         role = "server";
         cisHardening = true;
         manifests = {
-          rke2-canal-config.content = {
+          rke2-cilium-config.content = {
             apiVersion = "helm.cattle.io/v1";
             kind = "HelmChartConfig";
             metadata = {
-              name = "rke2-canal";
+              name = "rke2-cilium";
               namespace = "kube-system";
             };
             spec.valuesContent = builtins.toJSON {
-              flannel = {
-                backend = "wireguard";
-                iface = cfg.interface;
+              cni = {
+                chainingMode = "multus";
+                exclusive = false;
+              };
+              tunnelProtocol = "vxlan";
+              gatewayAPI = {
+                enabled = true;
+              };
+              hubble = {
+                enabled = true;
+                relay.enabled = true;
+                ui.enabled = true;
+              };
+              prometheus = {
+                enabled = true;
+              };
+              operator = {
+                prometheus.enabled = true;
+              };
+              bpf = {
+                masquerade = true;
+              };
+              ipv4NativeRoutingCIDR = "10.244.0.0/16";
+              ipam = {
+                operator.clusterPoolIPv4PodCIDRList = [
+                  "10.244.0.0/16"
+                ];
               };
             };
+          };
+
+          rke2-cilium-gateway-class.content = {
+            apiVersion = "networking.x-k8s.io/v1";
+            kind = "GatewayClass";
+            metadata.name = "rke2-cilium";
+            spec.controllerName = "cilium.io/gateway-controller";
           };
 
           rke2-coredns-config.content = {
@@ -176,11 +209,11 @@ with lib;
           etcdClientPort
           etcdPeerPort
           etcdMetricsPort
-          canalHealthCheckPort
+          ciliumHealthPort
+          gatewayAPIPort
         ];
         allowedUDPPorts = [
-          wireguardPort
-          wireguardIPv6Port
+          ciliumVXLANPort
         ];
         allowedTCPPortRanges = [ nodePortRange ];
       };

--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -9,7 +9,7 @@ with lib;
 let
   cfg = config.shikanime.rke2;
 
-  clusterCidr = lib.filter (cidr: cidr != null) [
+  clusterCidr = filter (cidr: cidr != null) [
     cfg.clusterCidrIPv4
     cfg.clusterCidrIPv6
   ];

--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -109,15 +109,21 @@ with lib;
               kubeProxyReplacement = true;
               k8sServiceHost = "localhost";
               k8sServicePort = "6443";
-              encryption.enabled = true;
-              encryption.type = "wireguard";
-              cni.chainingMode = "multus";
-              cni.exclusive = false;
+              encryption = {
+                enabled = true;
+                type = "wireguard";
+              };
+              cni = {
+                chainingMode = "multus";
+                exclusive = false;
+              };
               autoDirectNodeRoutes = true;
               gatewayAPI.enabled = true;
-              hubble.enabled = true;
-              hubble.relay.enabled = true;
-              hubble.ui.enabled = true;
+              hubble = {
+                enabled = true;
+                relay.enabled = true;
+                ui.enabled = true;
+              };
               prometheus.enabled = true;
               operator.prometheus.enabled = true;
               bpf.masquerade = true;

--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -9,7 +9,7 @@ with lib;
 let
   cfg = config.shikanime.rke2;
 
-  clusterCidrs = lib.filter (cidr: cidr != null) [
+  clusterCidr = lib.filter (cidr: cidr != null) [
     cfg.clusterCidrIPv4
     cfg.clusterCidrIPv6
   ];
@@ -100,7 +100,7 @@ in
         disableKubeProxy = true;
         enable = true;
         extraFlags = [
-          (optionalString (clusterCidrs != [ ]) "--cluster-cidr=${concatStringsSep "," clusterCidrs}")
+          (optionalString (clusterCidr != [ ]) "--cluster-cidr=${concatStringsSep "," clusterCidr}")
           "--cni=multus,cilium"
           "--kube-controller-manager-arg=node-cidr-mask-size-ipv4=${toString cfg.nodeCidrMaskSize}"
           "--kube-controller-manager-arg=node-cidr-mask-size-ipv6=${toString cfg.nodeCidrMaskSizeIPv6}"

--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -96,9 +96,9 @@ in
   config = mkIf cfg.enable {
     services.rke2 = mkMerge [
       {
-        cisHardening = true;
-        disableKubeProxy = true;
         enable = true;
+        cisHardening = true;
+        disable = [ "kube-proxy" ];
         extraFlags = [
           (optionalString (clusterCidr != [ ]) "--cluster-cidr=${concatStringsSep "," clusterCidr}")
           "--cni=multus,cilium"

--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -54,15 +54,6 @@ in
           description = "The IPv6 pod CIDR passed to RKE2.";
         };
 
-        cni = mkOption {
-          type = types.listOf types.str;
-          default = [
-            "multus"
-            "cilium"
-          ];
-          description = "The CNI plugins passed to RKE2.";
-        };
-
         nodeCidrMaskSize = mkOption {
           type = types.int;
           default = 24;
@@ -112,7 +103,7 @@ in
         enable = true;
         extraFlags = [
           (optionalString (clusterCidrs != [ ]) "--cluster-cidr=${concatStringsSep "," clusterCidrs}")
-          "--cni=${concatStringsSep "," cfg.cni}"
+          "--cni=multus,cilium"
           "--kube-controller-manager-arg=node-cidr-mask-size-ipv4=${toString cfg.nodeCidrMaskSize}"
           "--kube-controller-manager-arg=node-cidr-mask-size-ipv6=${toString cfg.nodeCidrMaskSizeIPv6}"
           (optionalString (cfg.serviceCidr != null) "--service-cidr=${cfg.serviceCidr}")
@@ -127,42 +118,37 @@ in
               name = "rke2-cilium";
               namespace = "kube-system";
             };
-            spec.valuesContent = builtins.toJSON (
-              {
-                autoDirectNodeRoutes = true;
-                bpf.masquerade = true;
-                cni = {
-                  chainingMode = "multus";
-                  exclusive = false;
-                };
-                encryption = {
-                  enabled = true;
-                  type = "wireguard";
-                };
-                gatewayAPI = {
-                  enabled = true;
-                  gatewayClass.create = true;
-                };
-                hubble = {
-                  enabled = true;
-                  relay.enabled = true;
-                  ui.enabled = true;
-                };
-                k8sServiceHost = "localhost";
-                k8sServicePort = "6443";
-                kubeProxyReplacement = true;
-                operator.prometheus.enabled = true;
-                prometheus.enabled = true;
-              }
-              // optionalAttrs (cfg.clusterCidrIPv4 != null) {
-                ipv4NativeRoutingCIDR = cfg.clusterCidrIPv4;
-                ipam.operator.clusterPoolIPv4PodCIDRList = [ cfg.clusterCidrIPv4 ];
-              }
-              // optionalAttrs (cfg.clusterCidrIPv6 != null) {
-                ipv6NativeRoutingCIDR = cfg.clusterCidrIPv6;
-                ipam.operator.clusterPoolIPv6PodCIDRList = [ cfg.clusterCidrIPv6 ];
-              }
-            );
+            spec.valuesContent = builtins.toJSON {
+              autoDirectNodeRoutes = true;
+              bpf.masquerade = true;
+              cni = {
+                chainingMode = "multus";
+                exclusive = false;
+              };
+              encryption = {
+                enabled = true;
+                type = "wireguard";
+              };
+              gatewayAPI = {
+                enabled = true;
+                gatewayClass.create = true;
+              };
+              hubble = {
+                enabled = true;
+                relay.enabled = true;
+                ui.enabled = true;
+              };
+              ipam.mode = "kubernetes";
+              k8s = {
+                requireIPv4PodCIDR = cfg.clusterCidrIPv4 != null;
+                requireIPv6PodCIDR = cfg.clusterCidrIPv6 != null;
+              };
+              k8sServiceHost = "localhost";
+              k8sServicePort = "6443";
+              kubeProxyReplacement = true;
+              operator.prometheus.enabled = true;
+              prometheus.enabled = true;
+            };
           };
 
           rke2-coredns-config.content = {

--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -14,9 +14,7 @@ let
   etcdPeerPort = 2380;
   etcdMetricsPort = 2381;
   ciliumHealthPort = 9890;
-  ciliumVXLANPort = 8472;
-  ciliumHubblePort = 4244;
-  ciliumHubblePeerPort = 4245;
+  wireguardPort = 51820;
   gatewayAPIPort = 8443;
 
   nodePortRange = {
@@ -98,6 +96,7 @@ with lib;
         enable = true;
         role = "server";
         cisHardening = true;
+        disableKubeProxy = true;
         manifests = {
           rke2-cilium-config.content = {
             apiVersion = "helm.cattle.io/v1";
@@ -107,34 +106,25 @@ with lib;
               namespace = "kube-system";
             };
             spec.valuesContent = builtins.toJSON {
-              cni = {
-                chainingMode = "multus";
-                exclusive = false;
-              };
-              tunnelProtocol = "vxlan";
-              gatewayAPI = {
-                enabled = true;
-              };
-              hubble = {
-                enabled = true;
-                relay.enabled = true;
-                ui.enabled = true;
-              };
-              prometheus = {
-                enabled = true;
-              };
-              operator = {
-                prometheus.enabled = true;
-              };
-              bpf = {
-                masquerade = true;
-              };
+              kubeProxyReplacement = true;
+              k8sServiceHost = "localhost";
+              k8sServicePort = "6443";
+              encryption.enabled = true;
+              encryption.type = "wireguard";
+              cni.chainingMode = "multus";
+              cni.exclusive = false;
+              autoDirectNodeRoutes = true;
+              gatewayAPI.enabled = true;
+              hubble.enabled = true;
+              hubble.relay.enabled = true;
+              hubble.ui.enabled = true;
+              prometheus.enabled = true;
+              operator.prometheus.enabled = true;
+              bpf.masquerade = true;
               ipv4NativeRoutingCIDR = "10.244.0.0/16";
-              ipam = {
-                operator.clusterPoolIPv4PodCIDRList = [
-                  "10.244.0.0/16"
-                ];
-              };
+              ipam.operator.clusterPoolIPv4PodCIDRList = [
+                "10.244.0.0/16"
+              ];
             };
           };
 
@@ -213,7 +203,7 @@ with lib;
           gatewayAPIPort
         ];
         allowedUDPPorts = [
-          ciliumVXLANPort
+          wireguardPort
         ];
         allowedTCPPortRanges = [ nodePortRange ];
       };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #857

Replace the Canal CNI plugin with Cilium across all RKE2 nodes.
This enables Gateway API support, eBPF-based networking, and
Hubble observability.

Changes:
- Update default CNI list from [multus canal] to [multus cilium]
- Replace rke2-canal HelmChartConfig with rke2-cilium HelmChartConfig
  (chainingMode=multus, vxlan tunnel, gatewayAPI enabled, hubble enabled)
- Add rke2-cilium-gateway-class manifest for Cilium Gateway API controller
- Update firewall ports: remove WireGuard/canal ports, add Cilium health
  (9890/tcp), VXLAN (8472/udp), and Gateway API (8443/tcp) ports

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>