### PR TITLE
Add operator age key to SOPS creation rules for fushi, minish, nemishi

### DIFF
--- a/modules/flake/devenv.nix
+++ b/modules/flake/devenv.nix
@@ -101,7 +101,13 @@
               }
               {
                 path_regex = "secrets/fushi.enc.yaml";
-                key_groups = [ { age = age; } ];
+                key_groups = [
+                  {
+                    age = age ++ [
+                      "age18zmkeyxun4gflllelsmdhwjh5xpfwrqshdxrednv7zljphepxc6strhysn"
+                    ];
+                  }
+                ];
               }
               {
                 path_regex = "secrets/manash.enc.yaml";
@@ -115,7 +121,13 @@
               }
               {
                 path_regex = "secrets/minish.enc.yaml";
-                key_groups = [ { age = age; } ];
+                key_groups = [
+                  {
+                    age = age ++ [
+                      "age18zmkeyxun4gflllelsmdhwjh5xpfwrqshdxrednv7zljphepxc6strhysn"
+                    ];
+                  }
+                ];
               }
               {
                 path_regex = "secrets/nalsha.enc.yaml";
@@ -129,7 +141,13 @@
               }
               {
                 path_regex = "secrets/nemishi.enc.yaml";
-                key_groups = [ { age = age; } ];
+                key_groups = [
+                  {
+                    age = age ++ [
+                      "age18zmkeyxun4gflllelsmdhwjh5xpfwrqshdxrednv7zljphepxc6strhysn"
+                    ];
+                  }
+                ];
               }
               {
                 path_regex = "secrets/nixtar.enc.yaml";

--- a/secrets/fushi.enc.yaml
+++ b/secrets/fushi.enc.yaml
@@ -1,4 +1,3 @@
----
 tailscale-authkey: ENC[AES256_GCM,data:S4jg9tpptFHiVPDy4jmnnr1xjpYmNcDwtuSO06wzvHXftvuH3y53NNMQSau3IHsGdgr9FVZHRgPJgznC/w==,iv:f0WlkO2U2rFlIUYMbXnOQauYB8/P1SsaajkwJLcrHrQ=,tag:PsH17/PbImiNLgObOaQWuQ==,type:str]
 nix-config: ENC[AES256_GCM,data:VtV1RfMz1xgmxI8xzwEF7XnCAgPqP1TDaR92dK2YqQHPu23ChzN9xqFXtoxpPojv7HYh87JgQUNjcEBPwYiFWuSmG/L52nKKcrw=,iv:bhPfnGokK56nz8hGNqQvNk9KzQs7bcNV+AoOHf0Jo7A=,tag:gIxSSxTD8qOS0dr01fAEfg==,type:str]
 sops:

--- a/secrets/minish.enc.yaml
+++ b/secrets/minish.enc.yaml
@@ -1,4 +1,3 @@
----
 tailscale-authkey: ENC[AES256_GCM,data:oUcwvMQ2X8bkViqLxANfhfRrNnQKTqVYrzAiTU6H2DLv23JgmGeQQb/ejbFyWO5D8smeoxizaWZGCIvU87A=,iv:t+ymRH/NiDzB9m2njhbeyYRRvOz7J7hpmCRaRd724WI=,tag:Hbfh+/ruk6J+4x2NnHl7/A==,type:str]
 nix-config: ENC[AES256_GCM,data:7GiXFxGHG+O/RWxzD+5qBsNHegW2I5SkSDJZg2mE61VytpGRTV1JL77nfz16svSLuEFe7t/OD7+tybVdQG9m72IqPAMeLgreyWM=,iv:Yd4sHqUijUFC8rXF1ocRF7E+TACtWJVksvr8OMxmlAc=,tag:d8FF+zR99VWtZMyAPOnlPA==,type:str]
 sops:

--- a/secrets/nemishi.enc.yaml
+++ b/secrets/nemishi.enc.yaml
@@ -1,4 +1,3 @@
----
 tailscale-authkey: ENC[AES256_GCM,data:+N7p9hQJZPXkK2cyTbuVC6a+agNyANm66yjUBwhu/30dKXWEoQGNXlxCxuTkpViVntIwMF3izgIhBZmlrA==,iv:xc+tasw9BS/BRsTrA2TE8rSibKJFr7IpEIUne07f9ys=,tag:YmW2cN2IDGH6iZ+wL22+uQ==,type:str]
 nix-config: ENC[AES256_GCM,data:zozNSNKi75Q2qqj64UZTTpXBEwzv1TS7AE/J10ZY5XeDrU/5QD/Et51oRL++HGPC8y+xltNm+HDaM2L+37Q4UuXFPwk5TJIp14M=,iv:jJCKbQlBTWCPNlePrdQN0YX1hpoJ/o2RFSSCpO1rp1Q=,tag:HSQdklyPm12618TwyTA94Q==,type:str]
 sops:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #902

The SOPS creation rules for the new Raspberry Pi nodes were missing the
operator age key (age18zmkeyxun4gflllelsmdhwjh5xpfwrqshdxrednv7zljphepxc6strhysn).
The encrypted secret files already had this key as a recipient, but the
creation rules only listed telsha and nixtar.

This caused sops updatekeys in CI to attempt a decrypt-and-re-encrypt
(to remove the 'extra' operator key), which failed because CI has no
private age key available. The direnv step then failed with exit code 1,
and the subsequent fromJSON('') in nix.yaml line 54 threw a template
parsing error.

Adding the operator key to the creation rules makes them match the
existing encrypted files, so sops updatekeys becomes a no-op.