### PR TITLE
Fix upstream Knix extraDeploy type error

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,11 +432,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782815671,
-        "narHash": "sha256-H7iCOFUEF4dAbEg/IaUW6NWwfgGpRjmphZHMmCONV80=",
+        "lastModified": 1782815887,
+        "narHash": "sha256-K2OXnDaODH4UD2HBX6V6u7ZKB3CwbZpPISDcTG2a7qQ=",
         "owner": "shikanime-studio",
         "repo": "knix",
-        "rev": "26fd774c91f8a8c3d52f15ec3e53113427885a86",
+        "rev": "24814b8d294a49007a124542a19cb15ef0eaf6f4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1073

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: Id62f6af96cf2b7ae72dc6458a60d17266a6a6964