### PR TITLE
Re-add minish, fushi, and nishir Raspberry Pi nodes

### DIFF
--- a/hosts/fushi/configuration.nix
+++ b/hosts/fushi/configuration.nix
@@ -1,0 +1,175 @@
+{ config, modulesPath, ... }:
+
+{
+  imports = [
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+    "${modulesPath}/profiles/headless.nix"
+    ../../modules/nixos/base.nix
+    ../../modules/nixos/rke2
+  ];
+
+  boot = {
+    # Enable cgroup for Kubernetes
+    kernelParams = [
+      "cgroup_enable=cpuset"
+      "cgroup_enable=memory"
+      "cgroup_memory=1"
+    ];
+
+    kernel.sysctl = {
+      # Allow many inotify instances for controllers and Syncthing
+      "fs.inotify.max_user_instances" = 8192;
+      # Allow many watched paths for large libraries (Syncthing/copyparty)
+      "fs.inotify.max_user_watches" = 524288;
+      # Raise system-wide open files to prevent global exhaustion
+      "fs.file-max" = 2097152;
+      # Increase conntrack capacity for Kubernetes NAT
+      "net.netfilter.nf_conntrack_max" = 262144;
+      # Fair queuing qdisc; synergizes with BBR
+      "net.core.default_qdisc" = "fq";
+      # Increase ingress backlog for bursty overlay traffic (Calico/Tailscale)
+      "net.core.netdev_max_backlog" = 16384;
+      # Raise default socket receive buffer
+      "net.core.rmem_default" = 7340032;
+      # Allow larger autotuned receive buffers
+      "net.core.rmem_max" = 16777216;
+      # Increase accept backlog for busy services (Jellyfin/copyparty)
+      "net.core.somaxconn" = 65535;
+      # Raise default socket send buffer
+      "net.core.wmem_default" = 7340032;
+      # Allow larger autotuned send buffers
+      "net.core.wmem_max" = 16777216;
+      # Relax rp_filter for asymmetric routing via Tailscale subnet router
+      "net.ipv4.conf.all.rp_filter" = 0;
+      "net.ipv4.conf.default.rp_filter" = 0;
+      "net.ipv4.conf.tailscale0.rp_filter" = 0;
+      # Enable forwarding for Kubernetes and Tailscale routes
+      "net.ipv4.ip_forward" = 1;
+      # Widen ephemeral port range to avoid exhaustion
+      "net.ipv4.ip_local_port_range" = "1024 65535";
+      # BBR congestion control for better throughput/latency
+      "net.ipv4.tcp_congestion_control" = "bbr";
+      # Free sockets sooner under load
+      "net.ipv4.tcp_fin_timeout" = 30;
+      # Maintain long-lived connections without frequent probes
+      "net.ipv4.tcp_keepalive_time" = 600;
+      # Enable PMTU probing for overlays/Tailnet
+      "net.ipv4.tcp_mtu_probing" = 1;
+      # Expand TCP autotuning bounds (recv)
+      "net.ipv4.tcp_rmem" = "4096 87380 16777216";
+      # Expand TCP autotuning bounds (send)
+      "net.ipv4.tcp_wmem" = "4096 65536 16777216";
+      # SATA SSD: background writeback tuned for balanced IO
+      "vm.dirty_background_ratio" = 5;
+      # SATA SSD: expire dirty data moderately for merges (15s)
+      "vm.dirty_expire_centisecs" = 1500;
+      # SATA SSD: limit dirty pages to reduce IO spikes
+      "vm.dirty_ratio" = 15;
+      # SATA SSD: writeback cadence (5s)
+      "vm.dirty_writeback_centisecs" = 500;
+      # Support many mmap/large indices/filesystems
+      "vm.max_map_count" = 262144;
+      "vm.page-cluster" = 0;
+      # Prefer page cache, avoid swap thrash
+      "vm.swappiness" = 10;
+      # Favor inode/dentry caching for large media libraries
+      "vm.vfs_cache_pressure" = 50;
+      "vm.watermark_boost_factor" = 0;
+      "vm.watermark_scale_factor" = 125;
+    };
+  };
+
+  fileSystems."/mnt/reimu" = {
+    device = "/dev/disk/by-label/reimu";
+    options = [
+      "defaults"
+      "nofail"
+      "x-systemd.automount"
+    ];
+  };
+
+  # Enable accelerator
+  hardware.raspberry-pi."4" = {
+    fkms-3d.enable = true;
+    apply-overlays-dtmerge.enable = true;
+  };
+
+  home-manager.users.nishir.imports = [
+    ./users/nishir/home-configuration.nix
+  ];
+
+  nix.extraOptions = ''
+    !include ${config.sops.templates.nix-config.path}
+  '';
+
+  networking.hostName = "fushi";
+
+  # https://github.com/NixOS/nixpkgs/issues/154163#issuecomment-1008362877
+  nixpkgs.overlays = [
+    (_: super: {
+      makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
+    })
+  ];
+
+  services = {
+    avahi = {
+      enable = true;
+      nssmdns4 = true;
+      nssmdns6 = true;
+      publish = {
+        enable = true;
+        addresses = true;
+        workstation = true;
+      };
+    };
+
+    openssh = {
+      enable = true;
+      openFirewall = true;
+    };
+
+    tailscale = {
+      enable = true;
+      openFirewall = true;
+      useRoutingFeatures = "server";
+      authKeyFile = config.sops.secrets.tailscale-authkey.path;
+      extraUpFlags = [ "--ssh" ];
+    };
+  };
+
+  shikanime.rke2 = {
+    enable = true;
+    extraConfig = {
+      nodeIP = "192.168.1.30";
+    };
+  };
+
+  sops = {
+    age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    defaultSopsFile = ../../secrets/fushi.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      nix-access-token = { };
+      tailscale-authkey = { };
+    };
+    templates.nix-config.content = ''
+      extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";
+    '';
+  };
+
+  systemd.tmpfiles.rules = [
+    "L+ /var/log/containers - - - - /mnt/reimu/log/containers"
+    "L+ /var/log/pods - - - - /mnt/reimu/log/pods"
+    "L+ /var/swap - - - - /mnt/reimu/swap"
+  ];
+
+  users.users.nishir = {
+    extraGroups = [ "wheel" ];
+    initialHashedPassword = "$y$j9T$HB1msXB0DEq00J48zRpB20$/3rhVrTzGrv1j/cPvZ0clOM2gEe1TeylUG39wgD0C42";
+    isNormalUser = true;
+    home = "/home/nishir";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+}

--- a/hosts/fushi/users/nishir/home-configuration.nix
+++ b/hosts/fushi/users/nishir/home-configuration.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ../../../../modules/home/base.nix
+  ];
+
+  programs.bash.enable = true;
+}

--- a/hosts/minish/configuration.nix
+++ b/hosts/minish/configuration.nix
@@ -1,0 +1,179 @@
+{ config, modulesPath, ... }:
+
+{
+  imports = [
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+    "${modulesPath}/profiles/headless.nix"
+    ../../modules/nixos/base.nix
+    ../../modules/nixos/rke2
+  ];
+
+  boot = {
+    # Enable cgroup for Kubernetes
+    kernelParams = [
+      "cgroup_enable=cpuset"
+      "cgroup_enable=memory"
+      "cgroup_memory=1"
+    ];
+
+    kernel.sysctl = {
+      # Allow many inotify instances for controllers and Syncthing
+      "fs.inotify.max_user_instances" = 8192;
+      # Allow many watched paths for large libraries (Syncthing/copyparty)
+      "fs.inotify.max_user_watches" = 524288;
+      # Raise system-wide open files to prevent global exhaustion
+      "fs.file-max" = 2097152;
+      # Increase conntrack capacity for Kubernetes NAT
+      "net.netfilter.nf_conntrack_max" = 262144;
+      # Fair queuing qdisc; synergizes with BBR
+      "net.core.default_qdisc" = "fq";
+      # Increase ingress backlog for bursty overlay traffic (Calico/Tailscale)
+      "net.core.netdev_max_backlog" = 16384;
+      # Raise default socket receive buffer
+      "net.core.rmem_default" = 7340032;
+      # Allow larger autotuned receive buffers
+      "net.core.rmem_max" = 16777216;
+      # Increase accept backlog for busy services (Jellyfin/copyparty)
+      "net.core.somaxconn" = 65535;
+      # Raise default socket send buffer
+      "net.core.wmem_default" = 7340032;
+      # Allow larger autotuned send buffers
+      "net.core.wmem_max" = 16777216;
+      # Relax rp_filter for asymmetric routing via Tailscale subnet router
+      "net.ipv4.conf.all.rp_filter" = 0;
+      "net.ipv4.conf.default.rp_filter" = 0;
+      "net.ipv4.conf.tailscale0.rp_filter" = 0;
+      # Enable forwarding for Kubernetes and Tailscale routes
+      "net.ipv4.ip_forward" = 1;
+      # Widen ephemeral port range to avoid exhaustion
+      "net.ipv4.ip_local_port_range" = "1024 65535";
+      # BBR congestion control for better throughput/latency
+      "net.ipv4.tcp_congestion_control" = "bbr";
+      # Free sockets sooner under load
+      "net.ipv4.tcp_fin_timeout" = 30;
+      # Maintain long-lived connections without frequent probes
+      "net.ipv4.tcp_keepalive_time" = 600;
+      # Enable PMTU probing for overlays/Tailnet
+      "net.ipv4.tcp_mtu_probing" = 1;
+      # Expand TCP autotuning bounds (recv)
+      "net.ipv4.tcp_rmem" = "4096 87380 16777216";
+      # Expand TCP autotuning bounds (send)
+      "net.ipv4.tcp_wmem" = "4096 65536 16777216";
+      # SATA SSD: background writeback tuned for balanced IO
+      "vm.dirty_background_ratio" = 5;
+      # SATA SSD: expire dirty data moderately for merges (15s)
+      "vm.dirty_expire_centisecs" = 1500;
+      # SATA SSD: limit dirty pages to reduce IO spikes
+      "vm.dirty_ratio" = 15;
+      # SATA SSD: writeback cadence (5s)
+      "vm.dirty_writeback_centisecs" = 500;
+      # Support many mmap/large indices/filesystems
+      "vm.max_map_count" = 262144;
+      "vm.page-cluster" = 0;
+      # Prefer page cache, avoid swap thrash
+      "vm.swappiness" = 10;
+      # Favor inode/dentry caching for large media libraries
+      "vm.vfs_cache_pressure" = 50;
+      "vm.watermark_boost_factor" = 0;
+      "vm.watermark_scale_factor" = 125;
+    };
+  };
+
+  fileSystems."/mnt/marisa" = {
+    device = "/dev/disk/by-label/marisa";
+    options = [
+      "defaults"
+      "nofail"
+      "x-systemd.automount"
+    ];
+  };
+
+  # Enable accelerator
+  hardware.raspberry-pi."4" = {
+    fkms-3d.enable = true;
+    apply-overlays-dtmerge.enable = true;
+  };
+
+  home-manager.users.nishir.imports = [
+    ./users/nishir/home-configuration.nix
+  ];
+
+  nix.extraOptions = ''
+    !include ${config.sops.templates.nix-config.path}
+  '';
+
+  networking.hostName = "minish";
+
+  # https://github.com/NixOS/nixpkgs/issues/154163#issuecomment-1008362877
+  nixpkgs.overlays = [
+    (_: super: {
+      makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
+    })
+  ];
+
+  services = {
+    avahi = {
+      enable = true;
+      nssmdns4 = true;
+      nssmdns6 = true;
+      publish = {
+        enable = true;
+        addresses = true;
+        workstation = true;
+      };
+    };
+
+    openssh = {
+      enable = true;
+      openFirewall = true;
+    };
+
+    tailscale = {
+      enable = true;
+      openFirewall = true;
+      useRoutingFeatures = "server";
+      authKeyFile = config.sops.secrets.tailscale-authkey.path;
+      extraUpFlags = [ "--ssh" ];
+    };
+  };
+
+  shikanime.rke2 = {
+    enable = true;
+    extraConfig = {
+      nodeIP = "192.168.1.29";
+    };
+    longhorn.enable = true;
+  };
+
+  sops = {
+    age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    defaultSopsFile = ../../secrets/minish.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      nix-access-token = { };
+      tailscale-authkey = { };
+    };
+    templates.nix-config.content = ''
+      extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";
+    '';
+  };
+
+  systemd.tmpfiles.rules = [
+    "L+ /var/lib/rancher/rke2 - - - - /mnt/marisa/rke2"
+    "L+ /var/lib/longhorn - - - - /mnt/marisa/longhorn"
+    "L+ /var/log/calico - - - - /mnt/marisa/log/calico"
+    "L+ /var/log/containers - - - - /mnt/marisa/log/containers"
+    "L+ /var/log/pods - - - - /mnt/marisa/log/pods"
+    "L+ /var/swap - - - - /mnt/marisa/swap"
+  ];
+
+  users.users.nishir = {
+    extraGroups = [ "wheel" ];
+    initialHashedPassword = "$y$j9T$HB1msXB0DEq00J48zRpB20$/3rhVrTzGrv1j/cPvZ0clOM2gEe1TeylUG39wgD0C42";
+    isNormalUser = true;
+    home = "/home/nishir";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+}

--- a/hosts/minish/users/nishir/home-configuration.nix
+++ b/hosts/minish/users/nishir/home-configuration.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ../../../../modules/home/base.nix
+  ];
+
+  programs.bash.enable = true;
+}

--- a/hosts/nishir/configuration.nix
+++ b/hosts/nishir/configuration.nix
@@ -1,0 +1,197 @@
+{ config, modulesPath, ... }:
+
+{
+  imports = [
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+    "${modulesPath}/profiles/headless.nix"
+    ../../modules/nixos/base.nix
+    ../../modules/nixos/rke2
+  ];
+
+  boot = {
+    # Enable cgroup for Kubernetes
+    kernelParams = [
+      "cgroup_enable=cpuset"
+      "cgroup_enable=memory"
+      "cgroup_memory=1"
+    ];
+
+    kernel.sysctl = {
+      # Allow many inotify instances for controllers and Syncthing
+      "fs.inotify.max_user_instances" = 8192;
+      # Allow many watched paths for large libraries (Syncthing/copyparty)
+      "fs.inotify.max_user_watches" = 524288;
+      # Raise system-wide open files to prevent global exhaustion
+      "fs.file-max" = 2097152;
+      # Increase conntrack capacity for Kubernetes NAT
+      "net.netfilter.nf_conntrack_max" = 262144;
+      # Fair queuing qdisc; synergizes with BBR
+      "net.core.default_qdisc" = "fq";
+      # Increase ingress backlog for bursty overlay traffic (Calico/Tailscale)
+      "net.core.netdev_max_backlog" = 16384;
+      # Raise default socket receive buffer
+      "net.core.rmem_default" = 7340032;
+      # Allow larger autotuned receive buffers
+      "net.core.rmem_max" = 16777216;
+      # Increase accept backlog for busy services (Jellyfin/copyparty)
+      "net.core.somaxconn" = 65535;
+      # Raise default socket send buffer
+      "net.core.wmem_default" = 7340032;
+      # Allow larger autotuned send buffers
+      "net.core.wmem_max" = 16777216;
+      # Relax rp_filter for asymmetric routing via Tailscale subnet router
+      "net.ipv4.conf.all.rp_filter" = 0;
+      "net.ipv4.conf.default.rp_filter" = 0;
+      "net.ipv4.conf.tailscale0.rp_filter" = 0;
+      # Enable forwarding for Kubernetes and Tailscale routes
+      "net.ipv4.ip_forward" = 1;
+      # Widen ephemeral port range to avoid exhaustion
+      "net.ipv4.ip_local_port_range" = "1024 65535";
+      # BBR congestion control for better throughput/latency
+      "net.ipv4.tcp_congestion_control" = "bbr";
+      # Free sockets sooner under load
+      "net.ipv4.tcp_fin_timeout" = 30;
+      # Maintain long-lived connections without frequent probes
+      "net.ipv4.tcp_keepalive_time" = 600;
+      # Enable PMTU probing for overlays/Tailnet
+      "net.ipv4.tcp_mtu_probing" = 1;
+      # Expand TCP autotuning bounds (recv)
+      "net.ipv4.tcp_rmem" = "4096 87380 16777216";
+      # Expand TCP autotuning bounds (send)
+      "net.ipv4.tcp_wmem" = "4096 65536 16777216";
+      # NVMe: increase background writeback for higher throughput
+      "vm.dirty_background_ratio" = 10;
+      # NVMe: delay expiration to allow larger merges (20s)
+      "vm.dirty_expire_centisecs" = 2000;
+      # NVMe: allow more dirty pages to utilize fast storage
+      "vm.dirty_ratio" = 20;
+      # NVMe: schedule writeback frequency (5s)
+      "vm.dirty_writeback_centisecs" = 500;
+      # Support many mmap/large indices/filesystems
+      "vm.max_map_count" = 262144;
+      "vm.page-cluster" = 0;
+      # Swappiness 10 to minimize swap pressure on zram
+      "vm.swappiness" = 10;
+      # Favor inode/dentry caching for large media libraries
+      "vm.vfs_cache_pressure" = 50;
+      "vm.watermark_boost_factor" = 0;
+      "vm.watermark_scale_factor" = 125;
+    };
+  };
+
+  fileSystems = {
+    "/mnt/flandre" = {
+      device = "/dev/disk/by-label/flandre";
+      options = [
+        "defaults"
+        "nofail"
+        "x-systemd.automount"
+      ];
+    };
+    "/mnt/nishir" = {
+      device = "/dev/nvme0n1";
+      options = [
+        "defaults"
+        "nofail"
+        "x-systemd.automount"
+      ];
+    };
+    "/mnt/remilia" = {
+      device = "/dev/disk/by-label/remilia";
+      options = [
+        "defaults"
+        "nofail"
+        "x-systemd.automount"
+      ];
+    };
+  };
+
+  # Enable RPi 5 hardware
+  hardware.raspberry-pi."5" = {
+    fkms-3d.enable = true;
+    apply-overlays-dtmerge.enable = true;
+  };
+
+  home-manager.users.nishir.imports = [
+    ./users/nishir/home-configuration.nix
+  ];
+
+  networking.hostName = "nishir";
+
+  nix.extraOptions = ''
+    !include ${config.sops.templates.nix-config.path}
+  '';
+
+  # https://github.com/NixOS/nixpkgs/issues/154163#issuecomment-1008362877
+  nixpkgs.overlays = [
+    (_: super: {
+      makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
+    })
+  ];
+
+  services = {
+    avahi = {
+      enable = true;
+      nssmdns4 = true;
+      nssmdns6 = true;
+      publish = {
+        enable = true;
+        addresses = true;
+        workstation = true;
+      };
+    };
+
+    openssh = {
+      enable = true;
+      openFirewall = true;
+    };
+
+    tailscale = {
+      enable = true;
+      openFirewall = true;
+      useRoutingFeatures = "server";
+      authKeyFile = config.sops.secrets.tailscale-authkey.path;
+      extraUpFlags = [ "--ssh" ];
+    };
+  };
+
+  shikanime.rke2 = {
+    enable = true;
+    extraConfig = {
+      nodeIP = "192.168.1.27";
+    };
+    longhorn.enable = true;
+  };
+
+  sops = {
+    age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    defaultSopsFile = ../../secrets/nishir.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      nix-access-token = { };
+      tailscale-authkey = { };
+    };
+    templates.nix-config.content = ''
+      extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";
+    '';
+  };
+
+  systemd.tmpfiles.rules = [
+    "L+ /var/lib/rancher/rke2 - - - - /mnt/nishir/rke2"
+    "L+ /var/lib/longhorn - - - - /mnt/nishir/longhorn"
+    "L+ /var/log/calico - - - - /mnt/nishir/log/calico"
+    "L+ /var/log/containers - - - - /mnt/nishir/log/containers"
+    "L+ /var/log/pods - - - - /mnt/nishir/log/pods"
+    "L+ /var/swap - - - - /mnt/nishir/swap"
+  ];
+
+  users.users.nishir = {
+    extraGroups = [ "wheel" ];
+    initialHashedPassword = "$y$j9T$HB1msXB0DEq00J48zRpB20$/3rhVrTzGrv1j/cPvZ0clOM2gEe1TeylUG39wgD0C42";
+    isNormalUser = true;
+    home = "/home/nishir";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+}

--- a/hosts/nishir/users/nishir/home-configuration.nix
+++ b/hosts/nishir/users/nishir/home-configuration.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ../../../../modules/home/base.nix
+  ];
+
+  programs.bash.enable = true;
+}

--- a/modules/flake/devenv.nix
+++ b/modules/flake/devenv.nix
@@ -75,6 +75,7 @@
           with pkgs;
           [
             age
+            docker
             skaffold
           ]
           ++ lib.optional stdenv.hostPlatform.isLinux nixos-facter;
@@ -101,6 +102,20 @@
                 ];
               }
               {
+                path_regex = "secrets/fushi.enc.yaml";
+                key_groups = [ { age = age; } ];
+              }
+              {
+                path_regex = "secrets/kaltashar.enc.yaml";
+                key_groups = [
+                  {
+                    age = age ++ [
+                      "age16pkwna5hq4hh03xfj6j5uew3wq6wfr5xgqgdmg6t3a27uz2dhuqsslh56c" # host
+                    ];
+                  }
+                ];
+              }
+              {
                 path_regex = "secrets/manash.enc.yaml";
                 key_groups = [
                   {
@@ -111,6 +126,10 @@
                 ];
               }
               {
+                path_regex = "secrets/minish.enc.yaml";
+                key_groups = [ { age = age; } ];
+              }
+              {
                 path_regex = "secrets/nalsha.enc.yaml";
                 key_groups = [
                   {
@@ -119,6 +138,10 @@
                     ];
                   }
                 ];
+              }
+              {
+                path_regex = "secrets/nishir.enc.yaml";
+                key_groups = [ { age = age; } ];
               }
               {
                 path_regex = "secrets/nixtar.enc.yaml";
@@ -136,16 +159,6 @@
                   {
                     age = age ++ [
                       "age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d"
-                    ];
-                  }
-                ];
-              }
-              {
-                path_regex = "secrets/kaltashar.enc.yaml";
-                key_groups = [
-                  {
-                    age = age ++ [
-                      "age16pkwna5hq4hh03xfj6j5uew3wq6wfr5xgqgdmg6t3a27uz2dhuqsslh56c" # host
                     ];
                   }
                 ];

--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -58,6 +58,57 @@
           }
         ];
       };
+      fushi = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/fushi/configuration.nix
+          inputs.home-manager.nixosModules.home-manager
+          inputs.sops-nix.nixosModules.sops
+          {
+            home-manager.sharedModules = [
+              inputs.devlib.homeModules.default
+              inputs.sops-nix.homeModules.default
+            ];
+          }
+        ];
+      };
+      minish = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/minish/configuration.nix
+          inputs.home-manager.nixosModules.home-manager
+          inputs.sops-nix.nixosModules.sops
+          {
+            home-manager.sharedModules = [
+              inputs.devlib.homeModules.default
+              inputs.sops-nix.homeModules.default
+            ];
+          }
+        ];
+      };
+      nishir = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nishir/configuration.nix
+          inputs.home-manager.nixosModules.home-manager
+          inputs.sops-nix.nixosModules.sops
+          {
+            home-manager.sharedModules = [
+              inputs.devlib.homeModules.default
+              inputs.sops-nix.homeModules.default
+            ];
+          }
+        ];
+      };
       nixtar = inputs.nixpkgs.lib.nixosSystem {
         pkgs = import inputs.nixpkgs {
           system = "x86_64-linux";
@@ -130,6 +181,9 @@
             };
           in
           catbox.config.system.build.buildLayeredImage;
+        fushi = self.nixosConfigurations.fushi.config.system.build.toplevel;
+        minish = self.nixosConfigurations.minish.config.system.build.toplevel;
+        nishir = self.nixosConfigurations.nishir.config.system.build.toplevel;
       };
     };
   };

--- a/secrets/fushi.enc.yaml
+++ b/secrets/fushi.enc.yaml
@@ -1,0 +1,36 @@
+---
+tailscale-authkey: ENC[AES256_GCM,data:S4jg9tpptFHiVPDy4jmnnr1xjpYmNcDwtuSO06wzvHXftvuH3y53NNMQSau3IHsGdgr9FVZHRgPJgznC/w==,iv:f0WlkO2U2rFlIUYMbXnOQauYB8/P1SsaajkwJLcrHrQ=,tag:PsH17/PbImiNLgObOaQWuQ==,type:str]
+nix-config: ENC[AES256_GCM,data:VtV1RfMz1xgmxI8xzwEF7XnCAgPqP1TDaR92dK2YqQHPu23ChzN9xqFXtoxpPojv7HYh87JgQUNjcEBPwYiFWuSmG/L52nKKcrw=,iv:bhPfnGokK56nz8hGNqQvNk9KzQs7bcNV+AoOHf0Jo7A=,tag:gIxSSxTD8qOS0dr01fAEfg==,type:str]
+sops:
+  version: 3.11.0
+  lastmodified: "2025-11-14T23:09:46Z"
+  mac: ENC[AES256_GCM,data:DyIleVkE88Z2e7fITLgYAmO7A6waRsy99N37uNxl3kXKVsQxnM/g0sXPcseMOgbT8TOE0z8/7arpv9GZdMb0Zmh+v3BDfwvZz4M65oYLZRirS/2OIcSXcLmoLYP+AiQXlrhLJXEOYz2yASDkS2EgTU69nit2l+2rL0ZkpJQfx6c=,iv:L+EJaHhQEH7USETr0I2Brg0OFRMawYN5W9ZeBxHMoYU=,tag:M7yJDxtKU5IFB5p+zp/TyA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBSTQwZVRwM2ZFSUFhZEdi
+        clFHNGlTa1dXTnAxN1NyQkdEeTc5M0VtblVFClY2YytwUEVSNExSYzcySFVsbXhy
+        RkJLZVFMeXZaNkVMY01uUUhXMjAvbjgKLS0tICt5ZjBqQUJjNjN6K1VadmJKRkx3
+        dVk5a1dEWWxiSUZOYnZycnJ1cko0dkkK3BYaZNbCkJ2bAFDljvCO9K5lZ08Kklu4
+        hBaZgG3Mv8q0vcifybYPq61zwjp7Jsug+hTXU5YC3tDDMKhg0dSnww==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4cEh0OWEyczZnRDRhNGdM
+        a3lUcDZNMjlaRThEYnFWSnZ5ZU5ZYWpZNjFZClBxTGx6MHpZQU9mUHh2RWJENDJ6
+        TmpzWFIyclZ2aS91eDdob2hZR0Z2RXMKLS0tIERQdEpyWGtlQkRpQ0lLcGI3bzhK
+        cXdzNE9nR1QybEpwSFY0RjVjdXV0VUkKmP5eKIwG9xOfgy12cGAeR4K8SEcp3HIt
+        MYYnBLV07LXy7jg+9etX1XQHpVGH1OC7gkjnIuQMbASWpJBCa4NQBQ==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age18zmkeyxun4gflllelsmdhwjh5xpfwrqshdxrednv7zljphepxc6strhysn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzK1UxclQva256ejNmNy9y
+        dEtKSFdQRzQ3MVQzR2ZiaS82THZ2c2hYUzNJCjlyYmItRTJ2bEdDaWtuOWt4V1BW
+        d21PRGZDTFJad0xOYmorVmNxWUU2djAKLS0tIEpJVjJ2b0FldjNJTFBXVXE3WHpD
+        KzREald0bUtEb1JKbWNkK2Z0bFR0VFUKFZkcCUFKx0qjBoQKzVUrJgAcvz7D1ho/
+        0VTwDsFvktAb81FYIOnGgiA/MB+JWLyQ/TP4CbZB3Jck/pY1qy87rA==
+        -----END AGE ENCRYPTED FILE-----

--- a/secrets/minish.enc.yaml
+++ b/secrets/minish.enc.yaml
@@ -1,0 +1,36 @@
+---
+tailscale-authkey: ENC[AES256_GCM,data:oUcwvMQ2X8bkViqLxANfhfRrNnQKTqVYrzAiTU6H2DLv23JgmGeQQb/ejbFyWO5D8smeoxizaWZGCIvU87A=,iv:t+ymRH/NiDzB9m2njhbeyYRRvOz7J7hpmCRaRd724WI=,tag:Hbfh+/ruk6J+4x2NnHl7/A==,type:str]
+nix-config: ENC[AES256_GCM,data:7GiXFxGHG+O/RWxzD+5qBsNHegW2I5SkSDJZg2mE61VytpGRTV1JL77nfz16svSLuEFe7t/OD7+tybVdQG9m72IqPAMeLgreyWM=,iv:Yd4sHqUijUFC8rXF1ocRF7E+TACtWJVksvr8OMxmlAc=,tag:d8FF+zR99VWtZMyAPOnlPA==,type:str]
+sops:
+  version: 3.11.0
+  lastmodified: "2025-11-14T23:10:43Z"
+  mac: ENC[AES256_GCM,data:sqMi3UsFzmtElwxHrKuK3YoPqG3xgTtxL9TpdMNB4g5EW8fxNW+QCZpP24bpahZ4OGdDgVbBDbSkP2hF6VC9L7vzA+2KyguOjMpw+sv4tZCVeooWQbos5QO5Zar6UmfIuSDjKqTrwXEXuXEUP6vhogi5HKxvREUJkDCXWLGYAh4=,iv:JBTQOMoU7wZnK2mVg+gHMDpDBfU90OLiUFOIxE4sFBM=,tag:7x1B5ieapC+aepP12GXqKg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMcVdwUnpRUVJxV0hINnVm
+        STBsRFI2MjhGbUN4V2htYTJvWkp3WHVHa0Q0CjVKY09IM3A1dzgvejk3NWJGbU9r
+        RmJnSGIwbWxIS21LU08vQlYrVkdTcDQKLS0tIHozU1BsenR4K3Iyd01EZFN3bWJ0
+        VFI2SE9XUWx0Nmt2WlZ4ZlVqR1R4L1kKTfUgkeAkJpBxa8YuKLeO3qapSdmD8PB9
+        n/ZCiKAg4hYMFZ+/d1g7uiE/wR6rWcHft1bskPWHBXkdnloIBjij2A==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhY29CamJ2QWkwN0Z3R3Vv
+        TDNRSm96TWZrM0k4ZzcvRUNOcmQzd2FKdUhjCmNkTlBsRTlaYk9WdE9LZVliaFBX
+        blJuamZGaitNc0NTdjB0djFkTXoxN0UKLS0tIENVSlNxc1E1dkdGVDN0aXFGK3Qv
+        alpXaXFvSjlNU29jRnUyb3lYVnRsSVkKfcKczxj1snxHZDnoQ//8cw57Yy8sRyL9
+        lpuJUPffkfARywJRVGweuaAnBWLZ7IB6YGnTWYjz78Y/fUvH1oXI3g==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age18zmkeyxun4gflllelsmdhwjh5xpfwrqshdxrednv7zljphepxc6strhysn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBaTmxub29DWTZPeW95TEZC
+        Z1ZMUXNjamMwWkdIeG5JU1hzbmRmdm5tK1U0CkowZitVL0taaEFMYVUvZGFzUkd6
+        ZzcxL2ZWNmhlRnVOejE3ekxnejhydFUKLS0tIDUwNHUxVXkwTFJnSEp2ekNpamo1
+        STExZkRISzFNL0xQN3d0T2lDck41M28KsEPXJqdPRdAY+UyvcTlKS+nUS2gAvEFm
+        CXCSebHXUfN0hCH0qSQhW3U1vcMcy13Q3F9K/ARax2S8pvHHMokOZw==
+        -----END AGE ENCRYPTED FILE-----

--- a/secrets/nishir.enc.yaml
+++ b/secrets/nishir.enc.yaml
@@ -1,0 +1,36 @@
+---
+tailscale-authkey: ENC[AES256_GCM,data:+N7p9hQJZPXkK2cyTbuVC6a+agNyANm66yjUBwhu/30dKXWEoQGNXlxCxuTkpViVntIwMF3izgIhBZmlrA==,iv:xc+tasw9BS/BRsTrA2TE8rSibKJFr7IpEIUne07f9ys=,tag:YmW2cN2IDGH6iZ+wL22+uQ==,type:str]
+nix-config: ENC[AES256_GCM,data:zozNSNKi75Q2qqj64UZTTpXBEwzv1TS7AE/J10ZY5XeDrU/5QD/Et51oRL++HGPC8y+xltNm+HDaM2L+37Q4UuXFPwk5TJIp14M=,iv:jJCKbQlBTWCPNlePrdQN0YX1hpoJ/o2RFSSCpO1rp1Q=,tag:HSQdklyPm12618TwyTA94Q==,type:str]
+sops:
+  version: 3.11.0
+  lastmodified: "2026-02-03T22:34:08Z"
+  mac: ENC[AES256_GCM,data:M7GzAXX/TdtZQE+Z6paBP/C3XLTJ8oehv0MTY5aQUvD/alSf9C/pxxCNYPtIM53P5SN1lUPDGr0rJQsbiGHf3gZ7jNGKeg4hrZC82bTh6YUs9P8tGsIQLLfSTEcES456Aesonkjlg13OnSR7VHruUAhsjKO3BxQI9Sl5uUg+msI=,iv:knGp4/ogBE6q6Iqiahfjq4tBH71GTCGY9dh7vvj+u6E=,tag:sFNbXmNMqin6bO0tdMROPA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBTGlGZXF0SXh0V1lIZG5E
+        MFQ4VUV6c0pKSmJuKzBha3gwL240SXRqTkNJCkRtY0tOVk9JV1BtOTF6R1lTZXo5
+        eXgyWVh6S0RCanVXZEJhOUNIek9NcnMKLS0tIDEyUVpPRXdXcERYZGVsTE84Unht
+        blloMTBPc05oUTBNUWk2QlNIc1RmbkkK1lMChoXl2kBjfpo0pYSRXNv+ZFVKesbG
+        enHAkc7B1T/sfgeAIkGLiOcAGqn/Y4FfyqviD/zXuALIovJNsmMF+w==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB2WjhVLzQ1VXc2MW5wbGdB
+        bCt2YU84NVo0dzR6aTkzamxxdzZuZG9qRHhrCk9uVGxFRExTYW5tT0pVMTNjUWs5
+        RTNCQW9xZ2JmNngwVUVxUEtHQkwva1kKLS0tIHJzcG1ucDNWUmJvdHVOR25sWlY0
+        RGhuY21VcXRPNTlZaWVMU3ZsYXo4R0kKziYTPmm6riBXSUdcv2dKqG6KPmI5PY3H
+        xvXyarRdGxZsB48+U1NQKnT3p76h8xuXhPWllS4Z2VN3Uq2d/vQFaA==
+        -----END AGE ENCRYPTED FILE-----
+    - recipient: age18zmkeyxun4gflllelsmdhwjh5xpfwrqshdxrednv7zljphepxc6strhysn
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkNFdIZnpEaEtvOFprNm9M
+        OWc4Mzh1YWZrQytCa0I2YkRxK1A3Y3liblg0CnJ3c1pEMFREZ2RtZDNqd1Y0U3N0
+        SzRUU1Y2VHdnQjJpdjhUenR3a0l5OEkKLS0tIFYwM0RCdkdiRlR0TnVtNFdMOHhX
+        azF1QWp0QzF1WURnN1pRQ3ZBTlgvUDQK/TUGxt+X08DSInCKQV+Rt68NiT+937B1
+        HzE2kVAVXHPy0/MMjvb4QC0VGxemwkgPCxnKCS2PtWeeJ56DoPjbhg==
+        -----END AGE ENCRYPTED FILE-----


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #880
* #879

Re-introduce three ARM64 NixOS hosts based on Raspberry Pi hardware:
- minish: RPi 4, aarch64-linux, RKE2 agent with Longhorn on /mnt/marisa
- fushi: RPi 4, aarch64-linux, RKE2 agent with /mnt/reimu storage
- nishir: RPi 5, aarch64-linux, RKE2 agent with Longhorn on NVMe + data disks

All three nodes use sd-image-aarch64 for SD card boot, headless profile,
Tailscale with SSH, Avahi mDNS, and the shikanime.rke2 module.

Secrets restored from git history (commit 10aadfe^).

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>