### PR TITLE
Fix Flux versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,11 +432,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782250844,
-        "narHash": "sha256-oPJP2dumRyPmOzCAHtoEqsMwbW696u5kW+P/BulVeVc=",
+        "lastModified": 1782251175,
+        "narHash": "sha256-1OO82M1ZV7GiOHkBKoXOemheKsrCrg2+Ha87Xazwp30=",
         "owner": "shikanime-studio",
         "repo": "knix",
-        "rev": "be9b1be9eb5c3d54c0a0c0d26ae98058b4574524",
+        "rev": "6ceb094b15b846d5d2a64f836ad91cb63fa8e12c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1002

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: Idaa6d8ad5248d1f416115fcc1f7046b76a6a6964