### PR TITLE
Fix Cilium missing Gateway API

### DIFF
--- a/modules/nixos/rke2/default.nix
+++ b/modules/nixos/rke2/default.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 
@@ -117,7 +118,10 @@ in
                 enabled = true;
                 type = "wireguard";
               };
-              gatewayAPI.enabled = true;
+              gatewayAPI = {
+                enabled = true;
+                gatewayClass.create = true;
+              };
               hubble = {
                 enabled = true;
                 relay.enabled = true;
@@ -160,6 +164,11 @@ in
             spec.valuesContent = builtins.toJSON {
               manifests.dhcpDaemonSet = true;
             };
+          };
+
+          gateway-api.source = pkgs.fetchurl {
+            url = "https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml";
+            hash = "sha256-UQM4z2cJ+EQQ78zlJpJo9MfFBn79xdBMdaov0vg4DJY=";
           };
         };
         role = "server";


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #866
* #865

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I38a5166d581c8a1aeabc1383e96223816a6a6964