### PR TITLE
Fix missing Tailscale SSH flag

### DIFF
--- a/modules/nixos/nishir.nix
+++ b/modules/nixos/nishir.nix
@@ -80,6 +80,7 @@
       openFirewall = true;
       useRoutingFeatures = "server";
       authKeyFile = config.sops.secrets.tailscale-authkey.path;
+      extraUpFlags = [ "--ssh" ];
     };
 
     fstrim.enable = true;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #954
* #953
* __->__ #952

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: Id52fe471e96f52aeed2870609fc9f0216a6a6964