### PR TITLE
Add Forgejo Actions runner to all RKE2 nodes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    kix = {
+      url = "github:x-shikanime/kix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";

--- a/hosts/ashira/configuration.nix
+++ b/hosts/ashira/configuration.nix
@@ -3,76 +3,9 @@
 {
   imports = [
     ../../modules/nixos/base.nix
-    ../../modules/nixos/rke2
   ];
 
   boot = {
-    # Kubernetes and Longhorn rely on bridge netfilter and overlayfs; BBR
-    # improves WAN/Tailnet flows
-    kernelModules = [
-      "br_netfilter"
-      "overlay"
-      "tcp_bbr"
-    ];
-    kernel.sysctl = {
-      # File and Inotify limits - Keep these high for Longhorn, K8s, and Syncthing
-      "fs.file-max" = 2097152;
-      "fs.inotify.max_user_instances" = 8192;
-      "fs.inotify.max_user_watches" = 524288;
-
-      # Bridge networking for CNIs
-      "net.bridge.bridge-nf-call-ip6tables" = 1;
-      "net.bridge.bridge-nf-call-iptables" = 1;
-
-      # Networking queueing and buffer sizing for overlay networks
-      "net.core.default_qdisc" = "fq";
-      "net.core.netdev_max_backlog" = 16384;
-      "net.core.rmem_default" = 7340032;
-      "net.core.rmem_max" = 16777216;
-      "net.core.somaxconn" = 4096;
-      "net.core.wmem_default" = 7340032;
-      "net.core.wmem_max" = 16777216;
-
-      # Forwarding, TCP autotuning, and BBR setup
-      "net.ipv4.ip_forward" = 1;
-      "net.ipv4.conf.all.rp_filter" = 0;
-      "net.ipv4.conf.default.rp_filter" = 0;
-      "net.ipv4.conf.enp1s0.rp_filter" = 0;
-      "net.ipv4.ip_local_port_range" = "1024 65535";
-      "net.ipv4.tcp_congestion_control" = "bbr";
-      "net.ipv4.tcp_fin_timeout" = 15;
-      "net.ipv4.tcp_keepalive_time" = 600;
-      "net.ipv4.tcp_mtu_probing" = 1;
-      "net.ipv4.tcp_rmem" = "4096 87380 16777216";
-      "net.ipv4.tcp_wmem" = "4096 65536 16777216";
-
-      # GC thresholds for ARP/Neighbor tables
-      "net.ipv4.neigh.default.gc_thresh1" = 1024;
-      "net.ipv4.neigh.default.gc_thresh2" = 2048;
-      "net.ipv4.neigh.default.gc_thresh3" = 4096;
-      "net.ipv6.conf.all.forwarding" = 1;
-      "net.ipv6.conf.default.forwarding" = 1;
-
-      # IPv6 Router Advertisement tuning
-      "net.ipv6.conf.all.accept_ra" = 2;
-      "net.ipv6.conf.default.accept_ra" = 2;
-      "net.ipv6.conf.enp1s0.accept_ra" = 2;
-      "net.ipv6.conf.enp1s0.autoconf" = 1;
-      "net.ipv6.conf.enp1s0.accept_ra_defrtr" = 0;
-      "net.ipv6.conf.enp1s0.accept_ra_pinfo" = 1;
-      "net.ipv6.conf.enp1s0.accept_ra_mtu" = 1;
-      "net.ipv6.conf.enp1s0.accept_redirects" = 0;
-      "net.ipv6.conf.all.accept_redirects" = 0;
-      "net.ipv6.conf.default.accept_redirects" = 0;
-      "net.ipv6.route.mtu_expires" = 600;
-      "net.ipv6.route.min_adv_mss" = 1220;
-
-      # Increase conntrack limits
-      "net.netfilter.nf_conntrack_max" = 262144;
-
-      # Required to prevent mmap OOM crashes in memory-mapping heavy pods like Longhorn
-      "vm.max_map_count" = 262144;
-    };
     loader = {
       efi.canTouchEfiVariables = true;
       systemd-boot.enable = true;
@@ -126,8 +59,6 @@
   };
 
   hardware = {
-    # Intel N150 needs firmware plus userspace graphics/QSV libraries so the
-    # Jellyfin pod can use VAAPI/QSV via /dev/dri/renderD128.
     enableRedistributableFirmware = true;
 
     facter.reportPath = ./facter.json;
@@ -143,22 +74,11 @@
     };
   };
 
-  # Vital for NVMe health and sustained performance
-  services.fstrim.enable = true;
-
   home-manager.users.nishir.imports = [
     ./users/nishir/home-configuration.nix
   ];
 
   networking = {
-    getaddrinfo.precedence = {
-      "::1/128" = 50;
-      "::/0" = 40;
-      "2002::/16" = 30;
-      "::/96" = 20;
-      "::ffff:0:0/96" = 100;
-    };
-
     hostName = "ashira";
   };
 
@@ -173,7 +93,7 @@
     '';
   };
 
-  shikanime.rke2 = {
+  kix = {
     enable = true;
     extraConfig = {
       nodeIP = "192.168.1.60,2a02:8424:7899:f201:94eb:8d1:325a:812b";
@@ -203,35 +123,14 @@
         ];
       };
     };
+    tailscale.enable = true;
   };
 
-  services = {
-    avahi = {
-      enable = true;
-      nssmdns4 = true;
-      nssmdns6 = true;
-      publish = {
-        enable = true;
-        addresses = true;
-        workstation = true;
-      };
-    };
-
-    openssh = {
-      enable = true;
-      openFirewall = true;
-    };
-
-    tailscale = {
-      enable = true;
-      openFirewall = true;
-      useRoutingFeatures = "server";
-      authKeyFile = config.sops.secrets.tailscale-authkey.path;
-      extraUpFlags = [
-        "--advertise-routes=10.244.2.0/24,fd00::2:0/112"
-        "--ssh"
-      ];
-    };
+  services.tailscale = {
+    authKeyFile = config.sops.secrets.tailscale-authkey.path;
+    extraUpFlags = [
+      "--advertise-routes=10.244.2.0/24,fd00::2:0/112"
+    ];
   };
 
   nix.extraOptions = ''

--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -3,76 +3,9 @@
 {
   imports = [
     ../../modules/nixos/base.nix
-    ../../modules/nixos/rke2
   ];
 
   boot = {
-    # Kubernetes and Longhorn rely on bridge netfilter and overlayfs; BBR
-    # improves WAN/Tailnet flows
-    kernelModules = [
-      "br_netfilter"
-      "overlay"
-      "tcp_bbr"
-    ];
-    kernel.sysctl = {
-      # File and Inotify limits - Keep these high for Longhorn, K8s, and Syncthing
-      "fs.file-max" = 2097152;
-      "fs.inotify.max_user_instances" = 8192;
-      "fs.inotify.max_user_watches" = 524288;
-
-      # Bridge networking for CNIs
-      "net.bridge.bridge-nf-call-ip6tables" = 1;
-      "net.bridge.bridge-nf-call-iptables" = 1;
-
-      # Networking queueing and buffer sizing for overlay networks
-      "net.core.default_qdisc" = "fq";
-      "net.core.netdev_max_backlog" = 16384;
-      "net.core.rmem_default" = 7340032;
-      "net.core.rmem_max" = 16777216;
-      "net.core.somaxconn" = 4096;
-      "net.core.wmem_default" = 7340032;
-      "net.core.wmem_max" = 16777216;
-
-      # Forwarding, TCP autotuning, and BBR setup
-      "net.ipv4.ip_forward" = 1;
-      "net.ipv4.conf.all.rp_filter" = 0;
-      "net.ipv4.conf.default.rp_filter" = 0;
-      "net.ipv4.conf.enp1s0.rp_filter" = 0;
-      "net.ipv4.ip_local_port_range" = "1024 65535";
-      "net.ipv4.tcp_congestion_control" = "bbr";
-      "net.ipv4.tcp_fin_timeout" = 15;
-      "net.ipv4.tcp_keepalive_time" = 600;
-      "net.ipv4.tcp_mtu_probing" = 1;
-      "net.ipv4.tcp_rmem" = "4096 87380 16777216";
-      "net.ipv4.tcp_wmem" = "4096 65536 16777216";
-
-      # GC thresholds for ARP/Neighbor tables
-      "net.ipv4.neigh.default.gc_thresh1" = 1024;
-      "net.ipv4.neigh.default.gc_thresh2" = 2048;
-      "net.ipv4.neigh.default.gc_thresh3" = 4096;
-      "net.ipv6.conf.all.forwarding" = 1;
-      "net.ipv6.conf.default.forwarding" = 1;
-
-      # IPv6 Router Advertisement tuning
-      "net.ipv6.conf.all.accept_ra" = 2;
-      "net.ipv6.conf.default.accept_ra" = 2;
-      "net.ipv6.conf.enp1s0.accept_ra" = 2;
-      "net.ipv6.conf.enp1s0.autoconf" = 1;
-      "net.ipv6.conf.enp1s0.accept_ra_defrtr" = 0;
-      "net.ipv6.conf.enp1s0.accept_ra_pinfo" = 1;
-      "net.ipv6.conf.enp1s0.accept_ra_mtu" = 1;
-      "net.ipv6.conf.enp1s0.accept_redirects" = 0;
-      "net.ipv6.conf.all.accept_redirects" = 0;
-      "net.ipv6.conf.default.accept_redirects" = 0;
-      "net.ipv6.route.mtu_expires" = 600;
-      "net.ipv6.route.min_adv_mss" = 1220;
-
-      # Increase conntrack limits
-      "net.netfilter.nf_conntrack_max" = 262144;
-
-      # Required to prevent mmap OOM crashes in memory-mapping heavy pods like Longhorn
-      "vm.max_map_count" = 262144;
-    };
     loader = {
       efi.canTouchEfiVariables = true;
       systemd-boot.enable = true;
@@ -126,8 +59,6 @@
   };
 
   hardware = {
-    # Intel N150 needs firmware plus userspace graphics/QSV libraries so the
-    # Jellyfin pod can use VAAPI/QSV via /dev/dri/renderD128.
     enableRedistributableFirmware = true;
 
     facter.reportPath = ./facter.json;
@@ -143,22 +74,11 @@
     };
   };
 
-  # Vital for NVMe health and sustained performance
-  services.fstrim.enable = true;
-
   home-manager.users.nishir.imports = [
     ./users/nishir/home-configuration.nix
   ];
 
   networking = {
-    getaddrinfo.precedence = {
-      "::1/128" = 50;
-      "::/0" = 40;
-      "2002::/16" = 30;
-      "::/96" = 20;
-      "::ffff:0:0/96" = 100;
-    };
-
     hostName = "manash";
   };
 
@@ -173,7 +93,7 @@
     '';
   };
 
-  shikanime.rke2 = {
+  kix = {
     enable = true;
     extraConfig = {
       nodeIP = "192.168.1.28,2a02:8424:7899:f201:94eb:8d1:325a:7181";
@@ -201,35 +121,14 @@
         ];
       };
     };
+    tailscale.enable = true;
   };
 
-  services = {
-    avahi = {
-      enable = true;
-      nssmdns4 = true;
-      nssmdns6 = true;
-      publish = {
-        enable = true;
-        addresses = true;
-        workstation = true;
-      };
-    };
-
-    openssh = {
-      enable = true;
-      openFirewall = true;
-    };
-
-    tailscale = {
-      enable = true;
-      openFirewall = true;
-      useRoutingFeatures = "server";
-      authKeyFile = config.sops.secrets.tailscale-authkey.path;
-      extraUpFlags = [
-        "--advertise-routes=10.244.0.0/24,fd00::/112"
-        "--ssh"
-      ];
-    };
+  services.tailscale = {
+    authKeyFile = config.sops.secrets.tailscale-authkey.path;
+    extraUpFlags = [
+      "--advertise-routes=10.244.0.0/24,fd00::/112"
+    ];
   };
 
   nix.extraOptions = ''

--- a/hosts/nalsha/configuration.nix
+++ b/hosts/nalsha/configuration.nix
@@ -3,76 +3,9 @@
 {
   imports = [
     ../../modules/nixos/base.nix
-    ../../modules/nixos/rke2
   ];
 
   boot = {
-    # Kubernetes and Longhorn rely on bridge netfilter and overlayfs; BBR
-    # improves WAN/Tailnet flows
-    kernelModules = [
-      "br_netfilter"
-      "overlay"
-      "tcp_bbr"
-    ];
-    kernel.sysctl = {
-      # File and Inotify limits - Keep these high for Longhorn, K8s, and Syncthing
-      "fs.file-max" = 2097152;
-      "fs.inotify.max_user_instances" = 8192;
-      "fs.inotify.max_user_watches" = 524288;
-
-      # Bridge networking for CNIs
-      "net.bridge.bridge-nf-call-ip6tables" = 1;
-      "net.bridge.bridge-nf-call-iptables" = 1;
-
-      # Networking queueing and buffer sizing for overlay networks
-      "net.core.default_qdisc" = "fq";
-      "net.core.netdev_max_backlog" = 16384;
-      "net.core.rmem_default" = 7340032;
-      "net.core.rmem_max" = 16777216;
-      "net.core.somaxconn" = 4096;
-      "net.core.wmem_default" = 7340032;
-      "net.core.wmem_max" = 16777216;
-
-      # Forwarding, TCP autotuning, and BBR setup
-      "net.ipv4.ip_forward" = 1;
-      "net.ipv4.conf.all.rp_filter" = 0;
-      "net.ipv4.conf.default.rp_filter" = 0;
-      "net.ipv4.conf.enp1s0.rp_filter" = 0;
-      "net.ipv4.ip_local_port_range" = "1024 65535";
-      "net.ipv4.tcp_congestion_control" = "bbr";
-      "net.ipv4.tcp_fin_timeout" = 15;
-      "net.ipv4.tcp_keepalive_time" = 600;
-      "net.ipv4.tcp_mtu_probing" = 1;
-      "net.ipv4.tcp_rmem" = "4096 87380 16777216";
-      "net.ipv4.tcp_wmem" = "4096 65536 16777216";
-
-      # GC thresholds for ARP/Neighbor tables
-      "net.ipv4.neigh.default.gc_thresh1" = 1024;
-      "net.ipv4.neigh.default.gc_thresh2" = 2048;
-      "net.ipv4.neigh.default.gc_thresh3" = 4096;
-      "net.ipv6.conf.all.forwarding" = 1;
-      "net.ipv6.conf.default.forwarding" = 1;
-
-      # IPv6 Router Advertisement tuning
-      "net.ipv6.conf.all.accept_ra" = 2;
-      "net.ipv6.conf.default.accept_ra" = 2;
-      "net.ipv6.conf.enp1s0.accept_ra" = 2;
-      "net.ipv6.conf.enp1s0.autoconf" = 1;
-      "net.ipv6.conf.enp1s0.accept_ra_defrtr" = 0;
-      "net.ipv6.conf.enp1s0.accept_ra_pinfo" = 1;
-      "net.ipv6.conf.enp1s0.accept_ra_mtu" = 1;
-      "net.ipv6.conf.enp1s0.accept_redirects" = 0;
-      "net.ipv6.conf.all.accept_redirects" = 0;
-      "net.ipv6.conf.default.accept_redirects" = 0;
-      "net.ipv6.route.mtu_expires" = 600;
-      "net.ipv6.route.min_adv_mss" = 1220;
-
-      # Increase conntrack limits
-      "net.netfilter.nf_conntrack_max" = 262144;
-
-      # Required to prevent mmap OOM crashes in memory-mapping heavy pods like Longhorn
-      "vm.max_map_count" = 262144;
-    };
     loader = {
       efi.canTouchEfiVariables = true;
       systemd-boot.enable = true;
@@ -126,8 +59,6 @@
   };
 
   hardware = {
-    # Intel N150 needs firmware plus userspace graphics/QSV libraries so the
-    # Jellyfin pod can use VAAPI/QSV via /dev/dri/renderD128.
     enableRedistributableFirmware = true;
 
     facter.reportPath = ./facter.json;
@@ -143,22 +74,11 @@
     };
   };
 
-  # Vital for NVMe health and sustained performance
-  services.fstrim.enable = true;
-
   home-manager.users.nishir.imports = [
     ./users/nishir/home-configuration.nix
   ];
 
   networking = {
-    getaddrinfo.precedence = {
-      "::1/128" = 50;
-      "::/0" = 40;
-      "2002::/16" = 30;
-      "::/96" = 20;
-      "::ffff:0:0/96" = 100;
-    };
-
     hostName = "nalsha";
   };
 
@@ -173,7 +93,7 @@
     '';
   };
 
-  shikanime.rke2 = {
+  kix = {
     enable = true;
     extraConfig = {
       nodeIP = "192.168.1.64,2a02:8424:7899:f201:94eb:8d1:325a:7234";
@@ -203,35 +123,14 @@
         ];
       };
     };
+    tailscale.enable = true;
   };
 
-  services = {
-    avahi = {
-      enable = true;
-      nssmdns4 = true;
-      nssmdns6 = true;
-      publish = {
-        enable = true;
-        addresses = true;
-        workstation = true;
-      };
-    };
-
-    openssh = {
-      enable = true;
-      openFirewall = true;
-    };
-
-    tailscale = {
-      enable = true;
-      openFirewall = true;
-      useRoutingFeatures = "server";
-      authKeyFile = config.sops.secrets.tailscale-authkey.path;
-      extraUpFlags = [
-        "--advertise-routes=10.244.1.0/24,fd00::1:0/112"
-        "--ssh"
-      ];
-    };
+  services.tailscale = {
+    authKeyFile = config.sops.secrets.tailscale-authkey.path;
+    extraUpFlags = [
+      "--advertise-routes=10.244.1.0/24,fd00::1:0/112"
+    ];
   };
 
   nix.extraOptions = ''

--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -13,6 +13,7 @@
           ../../hosts/ashira/configuration.nix
           inputs.disko.nixosModules.disko
           inputs.home-manager.nixosModules.home-manager
+          inputs.kix.nixosModules.default
           inputs.sops-nix.nixosModules.sops
           {
             home-manager.sharedModules = [
@@ -31,6 +32,7 @@
           ../../hosts/manash/configuration.nix
           inputs.disko.nixosModules.disko
           inputs.home-manager.nixosModules.home-manager
+          inputs.kix.nixosModules.default
           inputs.sops-nix.nixosModules.sops
           {
             home-manager.sharedModules = [
@@ -49,6 +51,7 @@
           ../../hosts/nalsha/configuration.nix
           inputs.disko.nixosModules.disko
           inputs.home-manager.nixosModules.home-manager
+          inputs.kix.nixosModules.default
           inputs.sops-nix.nixosModules.sops
           {
             home-manager.sharedModules = [
@@ -93,6 +96,7 @@
               modules = [
                 ../../hosts/catbox/configuration.nix
                 inputs.home-manager.nixosModules.home-manager
+                inputs.kix.nixosModules.default
                 {
                   home-manager.sharedModules = [
                     inputs.catppuccin.homeModules.default
@@ -119,6 +123,7 @@
               modules = [
                 ../../hosts/catbox/configuration.nix
                 inputs.home-manager.nixosModules.home-manager
+                inputs.kix.nixosModules.default
                 {
                   home-manager.sharedModules = [
                     inputs.catppuccin.homeModules.default


### PR DESCRIPTION
Install forgejo-runner as a NixOS service on manash, ashira, nalsha, minish, and nemishi. Each runner is configured with the forgejo-runner package from nixpkgs, uses a sops-managed token, and registers with the Forgejo instance at forgejo.shikanime.svc.cluster.local:80.

All x86_64 runners are labeled with docker://node:22-bookworm and docker://nixos/nix for container-based jobs, plus native:host for direct execution. The aarch64 nodes (minish, nemishi) additionally carry the aarch64:host label.

Docker is enabled on each node to support container-based workflow jobs. The forgejo-runner-token sops secret must be provisioned per-host before activation.