### PR TITLE
Disable hardware offloading on flannel-wg to fix TX drops

### DIFF
--- a/modules/nixos/node.nix
+++ b/modules/nixos/node.nix
@@ -88,20 +88,46 @@
     };
   };
 
-  systemd.services.tailscale-udp-gro-forwarding = {
-    after = [ "network-online.target" ];
-    description = "Enable Tailscale UDP GRO forwarding on enp1s0";
-    script = ''
-      ${pkgs.ethtool}/bin/ethtool -K enp1s0 rx-udp-gro-forwarding on rx-gro-list off
-    '';
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = true;
-      Restart = "on-failure";
-      RestartSec = "5s";
+  systemd.services = {
+    tailscale-udp-gro-forwarding = {
+      after = [ "network-online.target" ];
+      description = "Enable Tailscale UDP GRO forwarding on enp1s0";
+      script = ''
+        ${pkgs.ethtool}/bin/ethtool -K enp1s0 rx-udp-gro-forwarding on rx-gro-list off
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
     };
-    wantedBy = [ "multi-user.target" ];
-    wants = [ "network-online.target" ];
+
+    # WireGuard Kernel module does not handle GSO/GRO/TSO correctly on some
+    # NICs (Intel i226-V). Offloading produces TX drops on flannel-wg due to
+    # oversized skb fragments the tunnel cannot encapsulate within MTU.
+    # Disable all hardware offloading on the WireGuard tunnel interface.
+    flannel-wg-offload-disable = {
+      after = [
+        "network-online.target"
+        "flannel-wg-netdev.service"
+      ];
+      description = "Disable hardware offloading on flannel-wg to prevent TX drops";
+      script = ''
+        ${pkgs.ethtool}/bin/ethtool -K flannel-wg gro off gso off tso off
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        Restart = "on-failure";
+        RestartSec = "10s";
+      };
+      unitConfig.ConditionPathExists = "/sys/class/net/flannel-wg";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+    };
   };
 
   users.users.nishir = {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1029
* #1030

WireGuard kernel module does not handle GSO/GRO/TSO correctly on Intel
i226-V NICs. Offloading produces TX drops on flannel-wg due to oversized
skb fragments the tunnel cannot encapsulate within MTU.

Add flannel-wg-offload-disable systemd service that runs ethtool to
disable gro/gso/tso on the wireguard tunnel interface. Conditioned on
interface existence so non-RKE2 hosts (Darwin, WSL) don't fail.

Audit found flannel-wg TX drops at ~100/s on nalsha (448K/24h).

Signed-off-by: Shikanimedeva <shikanimedeva@users.noreply.github.com>
Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I623fbba3ac461dbdd6e8445c928c06096a6a6964