### PR TITLE
fix: remove rke2 config from fushi, minish, nemishi host configs

### DIFF
--- a/hosts/fushi/configuration.nix
+++ b/hosts/fushi/configuration.nix
@@ -5,7 +5,6 @@
     "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
     "${modulesPath}/profiles/headless.nix"
     ../../modules/nixos/base.nix
-    ../../modules/nixos/rke2
   ];
 
   boot = {
@@ -143,22 +142,12 @@
     };
   };
 
-  shikanime.rke2 = {
-    enable = true;
-    extraConfig = {
-      nodeIP = "192.168.1.30";
-      serverAddr = "https://192.168.1.28:9345";
-      tokenFile = config.sops.secrets.rke2-token.path;
-    };
-  };
-
   sops = {
     age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
     defaultSopsFile = ../../secrets/fushi.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets = {
       nix-config = { };
-      rke2-token = { };
       tailscale-authkey = { };
     };
   };

--- a/hosts/minish/configuration.nix
+++ b/hosts/minish/configuration.nix
@@ -5,7 +5,6 @@
     "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
     "${modulesPath}/profiles/headless.nix"
     ../../modules/nixos/base.nix
-    ../../modules/nixos/rke2
   ];
 
   boot = {
@@ -143,23 +142,12 @@
     };
   };
 
-  shikanime.rke2 = {
-    enable = true;
-    extraConfig = {
-      nodeIP = "192.168.1.29";
-      serverAddr = "https://192.168.1.28:9345";
-      tokenFile = config.sops.secrets.rke2-token.path;
-    };
-    longhorn.enable = true;
-  };
-
   sops = {
     age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
     defaultSopsFile = ../../secrets/minish.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets = {
       nix-config = { };
-      rke2-token = { };
       tailscale-authkey = { };
     };
   };

--- a/hosts/nemishi/configuration.nix
+++ b/hosts/nemishi/configuration.nix
@@ -5,7 +5,6 @@
     "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
     "${modulesPath}/profiles/headless.nix"
     ../../modules/nixos/base.nix
-    ../../modules/nixos/rke2
   ];
 
   boot = {
@@ -176,23 +175,12 @@
     };
   };
 
-  shikanime.rke2 = {
-    enable = true;
-    extraConfig = {
-      nodeIP = "192.168.1.27";
-      serverAddr = "https://192.168.1.28:9345";
-      tokenFile = config.sops.secrets.rke2-token.path;
-    };
-    longhorn.enable = true;
-  };
-
   sops = {
     age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
     defaultSopsFile = ../../secrets/nemishi.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets = {
       nix-config = { };
-      rke2-token = { };
       tailscale-authkey = { };
     };
   };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #899
* __->__ #898

The host configs referenced sops.secrets.rke2-token but the encrypted
secret files (fushi.enc.yaml, minish.enc.yaml, nemishi.enc.yaml) do not
contain the rke2-token key. This caused sops-install-secrets to fail
during NixOS system build.

Removed the shikanime.rke2 configuration block, the rke2 sops secret
reference, and the rke2 module import from all three host configs.
The rke2 cluster join can be re-added later once the token is
provisioned in the encrypted secrets.