### PR TITLE
feat: convert x86 host data disks to disko

### DIFF
--- a/hosts/ashira/configuration.nix
+++ b/hosts/ashira/configuration.nix
@@ -109,15 +109,20 @@
     };
   };
 
-  fileSystems."/mnt/patchouli" = {
-    label = "patchouli";
-    fsType = "xfs";
-    options = [
-      "nofail"
-      "x-systemd.automount"
-      "x-systemd.device-timeout=10s"
-      "x-systemd.mount-timeout=30s"
-    ];
+  disko.devices.disk.patchouli = {
+    type = "disk";
+    device = "/dev/disk/by-label/patchouli";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/patchouli";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
   };
 
   hardware = {

--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -109,15 +109,20 @@
     };
   };
 
-  fileSystems."/mnt/flandre" = {
-    label = "flandre";
-    fsType = "xfs";
-    options = [
-      "nofail"
-      "x-systemd.automount"
-      "x-systemd.device-timeout=10s"
-      "x-systemd.mount-timeout=30s"
-    ];
+  disko.devices.disk.flandre = {
+    type = "disk";
+    device = "/dev/disk/by-label/flandre";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/flandre";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
   };
 
   hardware = {

--- a/hosts/nalsha/configuration.nix
+++ b/hosts/nalsha/configuration.nix
@@ -109,15 +109,20 @@
     };
   };
 
-  fileSystems."/mnt/remilia" = {
-    label = "remilia";
-    fsType = "xfs";
-    options = [
-      "nofail"
-      "x-systemd.automount"
-      "x-systemd.device-timeout=10s"
-      "x-systemd.mount-timeout=30s"
-    ];
+  disko.devices.disk.remilia = {
+    type = "disk";
+    device = "/dev/disk/by-label/remilia";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/remilia";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
   };
 
   hardware = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #891
* __->__ #890

Replace fileSystems with disko.devices for data disks on ashira
(patchouli), manash (flandre), and nalsha (remilia). All data disks
now use the same declarative disko pattern already used by the Pi
hosts and the existing root disk configurations.

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>