### PR TITLE
Fix TLS passthrough for RKE2

### DIFF
--- a/modules/nixos/server.nix
+++ b/modules/nixos/server.nix
@@ -74,8 +74,8 @@
       services.nishir = {
         advertised = true;
         endpoints = {
-          "tcp:6443" = "https+insecure://127.0.0.1:6443";
-          "tcp:9345" = "https+insecure://127.0.0.1:9345";
+          "tcp:6443" = "tcp://127.0.0.1:6443";
+          "tcp:9345" = "tcp://127.0.0.1:9345";
         };
       };
     };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1059

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: If2e5c934fbc7bdfc3c16d2b5da5a265a6a6a6964