### PR TITLE
Fix upstream RKE2 and K8s APIs TLS

### DIFF
--- a/modules/nixos/agent.nix
+++ b/modules/nixos/agent.nix
@@ -15,7 +15,7 @@
       services.nishir = {
         advertised = true;
         endpoints = {
-          "tcp:9345" = "http://127.0.0.1:9345";
+          "tcp:9345" = "https+insecure://127.0.0.1:9345";
         };
       };
     };

--- a/modules/nixos/server.nix
+++ b/modules/nixos/server.nix
@@ -74,8 +74,8 @@
       services.nishir = {
         advertised = true;
         endpoints = {
-          "tcp:6443" = "http://127.0.0.1:6443";
-          "tcp:9345" = "http://127.0.0.1:9345";
+          "tcp:6443" = "https+insecure://127.0.0.1:6443";
+          "tcp:9345" = "https+insecure://127.0.0.1:9345";
         };
       };
     };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1056
* #1053

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I7fabf75351ad8f74fe58e0e4e662b14d6a6a6964