### PR TITLE
docs: note Catppuccin built-in palette for Noctalia

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ Several hosts share remote build configuration through
 `modules/nixos/distributed.nix`, which lets local builds offload work to the
 other machines.
 
+## Theming
+
+Noctalia uses the Catppuccin built-in palette for its shell. The Ishtar home
+configuration selects it via
+`programs.noctalia.settings.theme.builtin = "Catppuccin"` with `mode = "auto"`,
+so the shell follows the system light/dark state. The `catppuccin` Home Manager
+module (Latte flavor on the workstation profile) supplies matching terminal and
+application colors.
+
 ## Related Repos
 
 This repository follows the same general shape as the other Shikanime


### PR DESCRIPTION
## Summary

- Adds a `## Theming` section to the README documenting Noctalia's Catppuccin built-in palette selection (`programs.noctalia.settings.theme.builtin = "Catppuccin"`, `mode = "auto"`) and the matching `catppuccin` Home Manager module on the workstation profile.
- Docs-only change; no functional code modified.

## Verification

- `nix build .#checks.aarch64-darwin.treefmt --accept-flake-config --no-pure-eval` → PASS (no regressions; treefmt reformatted prose to 100-col).
- `nix build .#checks.aarch64-darwin.pre-commit --accept-flake-config --no-pure-eval` → PASS.
- Working tree clean post-commit.

## Notes

- This branch is at main HEAD, so it intentionally does not include the sibling greeter fix (`appearance.scheme = "Catppuccin"` in `modules/nixos/graphical.nix`) or the sibling's separate `docs/noctalia-catppuccin-palette.md`. If that fuller doc lands, the README note and that doc should cross-reference. DCO-signed per repo convention.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)