### PR TITLE
Fix RKE2 and K8s API TLS

### DIFF
--- a/modules/nixos/nishir.nix
+++ b/modules/nixos/nishir.nix
@@ -1,3 +1,7 @@
+{ lib, ... }:
+
+with lib;
+
 {
   imports = [
     ./server.nix
@@ -103,20 +107,28 @@
 
   services = {
     fstrim.enable = true;
+  };
 
-    # Expose RKE2 API (9345) and Kubernetes API (6443) as a single Tailscale Service.
-    tailscale.serve = {
-      enable = true;
-      services.nishir = {
-        advertised = true;
-        endpoints = {
-          # Kubernetes API
-          "tcp:6443" = "http://127.0.0.1:6443";
-          # RKE2 API
-          "tcp:9345" = "http://127.0.0.1:9345";
-        };
-      };
+  # Tailscale serve with TLS termination (HTTPS) for RKE2 and Kubernetes APIs.
+  # The NixOS module (services.tailscale.serve) only supports tcp:<port> which
+  # maps to "HTTP": true — no TLS termination. Use systemd oneshot with the
+  # tailscale CLI directly as a workaround. Upstream bug: tailscale#18381,
+  # nixpkgs#530174.
+  systemd.services.tailscale-serve-https = {
+    description = "Expose RKE2 and Kubernetes APIs via Tailscale serve with HTTPS";
+    after = [ "tailscaled.service" ];
+    wants = [ "tailscaled.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
     };
+    script = ''
+      ${getExe tailscale} serve --yes --bg --service=svc:nishir --https=6443 http://127.0.0.1:6443
+      ${getExe tailscale} serve --yes --bg --service=svc:nishir --https=9345 http://127.0.0.1:9345
+    '';
   };
 
   users.users.nishir = {

--- a/modules/nixos/nishir.nix
+++ b/modules/nixos/nishir.nix
@@ -114,7 +114,7 @@ with lib;
   # maps to "HTTP": true — no TLS termination. Use systemd oneshot with the
   # tailscale CLI directly as a workaround. Upstream bug: tailscale#18381,
   # nixpkgs#530174.
-  systemd.services.tailscale-serve-https = {
+  systemd.services.tailscale-serve-k8s-node = {
     description = "Expose RKE2 and Kubernetes APIs via Tailscale serve with HTTPS";
     after = [ "tailscaled.service" ];
     wants = [ "tailscaled.service" ];

--- a/modules/nixos/nishir.nix
+++ b/modules/nixos/nishir.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 
 with lib;
 
@@ -126,8 +126,8 @@ with lib;
       RestartSec = "5s";
     };
     script = ''
-      ${getExe tailscale} serve --yes --bg --service=svc:nishir --https=6443 http://127.0.0.1:6443
-      ${getExe tailscale} serve --yes --bg --service=svc:nishir --https=9345 http://127.0.0.1:9345
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:nishir --https=6443 http://127.0.0.1:6443
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:nishir --https=9345 http://127.0.0.1:9345
     '';
   };
 

--- a/modules/nixos/nishir.nix
+++ b/modules/nixos/nishir.nix
@@ -105,9 +105,7 @@ with lib;
 
   sops.age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
 
-  services = {
-    fstrim.enable = true;
-  };
+  services.fstrim.enable = true;
 
   # Tailscale serve with TLS termination (HTTPS) for RKE2 and Kubernetes APIs.
   # The NixOS module (services.tailscale.serve) only supports tcp:<port> which

--- a/modules/nixos/nishir.nix
+++ b/modules/nixos/nishir.nix
@@ -114,7 +114,7 @@ with lib;
   # maps to "HTTP": true — no TLS termination. Use systemd oneshot with the
   # tailscale CLI directly as a workaround. Upstream bug: tailscale#18381,
   # nixpkgs#530174.
-  systemd.services.tailscale-serve-k8s-node = {
+  systemd.services.tailscale-serve-nishir = {
     description = "Expose RKE2 and Kubernetes APIs via Tailscale serve with HTTPS";
     after = [ "tailscaled.service" ];
     wants = [ "tailscaled.service" ];

--- a/modules/nixos/node.nix
+++ b/modules/nixos/node.nix
@@ -69,7 +69,12 @@
     script = ''
       ${pkgs.ethtool}/bin/ethtool -K enp1s0 rx-udp-gro-forwarding on rx-gro-list off
     '';
-    serviceConfig.Type = "oneshot";
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
     wantedBy = [ "multi-user.target" ];
     wants = [ "network-online.target" ];
   };

--- a/modules/nixos/talashi.nix
+++ b/modules/nixos/talashi.nix
@@ -1,3 +1,7 @@
+{ lib, ... }:
+
+with lib;
+
 {
   imports = [
     ./server.nix
@@ -71,20 +75,28 @@
 
   services = {
     fstrim.enable = true;
+  };
 
-    # Expose RKE2 API (9345) and Kubernetes API (6443)
-    tailscale.serve = {
-      enable = true;
-      services.talashi-k8s = {
-        endpoints = {
-          # RKE2 API
-          "tcp:9345" = "http://127.0.0.1:9345";
-          # Kubernetes API
-          "tcp:6443" = "http://127.0.0.1:6443";
-        };
-        advertised = true;
-      };
+  # Tailscale serve with TLS termination (HTTPS) for RKE2 and Kubernetes APIs.
+  # The NixOS module (services.tailscale.serve) only supports tcp:<port> which
+  # maps to "HTTP": true — no TLS termination. Use systemd oneshot with the
+  # tailscale CLI directly as a workaround. Upstream bug: tailscale#18381,
+  # nixpkgs#530174.
+  systemd.services.tailscale-serve-https = {
+    description = "Expose RKE2 and Kubernetes APIs via Tailscale serve with HTTPS";
+    after = [ "tailscaled.service" ];
+    wants = [ "tailscaled.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
     };
+    script = ''
+      ${getExe tailscale} serve --yes --bg --service=svc:talashi-k8s --https=6443 http://127.0.0.1:6443
+      ${getExe tailscale} serve --yes --bg --service=svc:talashi-k8s --https=9345 http://127.0.0.1:9345
+    '';
   };
 
   users.users.talashi = {

--- a/modules/nixos/talashi.nix
+++ b/modules/nixos/talashi.nix
@@ -73,9 +73,7 @@ with lib;
 
   sops.age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
 
-  services = {
-    fstrim.enable = true;
-  };
+  services.fstrim.enable = true;
 
   # Tailscale serve with TLS termination (HTTPS) for RKE2 and Kubernetes APIs.
   # The NixOS module (services.tailscale.serve) only supports tcp:<port> which

--- a/modules/nixos/talashi.nix
+++ b/modules/nixos/talashi.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, pkgs, ... }:
 
 with lib;
 
@@ -94,8 +94,8 @@ with lib;
       RestartSec = "5s";
     };
     script = ''
-      ${getExe tailscale} serve --yes --bg --service=svc:talashi-k8s --https=6443 http://127.0.0.1:6443
-      ${getExe tailscale} serve --yes --bg --service=svc:talashi-k8s --https=9345 http://127.0.0.1:9345
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:talashi-k8s --https=6443 http://127.0.0.1:6443
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:talashi-k8s --https=9345 http://127.0.0.1:9345
     '';
   };
 

--- a/modules/nixos/talashi.nix
+++ b/modules/nixos/talashi.nix
@@ -82,7 +82,7 @@ with lib;
   # maps to "HTTP": true — no TLS termination. Use systemd oneshot with the
   # tailscale CLI directly as a workaround. Upstream bug: tailscale#18381,
   # nixpkgs#530174.
-  systemd.services.tailscale-serve-https = {
+  systemd.services.tailscale-serve-k8s-node = {
     description = "Expose RKE2 and Kubernetes APIs via Tailscale serve with HTTPS";
     after = [ "tailscaled.service" ];
     wants = [ "tailscaled.service" ];

--- a/modules/nixos/talashi.nix
+++ b/modules/nixos/talashi.nix
@@ -82,7 +82,7 @@ with lib;
   # maps to "HTTP": true — no TLS termination. Use systemd oneshot with the
   # tailscale CLI directly as a workaround. Upstream bug: tailscale#18381,
   # nixpkgs#530174.
-  systemd.services.tailscale-serve-k8s-node = {
+  systemd.services.tailscale-serve-talashi = {
     description = "Expose RKE2 and Kubernetes APIs via Tailscale serve with HTTPS";
     after = [ "tailscaled.service" ];
     wants = [ "tailscaled.service" ];
@@ -94,8 +94,8 @@ with lib;
       RestartSec = "5s";
     };
     script = ''
-      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:talashi-k8s --https=6443 http://127.0.0.1:6443
-      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:talashi-k8s --https=9345 http://127.0.0.1:9345
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:talashi --https=6443 http://127.0.0.1:6443
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:talashi --https=9345 http://127.0.0.1:9345
     '';
   };
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #996

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I5375935631614a1e52eb19db259ed4556a6a6964