### PR TITLE
Remove explicit Canal interface

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,11 +432,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782759287,
-        "narHash": "sha256-VFcM2gsJUmPoqvkduhpbC6Y2ButcwiPK5SFhvyguw6g=",
+        "lastModified": 1782770118,
+        "narHash": "sha256-V1b+95PyWNMVexKRv+L9rkZcdO+C76DX8Ys7tGJOJ90=",
         "owner": "shikanime-studio",
         "repo": "knix",
-        "rev": "8880d72e4a1eaf3625ed980a33f89c22a4b0d834",
+        "rev": "2ac30cecf326f0c13f7de0868edda48d3d9724bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1067

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: Ia0e87b412bc77f0e7077b6c1964a2a646a6a6964