### PR TITLE
Fix upstream Knix import error

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,11 +432,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782815498,
-        "narHash": "sha256-Y2ED8IxeU802IOSSLtwf0Lae4brIxylfFRyWEVXr274=",
+        "lastModified": 1782815671,
+        "narHash": "sha256-H7iCOFUEF4dAbEg/IaUW6NWwfgGpRjmphZHMmCONV80=",
         "owner": "shikanime-studio",
         "repo": "knix",
-        "rev": "1275e59f1432a141df4bcb8ae8aebfa3ed8a408e",
+        "rev": "26fd774c91f8a8c3d52f15ec3e53113427885a86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1072

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: Ic9a2277991642452840d0a5e3f2b03236a6a6964