### PR TITLE
Integrate graphify

### DIFF
--- a/modules/home/vcs.nix
+++ b/modules/home/vcs.nix
@@ -13,7 +13,14 @@
     git = {
       enable = true;
       lfs.enable = true;
-      ignores = [ ".hermes/" ];
+      ignores = [
+        ".hermes/"
+        "*.graphify"
+        "graphify_output/"
+        "graphify-out/"
+        ".graphify_cache/"
+        "graphify_cache/"
+      ];
       settings.credential.helper = "manager";
     };
 

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -21,6 +21,7 @@ with lib;
       corepack
       gh
       git
+      graphify
       honcho
       nodejs
       rtk


### PR DESCRIPTION
## Summary
Reconciles the three completed child tasks for graphify into a single branch:

- `modules/flake/darwin.nix` + `modules/flake/nixos.nix` — expose `graphify` as a flake package (`.#graphify`) via a `mkGraphify` helper on both Linux arches and aarch64-darwin.
- `modules/nixos/ai.nix` — add `graphify` to `services.hermes-agent.extraPackages` so the agent's service PATH/user profile carry it.
- `modules/home/vcs.nix` + repo-root `.gitignore` — ignore graphify artifacts (`*.graphify`, `graphify_output/`, `graphify-out/`, `graphify_cache/`, `raw/`) at the fleet global exclude and repo layers.

## Notes
- The duplicate flake commit (`6c7eaa36`) on the ai.nix child branch was skipped to avoid double-adding the flake `.graphify` attribute; canonical `994f6d47` is the source of truth and is included.
- Live macOS `~/.gitignore_global` is hand-managed on this host, not home-manager-regenerated; the `vcs.nix` change covers fleet Linux/NixOS hosts only.
- Full host eval intentionally not run — blocked by a pre-existing, unrelated `leader.nix` error (`services.knix.addons.traefik`); out of scope.

## Verification
- `grep graphify` across the 5 files: one addition each, no duplicates.
- `git check-ignore`: all graphify patterns + `raw/` -> IGNORED.
- `nix-instantiate --parse` OK on darwin.nix, nixos.nix, ai.nix, vcs.nix.

Generated with Hermes Agent