### PR TITLE
Fix node exporter already used by VictoriaMetrics

### DIFF
--- a/modules/nixos/base.nix
+++ b/modules/nixos/base.nix
@@ -29,26 +29,11 @@
       ];
     };
 
-    # Defaults (cpu, cpufreq, diskstats, filesystem, loadavg, meminfo,
-    # netdev, stat, systemd, processes, thermal_zone) — same set the
-    # victoria-metrics-k8s-stack node-exporter DaemonSet uses on servers.
-    prometheus.exporters.node = {
-      enable = true;
-      port = 9100;
-      listenAddress = "127.0.0.1";
-    };
-
     # Victoria Metrics agent scrapes local exporters and pushes to vminsert.
     vmagent = {
       enable = true;
       prometheusConfig = {
         scrape_configs = [
-          {
-            job_name = "node";
-            static_configs = [
-              { targets = [ "127.0.0.1:9100" ]; }
-            ];
-          }
           {
             job_name = "comin";
             static_configs = [


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1023
* #1022
* __->__ #1021

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: If10bf5495b4728d05367ff8f784f1d216a6a6964