### PR TITLE
fix(flake): pin colemak to home.sessionVariables wayland fix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784903964,
-        "narHash": "sha256-wl7m4ko4ypUhr7xOpfLhdmNTi/Sqti/0yX21n66f8WA=",
+        "lastModified": 1784993668,
+        "narHash": "sha256-ZcZYJFDE8mwI8x5Oydvmj/wrHSpikn8NcIqWXhuSvh4=",
         "owner": "shikanime-labs",
         "repo": "colemak",
-        "rev": "9d929da41c6a9bcda169c7345f3f21f334268643",
+        "rev": "8c8a2a679ace7fc64f213735ea2c6899ab5748bc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
Bumps the `colemak` flake input to `8c8a2a6`, which fixes a home-manager module bug breaking `nix flake check` on `nixosConfigurations.nixtar`:

    error: The option `home-manager.users.shika.environment' does not exist
      defined in .../colemak/modules/home/wayland.nix

Root cause: `modules/home/wayland.nix` set `environment.sessionVariables` (NixOS syntax) inside a **home-manager** module. Fix switches it to `home.sessionVariables` (shikanime-labs/colemak#11).

## Verification
With the new pin, `nix flake check` evaluates `nixosConfigurations.nixtar` past the `environment does not exist` failure (proceeds into starship/home.file graph). Only remaining *local* failure on this aarch64-darwin host is an `x86_64-linux` platform mismatch for catppuccin derivations; the Linux CI runner builds those natively.

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>