### PR TITLE
Fix missing rpi4 import

### DIFF
--- a/hosts/fushi/configuration.nix
+++ b/hosts/fushi/configuration.nix
@@ -6,7 +6,7 @@
     ../../modules/nixos/builder.nix
     ../../modules/nixos/distributed.nix
     ../../modules/nixos/follower.nix
-    ../../modules/nixos/rpi.nix
+    ../../modules/nixos/rpi4.nix
     "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
   ];
 

--- a/hosts/minish/configuration.nix
+++ b/hosts/minish/configuration.nix
@@ -6,7 +6,7 @@
     ../../modules/nixos/builder.nix
     ../../modules/nixos/distributed.nix
     ../../modules/nixos/follower.nix
-    ../../modules/nixos/rpi.nix
+    ../../modules/nixos/rpi4.nix
     "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
   ];
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1048

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: If58068032c819a3d66bf1e059b4289c16a6a6964