### PR TITLE
Migrate IPv4 getaddrinfo precedence to machine.nix

### DIFF
--- a/modules/nixos/profiles/machine.nix
+++ b/modules/nixos/profiles/machine.nix
@@ -54,4 +54,13 @@
   # zram swap so the kernel OOM-killer isn't the first responder on small nodes.
   # PSI is enabled by default on NixOS std kernel; that also lets systemd-oomd run.
   zramSwap.enable = true;
+
+  # Force glibc to prefer IPv4 over IPv6 for dual-stack destinations.
+  networking.getaddrinfo.precedence = {
+    "::1/128" = 50;
+    "::/0" = 40;
+    "2002::/16" = 30;
+    "::/96" = 20;
+    "::ffff:0:0/96" = 100;
+  };
 }

--- a/modules/nixos/profiles/nishir.nix
+++ b/modules/nixos/profiles/nishir.nix
@@ -33,14 +33,6 @@ with lib;
         ip6tables -D FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
       '';
     };
-
-    getaddrinfo.precedence = {
-      "::1/128" = 50;
-      "::/0" = 40;
-      "2002::/16" = 30;
-      "::/96" = 20;
-      "::ffff:0:0/96" = 100;
-    };
   };
 
   services = {


### PR DESCRIPTION
Relocate the IPv4 getaddrinfo precedence block from nishir.nix into machine.nix (root profile). Broadens coverage from the 6 nishir hosts to also include ishtar via graphical.nix/leader.nix. Single source of truth, built-in NixOS option, both files parse clean.