### PR TITLE
Add Forgejo Actions runner to all RKE2 nodes

### DIFF
--- a/hosts/ashira/configuration.nix
+++ b/hosts/ashira/configuration.nix
@@ -239,7 +239,7 @@
         enable = true;
         name = "ashira";
         tokenFile = config.sops.secrets.forgejo-runner-token.path;
-        url = "https://git.taila659a.ts.net";
+        url = "https://ashira.taila659a.ts.net";
         labels = [
           "docker:docker://node:22-bookworm"
           "nixos-latest:docker://nixos/nix"

--- a/hosts/ashira/configuration.nix
+++ b/hosts/ashira/configuration.nix
@@ -232,7 +232,24 @@
         "--ssh"
       ];
     };
+
+    gitea-actions-runner = {
+      package = pkgs.forgejo-runner;
+      instances.ashira = {
+        enable = true;
+        name = "ashira";
+        tokenFile = config.sops.secrets.forgejo-runner-token.path;
+        url = "https://git.taila659a.ts.net";
+        labels = [
+          "docker:docker://node:22-bookworm"
+          "nixos-latest:docker://nixos/nix"
+          "native:host"
+        ];
+      };
+    };
   };
+
+  virtualisation.docker.enable = true;
 
   nix.extraOptions = ''
     !include ${config.sops.templates.nix-config.path}
@@ -246,6 +263,7 @@
       nix-access-token = { };
       rke2-token = { };
       tailscale-authkey = { };
+      forgejo-runner-token = { };
     };
     templates.nix-config.content = ''
       extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";

--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -230,7 +230,24 @@
         "--ssh"
       ];
     };
+
+    gitea-actions-runner = {
+      package = pkgs.forgejo-runner;
+      instances.manash = {
+        enable = true;
+        name = "manash";
+        tokenFile = config.sops.secrets.forgejo-runner-token.path;
+        url = "https://git.taila659a.ts.net";
+        labels = [
+          "docker:docker://node:22-bookworm"
+          "nixos-latest:docker://nixos/nix"
+          "native:host"
+        ];
+      };
+    };
   };
+
+  virtualisation.docker.enable = true;
 
   nix.extraOptions = ''
     !include ${config.sops.templates.nix-config.path}
@@ -243,6 +260,7 @@
     secrets = {
       nix-access-token = { };
       tailscale-authkey = { };
+      forgejo-runner-token = { };
     };
     templates.nix-config.content = ''
       extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";

--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -237,7 +237,7 @@
         enable = true;
         name = "manash";
         tokenFile = config.sops.secrets.forgejo-runner-token.path;
-        url = "https://git.taila659a.ts.net";
+        url = "https://manash.taila659a.ts.net";
         labels = [
           "docker:docker://node:22-bookworm"
           "nixos-latest:docker://nixos/nix"

--- a/hosts/nalsha/configuration.nix
+++ b/hosts/nalsha/configuration.nix
@@ -239,7 +239,7 @@
         enable = true;
         name = "nalsha";
         tokenFile = config.sops.secrets.forgejo-runner-token.path;
-        url = "https://git.taila659a.ts.net";
+        url = "https://nalsha.taila659a.ts.net";
         labels = [
           "docker:docker://node:22-bookworm"
           "nixos-latest:docker://nixos/nix"

--- a/hosts/nalsha/configuration.nix
+++ b/hosts/nalsha/configuration.nix
@@ -232,7 +232,24 @@
         "--ssh"
       ];
     };
+
+    gitea-actions-runner = {
+      package = pkgs.forgejo-runner;
+      instances.nalsha = {
+        enable = true;
+        name = "nalsha";
+        tokenFile = config.sops.secrets.forgejo-runner-token.path;
+        url = "https://git.taila659a.ts.net";
+        labels = [
+          "docker:docker://node:22-bookworm"
+          "nixos-latest:docker://nixos/nix"
+          "native:host"
+        ];
+      };
+    };
   };
+
+  virtualisation.docker.enable = true;
 
   nix.extraOptions = ''
     !include ${config.sops.templates.nix-config.path}
@@ -246,6 +263,7 @@
       nix-access-token = { };
       rke2-token = { };
       tailscale-authkey = { };
+      forgejo-runner-token = { };
     };
     templates.nix-config.content = ''
       extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}";

--- a/secrets/ashira.enc.yaml
+++ b/secrets/ashira.enc.yaml
@@ -1,10 +1,11 @@
 nix-access-token: ENC[AES256_GCM,data:KbtukowRITa2QHoUjVEhghocgiGMXIr0V0nrJ8emAyXU5/Rkwpa4KA==,iv:lFDgBHIo8IuqvCNyrbKCn5v1G0Quygvc/XcwRxzLMUI=,tag:XPSXt8ZO+K6WB5WJseFiaA==,type:str]
 tailscale-authkey: ENC[AES256_GCM,data:qfFWKqM8wFIG5rE3wCURxZtGBtbcutjl+cMYIuIxvhxAotpfYMjnZsT6VxtCzwkQUFVZptqMBA8xB57UUwk=,iv:3ZA/q7WHvfscBSUkRuW5IzsPG8EMlZj+FQrE68QnWf0=,tag:3O7384nD+ahnWmLUkrDqqg==,type:str]
 rke2-token: ENC[AES256_GCM,data:AKcl4tw8v0XmhwVbmcI2BwafeuvY1egmSzoV/vxoHJ5Q2Mbm/trQ0sZLKDSPHnHRG7HaY+l7X52v1H4mbYQMcb00zHE0wT46rXm1dTiHW5m1eTfe7B+WoK4wNvwPbcHQYwntMS+k6p+MCu19,iv:DUHifzjDaFSEj0920f0EJX5q/EMkyeIiOlBFxx1DX0c=,tag:9GFLZUzLWd+F6V+Tqe5qMA==,type:str]
+forgejo-runner-token: ENC[AES256_GCM,data:ChoA62e1A3o6KMEp29AJlBp82DPSGcmSUk25XXOMTe/qRPDN8hhffNiTOQ==,iv:11UqKP6yv8OiMuGENXfVBdQ1JLOR6FtAHnGch4+yo+c=,tag:Z0GdFRnS889ShD6tsQxxQw==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-06-09T21:59:04Z"
-  mac: ENC[AES256_GCM,data:o6qFqZljWnttxbijee5K7coWcSUtrPPxWZpb/xOWRkgdVsm/RRhDREcXRvGM/RDMb2v19pLaCYSxr7ztNn5u6v0fwjQisWqpRh3nZ3MKJvwy38O4xFKhNbJEGk6AetWHw4UBKplsZTG5pShd6uecNPOh+DzvFQHkOzyenb1GgP0=,iv:6kDP0aWD9VXPmKHZmHhvWdcYUqaoKu5AHk655FLIP6g=,tag:xiUE0MbsJZ4MqtYj7/cNWA==,type:str]
+  lastmodified: "2026-06-18T12:27:37Z"
+  mac: ENC[AES256_GCM,data:TqlIJ1gMI9GO0fhVqp1x4fwDb0fvJqHqk2+Zyxzs76VNs+aBe3hncjhRfkezQeUabl7dR9ioIGhKz0BE29i3ibUqRNY/Os39tmlkEHRu9xBESUR/yvjuzzZHVQH0kSSs6FHKasWnWdQIH6s0Mf5rDne0tnEBqwur1yDCbU7Zjy8=,iv:W8JFJaNH7GkmYMfk/6AKPsDlsGbfZQwii2MIr6mS0gI=,tag:XWmfWOoUYYhz6e7js8Ef1Q==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/ashira.enc.yaml
+++ b/secrets/ashira.enc.yaml
@@ -1,11 +1,11 @@
 nix-access-token: ENC[AES256_GCM,data:KbtukowRITa2QHoUjVEhghocgiGMXIr0V0nrJ8emAyXU5/Rkwpa4KA==,iv:lFDgBHIo8IuqvCNyrbKCn5v1G0Quygvc/XcwRxzLMUI=,tag:XPSXt8ZO+K6WB5WJseFiaA==,type:str]
 tailscale-authkey: ENC[AES256_GCM,data:qfFWKqM8wFIG5rE3wCURxZtGBtbcutjl+cMYIuIxvhxAotpfYMjnZsT6VxtCzwkQUFVZptqMBA8xB57UUwk=,iv:3ZA/q7WHvfscBSUkRuW5IzsPG8EMlZj+FQrE68QnWf0=,tag:3O7384nD+ahnWmLUkrDqqg==,type:str]
 rke2-token: ENC[AES256_GCM,data:AKcl4tw8v0XmhwVbmcI2BwafeuvY1egmSzoV/vxoHJ5Q2Mbm/trQ0sZLKDSPHnHRG7HaY+l7X52v1H4mbYQMcb00zHE0wT46rXm1dTiHW5m1eTfe7B+WoK4wNvwPbcHQYwntMS+k6p+MCu19,iv:DUHifzjDaFSEj0920f0EJX5q/EMkyeIiOlBFxx1DX0c=,tag:9GFLZUzLWd+F6V+Tqe5qMA==,type:str]
-forgejo-runner-token: ENC[AES256_GCM,data:ChoA62e1A3o6KMEp29AJlBp82DPSGcmSUk25XXOMTe/qRPDN8hhffNiTOQ==,iv:11UqKP6yv8OiMuGENXfVBdQ1JLOR6FtAHnGch4+yo+c=,tag:Z0GdFRnS889ShD6tsQxxQw==,type:str]
+forgejo-runner-token: ENC[AES256_GCM,data:PO34zV3S0o9NKsNVqpfxaaauluKlFLQMkTFRoZGUlyeWdIa3PSXjqQ==,iv:ZGiWFMIratZyoGdIMHNnzzGxJT017RdK5EomBbO09eA=,tag:/FplHvC2xfw/gDgoX+iTEw==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-06-18T12:27:37Z"
-  mac: ENC[AES256_GCM,data:TqlIJ1gMI9GO0fhVqp1x4fwDb0fvJqHqk2+Zyxzs76VNs+aBe3hncjhRfkezQeUabl7dR9ioIGhKz0BE29i3ibUqRNY/Os39tmlkEHRu9xBESUR/yvjuzzZHVQH0kSSs6FHKasWnWdQIH6s0Mf5rDne0tnEBqwur1yDCbU7Zjy8=,iv:W8JFJaNH7GkmYMfk/6AKPsDlsGbfZQwii2MIr6mS0gI=,tag:XWmfWOoUYYhz6e7js8Ef1Q==,type:str]
+  lastmodified: "2026-06-18T12:31:12Z"
+  mac: ENC[AES256_GCM,data:d14tB5z+V7Jwbzwxn6PsFh7W+rtOOeVQWmXy9Rxo3oUuJzsz++b5AJuEpycSfSVhcveNBpIsrvoF+FUe07TOcMecumtaQcils7GQVDO99ToCpnW3fecbZSrAb+St8ITRwbavaB8T43vqaAdytUCinjfKu/5VokqAxr0K1fYKX3o=,iv:qYR8bp4e8S9F2q1XYX8X9WCDrKlloAG7QcoC+8vb2EY=,tag:FslaJVyb2UiVZhuhKv6Iag==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/manash.enc.yaml
+++ b/secrets/manash.enc.yaml
@@ -1,10 +1,10 @@
 nix-access-token: ENC[AES256_GCM,data:n3MQAkPKp1hI/bzoWN6hknK1E5Xfok46878udatrW8pJx6bsbRElQg==,iv:gQ9wbGlV0FGXhsryOFhFL6pEOTEiY5Q2XfvgHKRFNs8=,tag:1Dq9DqJfEA7P0GKAWrgQDQ==,type:str]
 tailscale-authkey: ENC[AES256_GCM,data:ZEPLllMaCT6CL/niE64vzCZYxU/4qwqofSH3/vcBZdrZI5PrwiIfjp85/QGRkxDl8CVZh8nhNd9hlrJ1ew==,iv:zgmCYCcyfiokdTDvMqMGYLKc8Z8DJoj2Rwz1hUk7Sok=,tag:yPdHH+uVG0y5DHBGmGUXMQ==,type:str]
-forgejo-runner-token: ENC[AES256_GCM,data:7GJiJyYD1YGO08D0T+wlZEjpSw1CiUQj3vwyBLqtLnthly2XEbme6dSCag==,iv:g89tftOZWlesIbH3iDjgSdpzj8JVVNfxB61Lb7hM3Uc=,tag:vFizKMl5GaOz6DZZw5I+Iw==,type:str]
+forgejo-runner-token: ENC[AES256_GCM,data:ZvpSeoqPIG8KHZL6mVbDN2KftId8doiGtFisIxjSbBibv+RpGtEPFg==,iv:oyE6xDS62ORKnoWPOcSNY/NeCT9TQASi4Q+LIsdppo0=,tag:SWVzQJUv5u1bVdiyYN4g0w==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-06-18T12:27:22Z"
-  mac: ENC[AES256_GCM,data:hzOeYU+pRt9HzES39cRDIWiF+kottdYVdAYuArM8e3Uupg7pWyySHGdOaRjGFAu9ne3LIrfagjXp0oECs15s6h0p9tTC2OKXZ0SsdTRDsAEw3LwBZVq90s9ohpbRaKem1KhamoxFcnF/zgKThM3NuGi73iS0Ue/F7fymJVhV+/Y=,iv:CgTwnpSY2ZwG7ooQFd0jxDfpBtOdrlsFNXW//74xQQM=,tag:hZYrrlzZUY4Rk2Q0L7WK/Q==,type:str]
+  lastmodified: "2026-06-18T12:31:39Z"
+  mac: ENC[AES256_GCM,data:aajI2pLnJEu6U7zNxo8N9JOq0lgUoq+dz51PVq7vzjR2rZIuTnX2XyHIbpgaXAaPWRrKjhBX2PlGu+npk+bXq8IbdQXnMJ62dItatjyjBjz5SLrjpygbQoQreY5Y4ulRbzGlQAnRGfew+QmNjg9dHjRXVkd0BzWgPdCe0ddqX1s=,iv:EG1JhUyoL7o8UeQ1WfwaOknuqmuBIm7wYcFHta3JTSw=,tag:5w2mgGtw6Mm6ULu1x8a93A==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/manash.enc.yaml
+++ b/secrets/manash.enc.yaml
@@ -1,9 +1,10 @@
 nix-access-token: ENC[AES256_GCM,data:n3MQAkPKp1hI/bzoWN6hknK1E5Xfok46878udatrW8pJx6bsbRElQg==,iv:gQ9wbGlV0FGXhsryOFhFL6pEOTEiY5Q2XfvgHKRFNs8=,tag:1Dq9DqJfEA7P0GKAWrgQDQ==,type:str]
 tailscale-authkey: ENC[AES256_GCM,data:ZEPLllMaCT6CL/niE64vzCZYxU/4qwqofSH3/vcBZdrZI5PrwiIfjp85/QGRkxDl8CVZh8nhNd9hlrJ1ew==,iv:zgmCYCcyfiokdTDvMqMGYLKc8Z8DJoj2Rwz1hUk7Sok=,tag:yPdHH+uVG0y5DHBGmGUXMQ==,type:str]
+forgejo-runner-token: ENC[AES256_GCM,data:7GJiJyYD1YGO08D0T+wlZEjpSw1CiUQj3vwyBLqtLnthly2XEbme6dSCag==,iv:g89tftOZWlesIbH3iDjgSdpzj8JVVNfxB61Lb7hM3Uc=,tag:vFizKMl5GaOz6DZZw5I+Iw==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-06-09T17:36:35Z"
-  mac: ENC[AES256_GCM,data:67/PLpQB7BLw+KMwCZwejm3MJCMOxPtaCjgJDB0ESf3EWmE+Ck5OWnjV078E3rsfUBYagEfh5UQ22d3xbSsFkCxDvBZpPTH37R/SCCni8b4sD8MOchcvnwQagwIyVcVkOGux5e1FHGGZU9MIrO+3Ev/lMVRZcktc7cd8k9mwtdk=,iv:tbfBd1zulSSaEb1AugZ6udrCOyDVl+qQKaX/IMu1+sg=,tag:Qyvnl/sbJk8QdsUYMfUtHw==,type:str]
+  lastmodified: "2026-06-18T12:27:22Z"
+  mac: ENC[AES256_GCM,data:hzOeYU+pRt9HzES39cRDIWiF+kottdYVdAYuArM8e3Uupg7pWyySHGdOaRjGFAu9ne3LIrfagjXp0oECs15s6h0p9tTC2OKXZ0SsdTRDsAEw3LwBZVq90s9ohpbRaKem1KhamoxFcnF/zgKThM3NuGi73iS0Ue/F7fymJVhV+/Y=,iv:CgTwnpSY2ZwG7ooQFd0jxDfpBtOdrlsFNXW//74xQQM=,tag:hZYrrlzZUY4Rk2Q0L7WK/Q==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/nalsha.enc.yaml
+++ b/secrets/nalsha.enc.yaml
@@ -1,11 +1,11 @@
 nix-access-token: ENC[AES256_GCM,data:cjZcJvHoQxdKBEbvoDrsNlYyv/ScZ4QpOXwoRYWoTZlooEIf/YNrhQ==,iv:MX8fgcoIDLPS+VQK4ZkEKfT3dv0fZ5cqjhJCyNU8kYw=,tag:rZBY9BH2MvE6nqf7DYp6SQ==,type:str]
 tailscale-authkey: ENC[AES256_GCM,data:VYdbGIAIfhzkTR4S6uXdVrVRZ5ik8+yeImeEAnhMndXCUrpfkiL4kZmcZuZuSqzJdcrApGqerjKQYalSDek=,iv:5UdlWSJebS37zz2/t1bgtTk+4J+37osTgi8ieIHE/II=,tag:c99a1/G8MdzUtzjce5w+cA==,type:str]
 rke2-token: ENC[AES256_GCM,data:yatfNBMaCNIpJHcxtqxUvBHYbU5H9rbkyif7alGwKl5ZrogOeUFfdNzA29K5vCBe7Kr+RVfrGZpqGah2KAbCfpH0Ygn3RgLxELpi/qDMrObLnQ7WowLuAjHkByMYaprBVwKm5jM+9oJ6UMei,iv:qqJo/IxYpk0Ftaal0RW62aFaqwAL0fPsroSEo/SI/ZQ=,tag:Q1QftMJARzZeT2HY03qClA==,type:str]
-forjejo-runner-token: ENC[AES256_GCM,data:vnkddpFwgty9//Cxj0mc/sc2ZRAy8ogqu5GcXQ/xqKmkhP+hIVd3bg==,iv:bXsseXAgf5A4HMow/fsa2uhKFLGGkhssEXdPehdJS40=,tag:Baz0tm84RBYfl9mYCkCI1Q==,type:str]
+forgejo-runner-token: ENC[AES256_GCM,data:NGZ1zy+ZIz4Rs43FCMD7KCjagu2qB2TvjWcEUd+V8VX440Hc7VAydw==,iv:1XqrbiC2bzdWn2OWjKzx6byxg4bkPqCcUMGTxx7PAV4=,tag:8RGCEQpYeVhlMrBnYAL1/A==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-06-18T12:31:54Z"
-  mac: ENC[AES256_GCM,data:VXWLjqxvGxJexy9zEm9unMiaZ3pD2zWID/sijW8Nc/J/xpkJMP3c1R5dhAs5FEAfCRT7VZgR+EhRBadGorLUD62wv8gl58PeP051oyPRFK0ZvLxBsByLncRtoXXtfbhydL1gDxIDc58OOOZdRidmErFmIF7VoL263Ps9WVzgHeU=,iv:4YkVzOrCiu7RqVKd/C/UABCtfr1uWdkoWjGlO+SHjqA=,tag:KFYYBnbTq8y/iFEsTfrleQ==,type:str]
+  lastmodified: "2026-06-18T12:50:57Z"
+  mac: ENC[AES256_GCM,data:q/yW16lYRBWQPT3DDbSDImqFL8j9tGWjce3ZZO/GEqyrCcu6F8DLR4Eay1MWLQjfhNdKn0lBH2lZTaBzHLKDDTGn7ZnyGpgqQ6V+m0znuFEc+vu1ZxVK7BWsFxVjaK3ccT5tX1I7DkuqyT+EO2en9O68SbIXebhE9pcIplDFKwg=,iv:Ic30g/j9P9va+5lI2P9GTbqx6PEz9tRaIdsw7o4gul4=,tag:pyek6IznvmpjUmI3/2DQsA==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/nalsha.enc.yaml
+++ b/secrets/nalsha.enc.yaml
@@ -1,10 +1,11 @@
 nix-access-token: ENC[AES256_GCM,data:cjZcJvHoQxdKBEbvoDrsNlYyv/ScZ4QpOXwoRYWoTZlooEIf/YNrhQ==,iv:MX8fgcoIDLPS+VQK4ZkEKfT3dv0fZ5cqjhJCyNU8kYw=,tag:rZBY9BH2MvE6nqf7DYp6SQ==,type:str]
 tailscale-authkey: ENC[AES256_GCM,data:VYdbGIAIfhzkTR4S6uXdVrVRZ5ik8+yeImeEAnhMndXCUrpfkiL4kZmcZuZuSqzJdcrApGqerjKQYalSDek=,iv:5UdlWSJebS37zz2/t1bgtTk+4J+37osTgi8ieIHE/II=,tag:c99a1/G8MdzUtzjce5w+cA==,type:str]
 rke2-token: ENC[AES256_GCM,data:yatfNBMaCNIpJHcxtqxUvBHYbU5H9rbkyif7alGwKl5ZrogOeUFfdNzA29K5vCBe7Kr+RVfrGZpqGah2KAbCfpH0Ygn3RgLxELpi/qDMrObLnQ7WowLuAjHkByMYaprBVwKm5jM+9oJ6UMei,iv:qqJo/IxYpk0Ftaal0RW62aFaqwAL0fPsroSEo/SI/ZQ=,tag:Q1QftMJARzZeT2HY03qClA==,type:str]
+forjejo-runner-token: ENC[AES256_GCM,data:K4sCbgur5L/l5Ma3q3iO9xFD1hD0UMNX5d9ISUd9pmAlxTnYXcyQm35K+A==,iv:eSflfsgb9tzGTeXMDqppLFpeygCUDoCWG1C4r29UfBY=,tag:fX5jGWDzSTtyiUuR2qMNvw==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-06-09T21:59:08Z"
-  mac: ENC[AES256_GCM,data:9DeqVuxuDeRxxpKzwcCIiNRPldofUvpAF+GTt0L8UtYJIo/wrrcJdlM1f3crTcuGSnYmjZd+N6kXSIzICjbWCAKAtI5gTTJm43sHXHEBSeWv7T96W+bqUJ3gj0188613DvnfC/cztjk1p31qs7v3tGSdgdfuM3Pl6BSwPMxddmU=,iv:RCfMipGLaxPITqHA0chdceq+nbAZCLhxeK7bEk5xbs0=,tag:oYfd+JxhtE1riITvZ+ESsg==,type:str]
+  lastmodified: "2026-06-18T12:27:03Z"
+  mac: ENC[AES256_GCM,data:NIZusrErFY3Oye1GaXe6rjxhTQdukBbCluoGHmo4J4uP8/3ZMYhnTnQWxvWfmYpUVZ+mGMLqQvDa+obAUGW9nch1obhdqYa1zOxyEpb0ZWOjWtiZDJLu8Llk8zkRKCqwDFqTS/si5NbV4kMtwCHkVBbzWZ0I56TYEMK/Kqutbng=,iv:l0UyCDh5ZKdXS3LqQPT+CeOPgMpM5zU07GykuKYgtXg=,tag:zuc0D0ycuEGsHhuExg91Rw==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/nalsha.enc.yaml
+++ b/secrets/nalsha.enc.yaml
@@ -1,11 +1,11 @@
 nix-access-token: ENC[AES256_GCM,data:cjZcJvHoQxdKBEbvoDrsNlYyv/ScZ4QpOXwoRYWoTZlooEIf/YNrhQ==,iv:MX8fgcoIDLPS+VQK4ZkEKfT3dv0fZ5cqjhJCyNU8kYw=,tag:rZBY9BH2MvE6nqf7DYp6SQ==,type:str]
 tailscale-authkey: ENC[AES256_GCM,data:VYdbGIAIfhzkTR4S6uXdVrVRZ5ik8+yeImeEAnhMndXCUrpfkiL4kZmcZuZuSqzJdcrApGqerjKQYalSDek=,iv:5UdlWSJebS37zz2/t1bgtTk+4J+37osTgi8ieIHE/II=,tag:c99a1/G8MdzUtzjce5w+cA==,type:str]
 rke2-token: ENC[AES256_GCM,data:yatfNBMaCNIpJHcxtqxUvBHYbU5H9rbkyif7alGwKl5ZrogOeUFfdNzA29K5vCBe7Kr+RVfrGZpqGah2KAbCfpH0Ygn3RgLxELpi/qDMrObLnQ7WowLuAjHkByMYaprBVwKm5jM+9oJ6UMei,iv:qqJo/IxYpk0Ftaal0RW62aFaqwAL0fPsroSEo/SI/ZQ=,tag:Q1QftMJARzZeT2HY03qClA==,type:str]
-forjejo-runner-token: ENC[AES256_GCM,data:K4sCbgur5L/l5Ma3q3iO9xFD1hD0UMNX5d9ISUd9pmAlxTnYXcyQm35K+A==,iv:eSflfsgb9tzGTeXMDqppLFpeygCUDoCWG1C4r29UfBY=,tag:fX5jGWDzSTtyiUuR2qMNvw==,type:str]
+forjejo-runner-token: ENC[AES256_GCM,data:vnkddpFwgty9//Cxj0mc/sc2ZRAy8ogqu5GcXQ/xqKmkhP+hIVd3bg==,iv:bXsseXAgf5A4HMow/fsa2uhKFLGGkhssEXdPehdJS40=,tag:Baz0tm84RBYfl9mYCkCI1Q==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-06-18T12:27:03Z"
-  mac: ENC[AES256_GCM,data:NIZusrErFY3Oye1GaXe6rjxhTQdukBbCluoGHmo4J4uP8/3ZMYhnTnQWxvWfmYpUVZ+mGMLqQvDa+obAUGW9nch1obhdqYa1zOxyEpb0ZWOjWtiZDJLu8Llk8zkRKCqwDFqTS/si5NbV4kMtwCHkVBbzWZ0I56TYEMK/Kqutbng=,iv:l0UyCDh5ZKdXS3LqQPT+CeOPgMpM5zU07GykuKYgtXg=,tag:zuc0D0ycuEGsHhuExg91Rw==,type:str]
+  lastmodified: "2026-06-18T12:31:54Z"
+  mac: ENC[AES256_GCM,data:VXWLjqxvGxJexy9zEm9unMiaZ3pD2zWID/sijW8Nc/J/xpkJMP3c1R5dhAs5FEAfCRT7VZgR+EhRBadGorLUD62wv8gl58PeP051oyPRFK0ZvLxBsByLncRtoXXtfbhydL1gDxIDc58OOOZdRidmErFmIF7VoL263Ps9WVzgHeU=,iv:4YkVzOrCiu7RqVKd/C/UABCtfr1uWdkoWjGlO+SHjqA=,tag:KFYYBnbTq8y/iFEsTfrleQ==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #910

Install forgejo-runner as a NixOS service on manash, ashira, and nalsha.
Each runner is configured with the forgejo-runner package from nixpkgs,
uses a sops-managed token, and registers with the Forgejo instance at
https://forgejo.taila659a.ts.net.

All runners are labeled with docker://node:22-bookworm and
docker://nixos/nix for container-based jobs, plus native:host for
direct execution.

Docker is enabled on each node to support container-based workflow jobs.
The forgejo-runner-token sops secret must be provisioned per-host before
activation.Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I78aaffc69295b1311192c53e8e98d3066a6a6964Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>