### PR TITLE
Add Forgejo Actions runner to all RKE2 nodes

### DIFF
--- a/hosts/ashira/configuration.nix
+++ b/hosts/ashira/configuration.nix
@@ -232,7 +232,24 @@
         "--ssh"
       ];
     };
+
+    gitea-actions-runner = {
+      package = pkgs.forgejo-runner;
+      instances.ashira = {
+        enable = true;
+        name = "ashira";
+        tokenFile = config.sops.secrets.forgejo-runner-token.path;
+        url = "http://forgejo.shikanime.svc.cluster.local:80";
+        labels = [
+          "docker:docker://node:22-bookworm"
+          "nixos-latest:docker://nixos/nix"
+          "native:host"
+        ];
+      };
+    };
   };
+
+  virtualisation.docker.enable = true;
 
   nix.extraOptions = ''
     !include ${config.sops.templates.nix-config.path}
@@ -246,6 +263,7 @@
       nix-access-token = { };
       rke2-token = { };
       tailscale-authkey = { };
+      forgejo-runner-token = { };
     };
     templates.nix-config.content = ''
       extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";

--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -230,7 +230,24 @@
         "--ssh"
       ];
     };
+
+    gitea-actions-runner = {
+      package = pkgs.forgejo-runner;
+      instances.manash = {
+        enable = true;
+        name = "manash";
+        tokenFile = config.sops.secrets.forgejo-runner-token.path;
+        url = "http://forgejo.shikanime.svc.cluster.local:80";
+        labels = [
+          "docker:docker://node:22-bookworm"
+          "nixos-latest:docker://nixos/nix"
+          "native:host"
+        ];
+      };
+    };
   };
+
+  virtualisation.docker.enable = true;
 
   nix.extraOptions = ''
     !include ${config.sops.templates.nix-config.path}
@@ -243,6 +260,7 @@
     secrets = {
       nix-access-token = { };
       tailscale-authkey = { };
+      forgejo-runner-token = { };
     };
     templates.nix-config.content = ''
       extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";

--- a/hosts/nalsha/configuration.nix
+++ b/hosts/nalsha/configuration.nix
@@ -232,7 +232,24 @@
         "--ssh"
       ];
     };
+
+    gitea-actions-runner = {
+      package = pkgs.forgejo-runner;
+      instances.nalsha = {
+        enable = true;
+        name = "nalsha";
+        tokenFile = config.sops.secrets.forgejo-runner-token.path;
+        url = "http://forgejo.shikanime.svc.cluster.local:80";
+        labels = [
+          "docker:docker://node:22-bookworm"
+          "nixos-latest:docker://nixos/nix"
+          "native:host"
+        ];
+      };
+    };
   };
+
+  virtualisation.docker.enable = true;
 
   nix.extraOptions = ''
     !include ${config.sops.templates.nix-config.path}
@@ -246,6 +263,7 @@
       nix-access-token = { };
       rke2-token = { };
       tailscale-authkey = { };
+      forgejo-runner-token = { };
     };
     templates.nix-config.content = ''
       extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #909

Install forgejo-runner as a NixOS service on manash, ashira, and nalsha.
Each runner is configured with the forgejo-runner package from nixpkgs,
uses a sops-managed token, and registers with the Forgejo instance at
forgejo.shikanime.svc.cluster.local:80.

All runners are labeled with docker://node:22-bookworm and
docker://nixos/nix for container-based jobs, plus native:host for
direct execution.

Docker is enabled on each node to support container-based workflow jobs.
The forgejo-runner-token sops secret must be provisioned per-host before
activation.