### PR TITLE
fix: remove --debug flag from skaffold build command

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -8,4 +8,3 @@ build:
       custom:
         buildCommand:
           nix run github:shikanime-studio/nix-containers -- skaffold build
-          --debug


### PR DESCRIPTION
## Summary

The `--debug` flag on the skaffold build command is unnecessary in CI and adds noise to build logs. Debug logging can still be enabled via the `DEBUG` env var when needed.

## Changes

- `skaffold.yaml`: Removed `--debug` from the custom build command

## Test plan

- [ ] Verify CI pipeline runs cleanly without `--debug` flag