### PR TITLE
fix: add sops-nix to catbox configuration

### DIFF
--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -154,12 +154,14 @@
               modules = [
                 ../../hosts/catbox/configuration.nix
                 inputs.home-manager.nixosModules.home-manager
+                inputs.sops-nix.nixosModules.sops
                 {
                   home-manager.sharedModules = [
                     inputs.catppuccin.homeModules.default
                     inputs.colemak.homeModules.default
                     inputs.devlib.homeModules.default
                     inputs.identities.homeModules.default
+                    inputs.sops-nix.homeModules.default
                   ];
                 }
               ];
@@ -181,12 +183,14 @@
               modules = [
                 ../../hosts/catbox/configuration.nix
                 inputs.home-manager.nixosModules.home-manager
+                inputs.sops-nix.nixosModules.sops
                 {
                   home-manager.sharedModules = [
                     inputs.catppuccin.homeModules.default
                     inputs.colemak.homeModules.default
                     inputs.devlib.homeModules.default
                     inputs.identities.homeModules.default
+                    inputs.sops-nix.homeModules.default
                   ];
                 }
               ];


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* (to be filled)

The catbox Docker image build was failing because the identities module
(operator-6o.nix) references config.sops.placeholder.* but sops-nix
was not imported in the catbox NixOS configuration. Add both the NixOS
and Home Manager sops-nix modules to match all other host configs.

Co-Authored-By: Shikanime Deva <<EMAIL>>
Signed-off-by: William Phetsinorath <<EMAIL>>
Change-Id: Iab5b9210b6901d9a4f88aaa82e33af0c6a6a6964