### PR TITLE
Document Noctalia auto-mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ Shared module layers.
   - shell, editor, font, VCS, and workstation-specific settings
 - `modules/flake/` contains flake-parts glue for NixOS, Darwin, and devenv
 
+### Theming
+
+Noctalia (the Wayland shell/bar) is configured entirely through Nix — there is
+no repo-owned theme schema or UI component to edit. The theme is set per user in
+`hosts/<host>/users/<user>/home-configuration.nix` under `programs.noctalia.settings`:
+
+- `theme.mode` — the auto-mode flag. `"auto"` follows the day/night schedule;
+  set it to `"dark"` or `"light"` to disable auto and pin a fixed theme.
+- `location.auto_locate` — when `true` (current ishtar setting), the schedule is
+  derived from runtime IP geolocation. For a fixed-location, offline setup use
+  `location.latitude`/`longitude` instead, or `location.custom_schedule` with
+  explicit `sunrise`/`sunset` times.
+
+The greeter (`modules/nixos/graphical.nix`, `programs.noctalia-greeter`) keeps a
+separate, static `theme.mode` — it does not inherit the shell's auto setting.
+
 ### `secrets/`
 
 Encrypted secrets managed by `sops-nix`.


### PR DESCRIPTION
## Summary
Task t_7468e552 asked for a boolean AUTO_MODE_ENABLED flag in `config/theme_config.json` plus a README note and UI references.

Per parent research (t_e73404a5) and the accepted reframe across this task family, **Noctalia is an upstream flake** (`noctalia-dev/noctalia`) consumed only as Nix config — there is no repo-owned `theme_config.json`, theme schema, or UI component. Authoring a JSON flag + placeholder UI would be dead code the upstream binary ignores.

The real "auto-mode flag" already lives as `theme.mode = "auto"` in `hosts/ishtar/users/shika/home-configuration.nix` (commit a237ef10 on this branch). This PR delivers the one non-dead deliverable: a README note documenting how to toggle auto-mode.

## Changes
- `README.md`: add a `Theming` subsection explaining `theme.mode` is the auto-mode flag and how to switch it / adjust location resolution.

## Verification
- pre-commit hooks pass
- `nix-instantiate --parse` on the home config: OK