### PR TITLE
Fix upstream Knix mkAutoDeployCharts type error

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -432,11 +432,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782815887,
-        "narHash": "sha256-K2OXnDaODH4UD2HBX6V6u7ZKB3CwbZpPISDcTG2a7qQ=",
+        "lastModified": 1782816357,
+        "narHash": "sha256-8icnQJnMgaKqnaXcya6RYiKpQSkXFK3MwmY/ZdWmc1s=",
         "owner": "shikanime-studio",
         "repo": "knix",
-        "rev": "24814b8d294a49007a124542a19cb15ef0eaf6f4",
+        "rev": "7c10e7c90dd7b20f4402145fea18af90729d9bd6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1074

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I83452b267ecfdb225559c82cb21266606a6a6964