### PR TITLE
noctalia: enable auto-mode with runtime IP geolocation (t_c70d0a00)

### DIFF
--- a/hosts/ishtar/users/shika/home-configuration.nix
+++ b/hosts/ishtar/users/shika/home-configuration.nix
@@ -53,14 +53,13 @@ in
       enable = true;
       systemd.enable = true;
       settings = {
-        shell = {
-          font = "JetBrainsMono Nerd Font";
-        };
+        shell.font = "JetBrainsMono Nerd Font";
         theme = {
-          mode = "dark";
+          mode = "auto";
           source = "builtin";
           builtin = "Catppuccin";
         };
+        location.auto_locate = true;
       };
     };
   };


### PR DESCRIPTION
## Summary
Config-only change to enable Noctalia auto-mode on ishtar (the Razer Blade17 graphical workstation host). Per dashboard decision (A), the shell now follows the day/night schedule via silent runtime IP geolocation rather than hardcoded coordinates.

- `hosts/ishtar/users/shika/home-configuration.nix`: `programs.noctalia.settings.theme.mode` = `"auto"` (was `"dark"`) + `location.auto_locate = true`.

## Context / reframe
Parent research (t_e73404a5) established Noctalia is an upstream flake (`noctalia-dev/noctalia@de753dec`) consumed only as config — there is no repo-owned theme schema, placeholder UI, or detection code to author. The task body's "define theme schema / create placeholder UI components / unit tests" deliverables were reframed to config-only Nix changes; authoring them here would be dead code upstream ignores.

Schema verified against upstream `nix/home-module.nix`: `settings` is a free-form TOML attrset (`pkgs.formats.toml`) passed to `noctalia config validate` at build time. `theme.mode = "auto"` + `location.auto_locate = true` is valid by construction.

## Verification
- `nix-instantiate --parse` on the home config: exit 0.
- Cherry-picked from sibling t_3dba3f87 (commit 41fb725e); landed as bc1d9adc on root branch wt/t_c70d0a00.

## Follow-up (not in scope)
Greeter (`modules/nixos/graphical.nix`) left `mode = "dark"` — fixed login screen, no auto needed. Can be revisited if a synced login theme is wanted.

No self-merge per workflow.
