### PR TITLE
Stop XFS I/O-error panics and add zram swap

### DIFF
--- a/modules/nixos/node.nix
+++ b/modules/nixos/node.nix
@@ -11,9 +11,14 @@ with lib;
     ./machine.nix
   ];
 
-  # 32 = SHUTDOWN_IOERROR. This specifically targets I/O failures.
-  # When XFS encounters a permanent I/O error, it panics the kernel.
-  boot.kernel.sysctl."fs.xfs.panic_mask" = 32;
+  # XFS no longer panics on I/O errors: on USB-backed nodes a transient
+  # enclosure I/O error was panicking the kernel and reboot-looping. Let XFS
+  # remount read-only and ride out the hiccup instead.
+  systemd.oomd.enable = true;
+
+  # zram swap so the kernel OOM-killer isn't the first responder on small nodes.
+  # PSI is enabled by default on NixOS std kernel; that also lets systemd-oomd run.
+  zramSwap.enable = true;
 
   networking = {
     firewall = {


### PR DESCRIPTION
## Summary
Config fix for the Fushi outage (root cause: FUSHI-ROOTCAUSE.md from t_d4602160).

Two changes in `modules/nixos/node.nix` (shared by all RKE2 nodes):
- **Drop `fs.xfs.panic_mask = 32`** (SHUTDOWN_IOERROR). On the USB-backed Longhorn node, a transient enclosure I/O error was panicking the kernel → reboot loop. XFS now remounts read-only and rides out the hiccup.
- **Add `zramSwap` (zstd, 50% RAM) + `systemd.oomd.enable`**. The 4 GiB Pi had 0 swap and no PSI, so the blunt kernel OOM-killer was killing `longhorn-manage` first. Userspace oomd can now relieve pressure before that.

## Notes
- `serverAddr = 192.168.1.28` (manash, the RKE2 **leader**) is correct — not config drift. The runtime connections to `.60`/`.64` are normal HA follower fanout.
- The corrupted XFS volume itself still needs `xfs_repair` on-node (data-risk, tracked separately) — this PR only stops the *recurrence* loop.
- Evaluated `nixosConfigurations.fushi` and `minish` cleanly.

## Test plan
- [ ] `comin` apply on fushi (or manual `nixos-rebuild`) — confirm boot, no panic loop
- [ ] `free -m` shows zram swap active; `systemctl is-active systemd-oomd`
- [ ] `cat /proc/sys/fs/xfs/panic_mask` is 0

🤖 Generated with [Hermes Agent](https://hermes.agent)