### PR TITLE
Enable Noctalia greeter backdrop (blur + tint)

### DIFF
--- a/modules/home/graphical.nix
+++ b/modules/home/graphical.nix
@@ -6,6 +6,11 @@
     enable = true;
     systemd.enable = true;
     settings = {
+      backdrop = {
+        enabled = true;
+        blur_intensity = 0.5; # default; 0.0 = no blur, 1.0 = max
+        tint_intensity = 0.3; # 0.0 = no tint, 1.0 = opaque
+      };
       location.auto_locate = true;
       shell = {
         font = "Fira Code";


### PR DESCRIPTION
## Summary
Integrates the orphaned backdrop fix into the deployable tree so the greeter backdrop actually renders.

- Adds `programs.noctalia.settings.backdrop` to `modules/home/graphical.nix` with `enabled = true`, `blur_intensity = 0.5`, `tint_intensity = 0.3`.
- Keys verified against the pinned upstream Noctalia schema (noctalia=de753dec, greeter=8e53bb30); `theme`/`opacity`/`animation` are NOT valid backdrop keys.
- `greeter_sync.auto_sync` is already `true` on `main`, so once this lands the Noctalia greeter inherits the backdrop automatically.

## Verification status
- [x] Nix syntax parse (`nix-instantiate --parse`) passes.
- [ ] **Visual render not verifiable from this runner.** Screenshot capture of the Wayland greeter requires display capture on the graphical host `ishtar`. After this PR merges, deploy to `ishtar` (via comin from `main`/`testing-ishtar`) and capture the greeter screen to confirm the blurred/tinted backdrop appears.

## Note
`ishtar` is the only graphical NixOS host and serves as the de-facto staging target — there is no separate staging environment in the repo.