### PR TITLE
fix: remove fushi, minish, nemishi from packages

### DIFF
--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -184,9 +184,6 @@
             };
           in
           catbox.config.system.build.buildLayeredImage;
-        fushi = self.nixosConfigurations.fushi.config.system.build.toplevel;
-        minish = self.nixosConfigurations.minish.config.system.build.toplevel;
-        nemishi = self.nixosConfigurations.nemishi.config.system.build.toplevel;
       };
     };
   };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #899
* #898

These hosts don't need toplevel builds in the CI package matrix.
Only catbox is needed since it builds a Docker image.