### PR TITLE
feat: re-add kaltashar host configuration

### DIFF
--- a/hosts/kaltashar/darwin-configuration.nix
+++ b/hosts/kaltashar/darwin-configuration.nix
@@ -1,0 +1,42 @@
+{ config, ... }:
+
+{
+  imports = [
+    ../../modules/darwin/base.nix
+    ../../modules/darwin/workstation.nix
+  ];
+
+  home-manager.users.shikanimedeva.imports = [
+    ./users/shikanimedeva/home-configuration.nix
+  ];
+
+  networking.hostName = "kaltashar";
+
+  nix.extraOptions = ''
+    !include ${config.sops.templates.nix-config.path}
+  '';
+
+  sops = {
+    age = {
+      generateKey = true;
+      keyFile = "/var/lib/sops-nix/key.txt";
+      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    };
+    defaultSopsFile = ../../secrets/kaltashar.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets.nix-access-token = { };
+    templates.nix-config.content = ''
+      extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";
+    '';
+  };
+
+  system.primaryUser = "shikanimedeva";
+
+  users.users.shikanimedeva = {
+    home = "/Users/shikanimedeva";
+    name = "shikanimedeva";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+}

--- a/hosts/kaltashar/users/shikanimedeva/home-configuration.nix
+++ b/hosts/kaltashar/users/shikanimedeva/home-configuration.nix
@@ -1,0 +1,172 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  toDhall = generators.toDhall { };
+
+  gitIni = pkgs.formats.gitIni { };
+  ini = pkgs.formats.ini { };
+  toml = pkgs.formats.toml { };
+  yaml = pkgs.formats.yaml { };
+
+  name = "William Phetsinorath";
+  signingKey = "09CA52A835C14157";
+in
+{
+  imports = [
+    ../../../../modules/home/base.nix
+    ../../../../modules/home/cloud.nix
+    ../../../../modules/home/fontconfig.nix
+    ../../../../modules/home/ghostty.nix
+    ../../../../modules/home/helix.nix
+    ../../../../modules/home/starship.nix
+    ../../../../modules/home/vcs.nix
+    ../../../../modules/home/workstation.nix
+    ../../../../modules/home/zed-editor.nix
+  ];
+
+  home = {
+    file."Library/Preferences/sapling/sapling.conf".source =
+      config.lib.file.mkOutOfStoreSymlink config.sops.templates.sapling-config.path;
+    sessionVariables = {
+      GHSTACKRC_PATH = config.lib.file.mkOutOfStoreSymlink config.sops.templates.ghstack-config.path;
+    };
+  };
+
+  nix.extraOptions = ''
+    !include ${config.sops.templates.nix-config.path}
+  '';
+
+  programs = {
+    bash.enable = true;
+
+    git = {
+      includes = [
+        { path = config.lib.file.mkOutOfStoreSymlink config.sops.templates.git-config.path; }
+      ];
+      signing = {
+        format = "openpgp";
+        signByDefault = true;
+      };
+    };
+
+    zsh.enable = true;
+  };
+
+  sops = {
+    age.keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
+    defaultSopsFile = ../../../../secrets/kaltashar.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      cachix-token = { };
+      github-token = { };
+      gitlab-token = { };
+      gouv-email = { };
+      gouv-signing-key = { };
+      shikanime-studio-email = { };
+      nix-access-token = { };
+    };
+    templates = {
+      cachix-config.content = toDhall {
+        authToken = config.sops.placeholder.cachix-token;
+        hostname = "https://cachix.org";
+      };
+      ghstack-config = {
+        file = ini.generate "ghstackrc" {
+          ghstack = {
+            github_oauth = config.sops.placeholder.github-token;
+            github_url = "github.com";
+            github_username = "shikanime";
+          };
+        };
+        mode = "0640";
+      };
+      glab-cli-config.file = yaml.generate "config.yaml" {
+        git_protocol = "https";
+        hosts.gitlab.com = {
+          api_host = "gitlab.com";
+          api_protocol = "https";
+          token = config.sops.placeholder.gitlab-token;
+        };
+      };
+      git-config.file = gitIni.generate "config" {
+        user = {
+          inherit name;
+          inherit signingKey;
+          email = config.sops.placeholder.shikanime-studio-email;
+        };
+      };
+      jujutsu-config.file = toml.generate "config.toml" {
+        "--scope" = [
+          {
+            "--when.repositories" = [ "~/Source/Repos/github.com/cloud-pi-native" ];
+            signing.key = config.sops.placeholder.gouv-signing-key;
+            user = {
+              email = config.sops.placeholder.gouv-email;
+              inherit name;
+            };
+          }
+        ];
+        signing = {
+          backend = "gpg";
+          behavior = "own";
+          key = signingKey;
+        };
+        user = {
+          inherit name;
+          email = config.sops.placeholder.shikanime-studio-email;
+        };
+      };
+      nix-config.content = ''
+        extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";
+      '';
+      sapling-config.file = ini.generate "sapling.conf" {
+        alias = {
+          ci = "ci --message-field Signed-off-by=\"${name} <${config.sops.placeholder.shikanime-studio-email}>\"";
+          commit = "commit --message-field Signed-off-by=\"${name} <${config.sops.placeholder.shikanime-studio-email}>\"";
+          push = "push --force";
+        };
+        committemplate = {
+          commit-message-fields = "Summary,Fixes,Signed-off-by";
+          emptymsg = "{if(title, title, defaulttitle)}\\n\\nSummary: {summary}\\n\\nFixes: {fixes}\\n\\nSigned-off-by: {author}";
+        };
+        diff-tools = {
+          "zed.args" = "--wait --diff $local $other";
+          "zed.gui" = true;
+          "zed.priority" = 20;
+        };
+        gpg.key = signingKey;
+        hooks = {
+          "precommit.git-hooks" = "test -f .git/hooks/pre-commit && .git/hooks/pre-commit || true";
+          "preoutgoing.git-hooks" = "test -f .git/hooks/pre-push && .git/hooks/pre-push || true";
+          "update.git-hooks" = "test -f .git/hooks/post-rewrite && .git/hooks/post-rewrite || true";
+        };
+        merge-tools = {
+          "mergiraf.args" = "merge --git $base $local $other -o $output";
+          "mergiraf.priority" = 30;
+        };
+        ui = {
+          editor = "hx";
+          username = "${name} <${config.sops.placeholder.shikanime-studio-email}>";
+        };
+      };
+    };
+  };
+
+  xdg.configFile = {
+    "cachix/cachix.dhall".source =
+      config.lib.file.mkOutOfStoreSymlink config.sops.templates.cachix-config.path;
+    "glab-cli/config.yml" = {
+      force = true;
+      source = config.lib.file.mkOutOfStoreSymlink config.sops.templates.glab-cli-config.path;
+    };
+    "jj/conf.d/default.toml".source =
+      config.lib.file.mkOutOfStoreSymlink config.sops.templates.jujutsu-config.path;
+  };
+}

--- a/modules/flake/darwin.nix
+++ b/modules/flake/darwin.nix
@@ -3,6 +3,25 @@
 
 {
   flake = {
+    darwinConfigurations.kaltashar = inputs.nix-darwin.lib.darwinSystem {
+      pkgs = import inputs.nixpkgs {
+        system = "x86_64-darwin";
+        config.allowUnfree = true;
+      };
+      modules = [
+        ../../hosts/kaltashar/darwin-configuration.nix
+        inputs.home-manager.darwinModules.home-manager
+        inputs.sops-nix.darwinModules.sops
+        {
+          home-manager.sharedModules = [
+            inputs.catppuccin.homeModules.default
+            inputs.colemak.homeModules.default
+            inputs.devlib.homeModules.default
+            inputs.sops-nix.homeModules.default
+          ];
+        }
+      ];
+    };
     darwinConfigurations.telsha = inputs.nix-darwin.lib.darwinSystem {
       pkgs = import inputs.nixpkgs {
         system = "aarch64-darwin";
@@ -22,6 +41,7 @@
         }
       ];
     };
+    packages.x86_64-darwin.kaltashar = self.darwinConfigurations.kaltashar.system;
     packages.aarch64-darwin.telsha = self.darwinConfigurations.telsha.system;
   };
 }

--- a/modules/flake/devenv.nix
+++ b/modules/flake/devenv.nix
@@ -84,6 +84,7 @@
           settings.creation_rules =
             let
               age = [
+                "age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5" # kaltashar
                 "age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g" # telsha
                 "age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay" # nixtar
               ];
@@ -135,6 +136,16 @@
                   {
                     age = age ++ [
                       "age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d"
+                    ];
+                  }
+                ];
+              }
+              {
+                path_regex = "secrets/kaltashar.enc.yaml";
+                key_groups = [
+                  {
+                    age = age ++ [
+                      "age16pkwna5hq4hh03xfj6j5uew3wq6wfr5xgqgdmg6t3a27uz2dhuqsslh56c" # host
                     ];
                   }
                 ];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #880
* __->__ #879

Reintroduce the kaltashar Darwin host that was retired in commit 2c167d7.
Adapted to current codebase conventions:
- Uses sops.templates pattern (matching telsha)
- x86_64-darwin system (matching this machine's architecture)
- Registered in flake darwinConfigurations and devenv sops creation rules
- Age keys restored from pre-retirement history

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>