### PR TITLE
Fix network interface naming are different on RPI

### DIFF
--- a/hosts/nemishi/configuration.nix
+++ b/hosts/nemishi/configuration.nix
@@ -6,7 +6,7 @@
     ../../modules/nixos/builder.nix
     ../../modules/nixos/distributed.nix
     ../../modules/nixos/follower.nix
-    ../../modules/nixos/rpi5.nix
+    ../../modules/nixos/rpi.nix
     "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
   ];
 

--- a/modules/nixos/beelink.nix
+++ b/modules/nixos/beelink.nix
@@ -1,3 +1,5 @@
+{ pkgs, ... }:
+
 {
   boot = {
     binfmt.emulatedSystems = [ "aarch64-linux" ];
@@ -44,5 +46,23 @@
     enable32Bit = true;
   };
 
-  services.fstrim.enable = true;
+  services = {
+    fstrim.enable = true;
+
+    tailscale-udp-gro-forwarding = {
+      after = [ "network-online.target" ];
+      description = "Enable Tailscale UDP GRO forwarding on enp1s0";
+      script = ''
+        ${pkgs.ethtool}/bin/ethtool -K enp1s0 rx-udp-gro-forwarding on rx-gro-list off
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+    };
+  };
 }

--- a/modules/nixos/node.nix
+++ b/modules/nixos/node.nix
@@ -91,40 +91,22 @@ with lib;
     };
   };
 
-  systemd.services = {
-    tailscale-udp-gro-forwarding = {
-      after = [ "network-online.target" ];
-      description = "Enable Tailscale UDP GRO forwarding on enp1s0";
-      script = ''
-        ${pkgs.ethtool}/bin/ethtool -K enp1s0 rx-udp-gro-forwarding on rx-gro-list off
-      '';
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-        Restart = "on-failure";
-        RestartSec = "5s";
-      };
-      wantedBy = [ "multi-user.target" ];
-      wants = [ "network-online.target" ];
+  systemd.services.tailscale-serve-syncthing = {
+    description = "Expose RKE2 and Kubernetes APIs via Tailscale serve with HTTPS";
+    after = [ "tailscaled.service" ];
+    wants = [ "tailscaled.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
     };
-
-    tailscale-serve-syncthing = {
-      description = "Expose RKE2 and Kubernetes APIs via Tailscale serve with HTTPS";
-      after = [ "tailscaled.service" ];
-      wants = [ "tailscaled.service" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-        Restart = "on-failure";
-        RestartSec = "5s";
-      };
-      script = ''
-        ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --https=80 http://127.0.0.1:80
-        ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --https=443 https+insecure://127.0.0.1:443
-        ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --tcp=22000 tcp://127.0.0.1:22000
-      '';
-    };
+    script = ''
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --https=80 http://127.0.0.1:80
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --https=443 https+insecure://127.0.0.1:443
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --tcp=22000 tcp://127.0.0.1:22000
+    '';
   };
 
   users.users.nishir = {

--- a/modules/nixos/rpi.nix
+++ b/modules/nixos/rpi.nix
@@ -1,0 +1,32 @@
+{ pkgs, ... }:
+
+{
+  # Older Raspberry Pi-class boards still need these cgroup knobs for RKE2.
+  boot.kernelParams = [
+    "cgroup_enable=cpuset"
+    "cgroup_enable=memory"
+    "cgroup_memory=1"
+  ];
+
+  nixpkgs.overlays = [
+    (_: super: {
+      makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
+    })
+  ];
+
+  services.tailscale-udp-gro-forwarding = {
+    after = [ "network-online.target" ];
+    description = "Enable Tailscale UDP GRO forwarding on end0";
+    script = ''
+      ${pkgs.ethtool}/bin/ethtool -K end0 rx-udp-gro-forwarding on rx-gro-list off
+    '';
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    wantedBy = [ "multi-user.target" ];
+    wants = [ "network-online.target" ];
+  };
+}

--- a/modules/nixos/rpi4.nix
+++ b/modules/nixos/rpi4.nix
@@ -1,15 +1,6 @@
 {
-  # Older Raspberry Pi-class boards still need these cgroup knobs for RKE2.
-  boot.kernelParams = [
-    "cgroup_enable=cpuset"
-    "cgroup_enable=memory"
-    "cgroup_memory=1"
-  ];
-
-  nixpkgs.overlays = [
-    (_: super: {
-      makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
-    })
+  imports = [
+    ./rpi.nix
   ];
 
   hardware.raspberry-pi."4".fkms-3d.enable = true;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1049

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: Ic5db6fd6b6e747903524477a831ad0a46a6a6964