### PR TITLE
Fix wireguard keepalive + mtu tuning

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,11 +432,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782257982,
-        "narHash": "sha256-p46mJ0oFAeTpi/kY12moitHx6RpfWhJEizFKdqYpojI=",
+        "lastModified": 1782660033,
+        "narHash": "sha256-C/zBMVCmowRC68U8xd+Ioqa9DasNWuEJhI75zzj6Z2s=",
         "owner": "shikanime-studio",
         "repo": "knix",
-        "rev": "6a558d2440f13242a322e0eb7905f5444fef55bc",
+        "rev": "30ed9611a527b4cbe3b45f740076d570472a8ddc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1029
* __->__ #1030

The knix/wireguard-tuning branch adds:
- wireguardKeepAlive=25s to prevent NAT/firewall pinhole expiry
- veth_mtu=1400 giving clean headroom for IPv6 wireguard overhead

Required for nishir cluster fix.

Signed-off-by: Shikanimedeva <shikanimedeva@users.noreply.github.com>
Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: Iecdba61a30d146cc789bec45e381fed96a6a6964