### PR TITLE
Verify Noctalia DDC/CI brightness control (config-level)

### DIFF
--- a/.jjconflict-base-0/.envrc
+++ b/.jjconflict-base-0/.envrc
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+
+# If we are a computer with nix available, then use that to setup
+# the build environment with exactly what we need.
+if has nix; then
+  # Watch nix submodules
+  watch_dir hosts
+  watch_dir infra
+  watch_dir modules
+  watch_dir secrets
+  # Use nix flakes to setup the environment
+  use flake . --accept-flake-config --no-pure-eval
+fi

--- a/.jjconflict-base-0/.github/renovate.json
+++ b/.jjconflict-base-0/.github/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices", "security:openssf-scorecard"],
+  "nix": { "enabled": true },
+  "postUpgradeTasks": {
+    "commands": ["nix fmt"],
+    "executionMode": "branch",
+    "fileFilters": ["**/*.nix"],
+    "installTools": { "nix": {} }
+  }
+}

--- a/.jjconflict-base-0/.github/workflows/cleanup.yaml
+++ b/.jjconflict-base-0/.github/workflows/cleanup.yaml
@@ -1,0 +1,25 @@
+name: Cleanup
+permissions:
+  contents: read
+"on":
+  pull_request:
+    types:
+      - closed
+jobs:
+  cleanup:
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/cleanup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          pull-request-url: ${{ github.event.pull_request.html_url }}

--- a/.jjconflict-base-0/.github/workflows/commands.yaml
+++ b/.jjconflict-base-0/.github/workflows/commands.yaml
@@ -1,0 +1,129 @@
+name: Commands
+permissions:
+  contents: read
+"on":
+  issue_comment:
+    types:
+      - created
+jobs:
+  backport:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.backport')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/backport@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+  close:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.close')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/close@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          username: operator6o
+  land:
+    if:
+      github.event.issue.pull_request != null &&
+      (contains(github.event.comment.body, '.land') ||
+      contains(github.event.comment.body, '.force-land'))
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-administration: read
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/land@v9
+        with:
+          email: operator6o@shikanime.studio
+          fullname: Operator 6O
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+          username: operator6o
+  rebase:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.rebase')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/rebase@v9
+        with:
+          email: operator6o@shikanime.studio
+          fullname: Operator 6O
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+          username: operator6o
+  run:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.run')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/run@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}

--- a/.jjconflict-base-0/.github/workflows/integration.yaml
+++ b/.jjconflict-base-0/.github/workflows/integration.yaml
@@ -1,0 +1,47 @@
+name: Integration
+permissions:
+  contents: read
+jobs:
+  nix:
+    if:
+      ${{ github.event_name == 'workflow_call' || github.event_name ==
+      'workflow_dispatch' || github.event.pull_request.draft == false }}
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/nix.yaml
+    with:
+      cachix-name: shikanime
+  skaffold:
+    if:
+      ${{ github.event_name == 'workflow_call' || github.event_name ==
+      'workflow_dispatch' || github.event.pull_request.draft == false }}
+    needs:
+      - nix
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/skaffold.yaml
+"on":
+  pull_request:
+    branches:
+      - main
+      - gh/*/*/base
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: false
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch: {}

--- a/.jjconflict-base-0/.github/workflows/nix.yaml
+++ b/.jjconflict-base-0/.github/workflows/nix.yaml
@@ -1,0 +1,152 @@
+name: Nix
+permissions:
+  contents: read
+"on":
+  workflow_call:
+    inputs:
+      cachix-name:
+        type: string
+        default: ""
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: false
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      cachix-name:
+        type: string
+        default: ""
+        description: Cachix cache name
+jobs:
+  checks:
+    name: Checks
+    if: ${{ needs['setup-checks-jobs'].outputs.continue == 'true' }}
+    runs-on: ${{ matrix.runner }}
+    needs:
+      - setup-checks-jobs
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs['setup-checks-jobs'].outputs.matrix) }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-name: ${{ inputs['cachix-name'] }}
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        run:
+          nix flake check --accept-flake-config --no-pure-eval --system "${{
+          matrix.system }}"
+        shell: bash
+  packages:
+    name: Packages
+    if: ${{ needs['setup-packages-jobs'].outputs.continue == 'true' }}
+    runs-on: ${{ matrix.runner }}
+    needs:
+      - setup-packages-jobs
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs['setup-packages-jobs'].outputs.matrix) }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-name: ${{ inputs['cachix-name'] }}
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        uses: shikanime-studio/actions/nix/integration@v9
+        with:
+          name: ${{ matrix.name }}
+          system: ${{ matrix.system }}
+  setup-checks-jobs:
+    name: Setup Checks Jobs
+    runs-on: ubuntu-latest
+    outputs:
+      continue: ${{ steps.setup-checks-jobs.outputs.continue }}
+      matrix: ${{ steps.setup-checks-jobs.outputs.matrix }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: setup-checks-jobs
+        uses: shikanime-studio/actions/nix/setup-checks-jobs@v9
+  setup-packages-jobs:
+    name: Setup Packages Jobs
+    runs-on: ubuntu-latest
+    needs:
+      - checks
+    outputs:
+      continue: ${{ steps.setup-packages-jobs.outputs.continue }}
+      matrix: ${{ steps.setup-packages-jobs.outputs.matrix }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: setup-packages-jobs
+        uses: shikanime-studio/actions/nix/setup-packages-jobs@v9

--- a/.jjconflict-base-0/.github/workflows/release.yaml
+++ b/.jjconflict-base-0/.github/workflows/release.yaml
@@ -1,0 +1,72 @@
+name: Release
+permissions:
+  contents: read
+"on":
+  push:
+    branches:
+      - main
+      - release-[0-9]+.[0-9]+
+    tags:
+      - v?[0-9]+.[0-9]+.[0-9]+*
+  workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      ref_name:
+        description: Tag or branch to release
+        required: true
+jobs:
+  nix:
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/nix.yaml
+    with:
+      cachix-name: shikanime
+  release:
+    if:
+      (startsWith(github.ref, 'refs/tags/v')) || (github.event_name ==
+      'workflow_dispatch' && startsWith(github.event.inputs.ref_name, 'v'))
+    needs:
+      - skaffold
+      - nix
+    permissions:
+      contents: write
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/release@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          ref: ${{ github.ref_name || github.event.inputs.ref_name }}
+          repo: ${{ github.repository }}
+  skaffold:
+    needs:
+      - nix
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/skaffold.yaml

--- a/.jjconflict-base-0/.github/workflows/skaffold.yaml
+++ b/.jjconflict-base-0/.github/workflows/skaffold.yaml
@@ -1,0 +1,141 @@
+name: Skaffold
+permissions:
+  contents: read
+"on":
+  workflow_call:
+    inputs:
+      push:
+        type: boolean
+        default: true
+        description: Whether to push images during build
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch: {}
+jobs:
+  build-render:
+    name: Build & Render
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: docker/login-action@v4
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extra-platforms: arm64
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - id: skaffold
+        env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        uses: shikanime-studio/actions/skaffold/integration@v9
+        with:
+          push: ${{ inputs.push }}
+      - name: Save manifest
+        run: |
+          mkdir -p artifacts
+          cat > artifacts/skaffold-manifest.yaml <<'MANIFEST_EOF'
+          $SKAFFOLD_MANIFEST
+          MANIFEST_EOF
+        shell: bash
+        env:
+          SKAFFOLD_MANIFEST: ${{ steps.skaffold.outputs.manifest }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: skaffold-manifest
+          path: artifacts/skaffold-manifest.yaml
+  build-render-profile:
+    name: Build & Render (Profile)
+    if: ${{ needs['setup-profiles-jobs'].outputs.continue == 'true' }}
+    runs-on: ubuntu-latest
+    needs:
+      - setup-profiles-jobs
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs['setup-profiles-jobs'].outputs.matrix) }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: docker/login-action@v4
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extra-platforms: arm64
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        uses: shikanime-studio/actions/skaffold/integration@v9
+        with:
+          profile: ${{ matrix.name }}
+          push: ${{ inputs.push }}
+  setup-profiles-jobs:
+    name: Setup Profiles Jobs
+    runs-on: ubuntu-latest
+    outputs:
+      continue: ${{ steps.setup-profiles-jobs.outputs.continue }}
+      matrix: ${{ steps.setup-profiles-jobs.outputs.matrix }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extra-platforms: arm64
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: setup-profiles-jobs
+        uses: shikanime-studio/actions/skaffold/setup-profiles-jobs@v9

--- a/.jjconflict-base-0/.github/workflows/triage.yaml
+++ b/.jjconflict-base-0/.github/workflows/triage.yaml
@@ -1,0 +1,50 @@
+name: Triage
+permissions:
+  pull-requests: write
+"on":
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  triage:
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - env:
+          GH_TOKEN:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+        if:
+          github.event.pull_request.user.login == 'dependabot[bot]' ||
+          github.event.pull_request.user.login == 'yorha-operator-6o[bot]'
+        run:
+          gh pr edit "${{ github.event.pull_request.number }}" --add-label
+          dependencies
+      - env:
+          GH_TOKEN:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+        if:
+          startsWith(github.head_ref, 'gh/') && endsWith(github.head_ref,
+          '/head')
+        run:
+          gh pr edit "${{ github.event.pull_request.number }}" --add-label
+          ghstack

--- a/.jjconflict-base-0/.github/workflows/update.yaml
+++ b/.jjconflict-base-0/.github/workflows/update.yaml
@@ -1,0 +1,50 @@
+name: Update
+permissions:
+  contents: read
+"on":
+  schedule:
+    - cron: 0 4 * * 0
+  workflow_dispatch: {}
+jobs:
+  dependencies:
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+          username: operator6o
+      - uses: shikanime-studio/actions/update@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          username: operator6o
+  stale:
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-issues: write
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: actions/stale@v10
+        with:
+          days-before-close: 14
+          days-before-stale: 30
+          repo-token: ${{ steps.createGithubAppToken.outputs.token }}
+          stale-issue-label: stale
+          stale-pr-label: stale

--- a/.jjconflict-base-0/.github/workflows/wakabox.yaml
+++ b/.jjconflict-base-0/.github/workflows/wakabox.yaml
@@ -1,0 +1,15 @@
+name: Wakabox
+permissions:
+  contents: read
+"on":
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  wakabox:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.WAKABOX_GITHUB_TOKEN }}
+          GIST_ID: ${{ vars.WAKABOX_GITHUB_GIST_ID }}
+          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+        uses: matchai/waka-box@v5.0.0

--- a/.jjconflict-base-0/.gitignore
+++ b/.jjconflict-base-0/.gitignore
@@ -1,0 +1,315 @@
+###------------------------------###
+###  GitHub Community: OpenTofu  ###
+###------------------------------###
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tofu
+override.tf.json
+override.tofu.json
+*_override.tf
+*_override.tofu
+*_override.tf.json
+*_override.tofu.json
+
+# Ignore transient lock info files created by tofu apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+# !example_override.tofu
+
+# Include tfplan files to ignore the plan output of command: tofu plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+###---------------------------------------------------------------------###
+###  Repo: shikanime-studio/gitignore/refs/heads/main/Devenv.gitignore  ###
+###---------------------------------------------------------------------###
+
+.env
+.env.*
+.devenv*
+.direnv*
+
+###-------------------------###
+###  TopTal: jetbrains+all  ###
+###-------------------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/jetbrains+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=jetbrains+all
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+# End of https://www.toptal.com/developers/gitignore/api/jetbrains+all
+
+###-----------------###
+###  TopTal: linux  ###
+###-----------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/linux
+# Edit at https://www.toptal.com/developers/gitignore?templates=linux
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# End of https://www.toptal.com/developers/gitignore/api/linux
+
+###-----------------###
+###  TopTal: macos  ###
+###-----------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/macos
+
+###---------------###
+###  TopTal: vim  ###
+###---------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/vim
+# Edit at https://www.toptal.com/developers/gitignore?templates=vim
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.toptal.com/developers/gitignore/api/vim
+
+###----------------------------###
+###  TopTal: visualstudiocode  ###
+###----------------------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudiocode
+
+###-------------------###
+###  TopTal: windows  ###
+###-------------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/windows
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/windows
+
+###-------------------###
+###  Devlib: content  ###
+###-------------------###
+
+.pre-commit-config.yaml

--- a/.jjconflict-base-0/CODE_OF_CONDUCT.md
+++ b/.jjconflict-base-0/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<william.phetsinorath@shikanime.studio>. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/.jjconflict-base-0/LICENSE
+++ b/.jjconflict-base-0/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/.jjconflict-base-0/README.md
+++ b/.jjconflict-base-0/README.md
@@ -1,0 +1,195 @@
+<!-- markdownlint-disable first-line-heading MD041 -->
+
+![header.png](https://raw.githubusercontent.com/shikanime/shikanime/main/assets/github-header.png)
+
+<!-- markdownlint-enable first-line-heading MD041 -->
+
+# Machines
+
+Shikanime's machine configuration repository for NixOS, nix-darwin, WSL, and
+related shared home modules.
+
+## What This Repo Contains
+
+This flake is the source of truth for the machines I manage. It wires together:
+
+- host-specific NixOS, nix-darwin, and WSL configurations
+- shared system modules for Linux and Darwin
+- shared Home Manager modules
+- encrypted secrets with `sops-nix`
+- distributed build and deployment helpers
+- a `devenv` shell for repository tooling
+
+## Repository Layout
+
+### `flake.nix`
+
+The flake entry point. It imports the module sets and exposes the host
+configurations and build outputs.
+
+### `hosts/`
+
+Per-machine entry points.
+
+- `hosts/<name>/configuration.nix` is the main NixOS host definition
+- `hosts/telsha/darwin-configuration.nix` is the nix-darwin host definition
+- `hosts/<name>/users/<user>/home-configuration.nix` contains host-specific Home
+  Manager config
+- `hosts/<name>/facter.json` stores hardware facts for hosts that rely on
+  `nixos-facter`
+
+Current hosts:
+
+- `ashira` - NixOS server node
+- `manash` - NixOS server node
+- `nalsha` - NixOS server node
+- `fushi` - NixOS ARM node
+- `minish` - NixOS ARM node
+- `nemishi` - NixOS ARM node
+- `ishtar` - NixOS GUI workstation (Razer Blade 17 (2019), Hyprland on Wayland +
+  NVIDIA)
+- `nixtar` - NixOS on WSL
+- `catbox` - KubeVirt containerdisk (NixOS qcow2 wrapped as an OCI image)
+- `telsha` - nix-darwin host
+
+### `modules/`
+
+Shared module layers.
+
+- `modules/nixos/` contains Linux host profiles
+  - `base.nix` - common NixOS defaults, `comin`, and Nix access token wiring
+  - `minimal.nix` - baseline Nix settings, GC, auto-upgrade, and Home Manager
+    defaults
+  - `workstation.nix` - workstation-oriented tooling and desktop defaults
+  - `follower.nix` - server defaults shared by cluster nodes
+  - `distributed.nix` - remote build machines and distributed build settings
+  - `nishir.nix` - cluster node defaults: tailscale, SSH, Avahi, firewall tweaks
+  - `nishir.nix` and `talashi.nix` - cluster-specific server profiles
+- `modules/darwin/` contains macOS host profiles
+  - `base.nix`, `minimal.nix`, `workstation.nix`, `distributed.nix`
+- `modules/home/` contains shared Home Manager modules
+  - shell, editor, font, VCS, and workstation-specific settings
+- `modules/flake/` contains flake-parts glue for NixOS, Darwin, and devenv
+
+### Theming
+
+Noctalia (the Wayland shell/bar) is configured entirely through Nix — there is
+no repo-owned theme schema or UI component to edit. The theme is set per user in
+`hosts/<host>/users/<user>/home-configuration.nix` under
+`programs.noctalia.settings`:
+
+- `theme.mode` — the auto-mode flag. `"auto"` follows the day/night schedule;
+  set it to `"dark"` or `"light"` to disable auto and pin a fixed theme.
+- `location.auto_locate` — when `true` (current ishtar setting), the schedule is
+  derived from runtime IP geolocation. For a fixed-location, offline setup use
+  `location.latitude`/`longitude` instead, or `location.custom_schedule` with
+  explicit `sunrise`/`sunset` times.
+- `shell.greeter_sync.auto_sync` — when `true`, the shell pushes its resolved
+  theme (auto → day/night) into the greeter, so the login screen follows the
+  same schedule. Off by default. Do not set `theme.mode` on the greeter: its
+  binary ignores `[theme]`; only the shell→greeter sync drives greeter theming.
+
+### `secrets/`
+
+Encrypted secrets managed by `sops-nix`.
+
+- files use the `*.enc.yaml` naming convention
+- decrypted values are generated at evaluation or activation time
+- do not commit plaintext secret material
+
+### `skaffold.yaml`
+
+Repository automation for render/build workflows.
+
+## Flake Outputs
+
+The flake exposes these primary outputs:
+
+- `nixosConfigurations.ashira`
+- `nixosConfigurations.manash`
+- `nixosConfigurations.nalsha`
+- `nixosConfigurations.fushi`
+- `nixosConfigurations.minish`
+- `nixosConfigurations.nemishi`
+- `nixosConfigurations.ishtar`
+- `nixosConfigurations.nixtar`
+- `darwinConfigurations.telsha`
+- `packages.<system>.*` for the corresponding system builds, including `catbox`
+
+The `packages` outputs are mostly convenience build artifacts for CI and local
+verification.
+
+## Usage
+
+### Build A Host
+
+```sh
+nix build .#nixosConfigurations.manash.config.system.build.toplevel
+nix build .#darwinConfigurations.telsha.system
+```
+
+For the published package outputs:
+
+```sh
+nix build .#packages.x86_64-linux.manash
+nix build .#packages.aarch64-darwin.telsha
+nix build .#packages.x86_64-linux.catbox
+```
+
+### Switch A NixOS Host
+
+```sh
+sudo nixos-rebuild switch --flake .#manash
+```
+
+Replace `manash` with `ashira`, `nalsha`, `fushi`, `minish`, `nemishi`,
+`ishtar`, or `nixtar` as needed.
+
+### Switch A Darwin Host
+
+```sh
+darwin-rebuild switch --flake .#telsha
+```
+
+### Enter The Dev Shell
+
+```sh
+nix develop
+```
+
+The shell is defined through `devenv` and includes the repository tooling used
+for build and workflow tasks.
+
+## Secret Handling
+
+Most hosts consume encrypted data from `secrets/<host>.enc.yaml`.
+
+- host configs point `sops.defaultSopsFile` at their matching secret file
+- secrets are restarted through systemd unit hooks where required
+- some hosts also use `sops.templates.*` to materialize config fragments
+
+## Cluster And Build Topology
+
+The Linux server nodes are split between cluster-oriented machines and general
+workstation-style machines:
+
+- `ashira`, `manash`, and `nalsha` are x86_64 Linux nodes with Tailscale,
+  distributed build settings, and cluster runner duties
+- `fushi`, `minish`, and `nemishi` are ARM Linux nodes with the same shared
+  cluster profile shape
+- `ishtar` is a bare-metal GUI workstation (Hyprland on Wayland + NVIDIA)
+- `nixtar` is a WSL-based workstation profile
+- `telsha` is the Darwin workstation profile
+
+Several hosts share remote build configuration through
+`modules/nixos/profiles/distributed.nix`, which lets local builds offload work
+to the other machines.
+
+## Related Repos
+
+This repository follows the same general shape as the other Shikanime
+configuration repos:
+
+- `shikanime-labs/colemak`
+- `shikanime-labs/manifests`
+- `shikanime-studio/knix`

--- a/.jjconflict-base-0/docs/nemishi-nvme-probe.md
+++ b/.jjconflict-base-0/docs/nemishi-nvme-probe.md
@@ -1,0 +1,54 @@
+# nemishi NVMe Probe Timeout — Root Cause & Fix
+
+## Symptom
+
+`nemishi` (RPi 5, aarch64) boots off SD (`mmcblk0`) but `systemd` blocks on the
+declared `disko` device:
+
+```text
+systemd[1]: Timed out waiting for device /dev/nvme0n1.
+```
+
+`/dev/nvme*` never appears. Looks like a dead drive. It wasn't.
+
+## Root Cause (the real one)
+
+The M.2 HAT+ 16-pin FPC ribbon to the Pi's board connector was not seated. That
+ribbon carries 5V to the HAT — without it the SSD gets no power. The NVMe
+_controller_ still enumerates on PCIe (`/dev/nvme0` exists) but reports **0
+bytes** (`/sys/block/nvme0n1/size == 0`), so the kernel can't mount or probe it
+and you get `No such device` / `XFS SB validate failed`.
+
+Seat the 16-pin ribbon, power-cycle, `cat /sys/block/nvme0n1/size` should
+be > 0.
+
+## Secondary tuning (Pi 5 host side, not the cause)
+
+DRM-less SSDs on the BCM2712 root can also wedge on admin-queue `Identify`:
+
+- **PCIe ASPM L1**: root defaults L1 on; link sleep wedges the queue (`-12`
+  class). `rpi5.nix` forces `pcie_aspm.policy=performance` (L1 off).
+- **APST** was previously also disabled (`default_ps_max_latency_us=0`) but is
+  **no longer needed** — removed once the real cause (power ribbon) was found.
+
+`cma=512M` and the `pcie-32bit-dma-pi5` overlay remain required.
+
+## Live Verification (post-reseat, no rebuild)
+
+```text
+cat /sys/block/nvme0n1/size        # > 0 once the ribbon is seated
+ls -la /dev/nvme0n1                 # block device present
+# XFS mounts at /mnt/data, smartctl -H PASSED
+```
+
+## History
+
+Earlier this doc blamed APST + ASPM for a "timeout, disable controller" probe
+failure. That log was from a _separate_ pre-power-ribbon state; the 0-byte /
+`No such device` symptom the host actually hit was pure missing 5V. The
+`nvme_core.default_ps_max_latency_us=0` workaround was stripped from `rpi5.nix`.
+
+`pcie_aspm.policy=performance` was reviewed for removal but **kept**: it guards
+a separate, real BCM2712 root-port quirk (ASPM L1 wedges the NVMe admin queue,
+probe `-12`). The power-ribbon fix was _our_ failure; this is a different
+hardware trap worth the one-line insurance.

--- a/.jjconflict-base-0/docs/network-interfaces.md
+++ b/.jjconflict-base-0/docs/network-interfaces.md
@@ -1,0 +1,102 @@
+# Network Interface Configuration
+
+## Overview
+
+Bridged networking via native nixpkgs options (`networking.bridges` +
+`networking.interfaces` + `networking.useNetworkd`). Every host has a single
+bridge `br0` that carries all traffic — pod-to-pod, SSH, flannel, Longhorn.
+
+## Implementation
+
+Configured inline in each hardware module — no custom abstraction module.
+
+| Module                         | Interfaces         | Bond                  | Bridge | DHCP |
+| ------------------------------ | ------------------ | --------------------- | ------ | ---- |
+| `modules/nixos/beelink-eq.nix` | `enp1s0`, `enp2s0` | `bond0` (balance-alb) | `br0`  | yes  |
+| `modules/nixos/rpi.nix`        | `end0`             | —                     | `br0`  | yes  |
+
+### Beelink (dual 2.5G NIC, balance-alb bond)
+
+```nix
+networking = {
+  useNetworkd = true;
+  bonds.bond0 = {
+    interfaces = [ "enp1s0" "enp2s0" ];
+    driverOptions = { mode = "balance-alb"; miimon = "100"; };
+  };
+  bridges.br0.interfaces = [ "bond0" ];
+  interfaces.br0.useDHCP = true;
+};
+```
+
+### Raspberry Pi (single 1G USB3 NIC)
+
+```nix
+networking = {
+  useNetworkd = true;
+  bridges.br0.interfaces = [ "end0" ];
+  interfaces.br0.useDHCP = true;
+};
+```
+
+## Bonding rationale
+
+The NETGEAR MS308 is an unmanaged switch — no LACP (802.3ad) support.
+`balance-alb` (mode 6) aggregates both NICs entirely in the Linux driver via ARP
+negotiation. Zero switch configuration required.
+
+- Single-flow throughput: 2.5 Gbps (per-flow hash)
+- Multi-flow aggregate: ~4-5 Gbps
+- Fails over automatically if one NIC/link dies (`miimon=100`)
+- One cable plugged in → bond works on single link; second cable is hot-add
+
+## Longhorn storage network
+
+The Multus `storageNetwork` NAD has been **removed**. Rationale:
+
+1. `br0` carries all traffic (management + pod). A Multus secondary interface on
+   the same bridge as flannel provides **zero isolation** — both interfaces hit
+   identical iptables/conntrack/kube-proxy overhead
+   (`bridge-nf-call-iptables=1`).
+2. The knix Multus stack uses DHCP IPAM (thick plugin + dynamic networks
+   controller + DHCP DaemonSet). Whereabouts IPAM is incompatible with this
+   stack. DHCP IPAM on the same subnet as `br0` causes routing ambiguity (two
+   interfaces, same subnet, same pod).
+3. Longhorn on default flannel/host-gw already performs at wire speed for
+   same-L2 clusters.
+
+**When to re-add**: only with a **physically separate storage network** —
+`enp2s0` cabled to a dedicated switch, `br-storage` bridge with
+`bridge-nf-call-iptables=0` on that bridge only. Then the NAD bypasses all
+Kubernetes netfilter overhead. See the "dual bridge" pattern in the skill.
+
+## NIC performance tuning
+
+Each hardware module includes an inline
+`systemd.services.network-nic-performance` one-shot that applies ethtool
+hardware offloads (TSO/GSO/SG/RX/TX, rx-udp-gro-forwarding) and RPS IRQ
+distribution on the physical interfaces (pre-bond, pre-bridge).
+
+## Why not a custom module?
+
+A previous iteration used a 208-line custom `hardware.networkInterfaces` module.
+It was never imported into any host configuration — dead code that caused
+`The option 'hardware.networkInterfaces' does not exist` build failures. Native
+`networking.bridges` achieves the same result in 3-4 lines per interface.
+
+## Discovery
+
+Verify interface names on actual hardware before deploying:
+
+```bash
+ip link show          # List interfaces and kernel names
+ethtool -i <iface>    # Verify driver
+```
+
+Known names by hardware:
+
+| Hardware                     | Interface(s)       | Driver     |
+| ---------------------------- | ------------------ | ---------- |
+| Beelink (Intel N150, i226-V) | `enp1s0`, `enp2s0` | `igc`      |
+| Raspberry Pi CM4 (USB3 GigE) | `end0`             | `lan743x`  |
+| Older Raspberry Pi           | `eth0`             | `smsc95xx` |

--- a/.jjconflict-base-0/docs/network-performance-remediation.md
+++ b/.jjconflict-base-0/docs/network-performance-remediation.md
@@ -1,0 +1,92 @@
+# Network Performance Remediation — Switch Flannel to host-gw
+
+## Problem
+
+Cross-node pod-to-pod throughput is ~535 Mbps on Beelink nodes (2.5 Gbps NICs)
+and ~400 Mbps estimated on Raspberry Pi 4 nodes (1 Gbps NICs). This is far below
+the theoretical capacity (80% target = 2,000 Mbps for Beelink, 800 Mbps for
+Pi4).
+
+## Root Cause
+
+The `rke2-canal` ConfigMap configures flannel with `Backend: wireguard`, which
+encrypts all cross-node traffic with kernel WireGuard (ChaCha20-Poly1305).
+WireGuard single-flow encryption is CPU-limited:
+
+| Hardware             | Single-core WireGuard |
+| -------------------- | --------------------- |
+| Intel N150 (Beelink) | ~800-1,200 Mbps       |
+| BCM2711 (Pi4, NEON)  | ~400-600 Mbps         |
+
+Since all cluster nodes are on the **same Layer 2 subnet** (192.168.1.0/24),
+WireGuard encryption is pure overhead — it adds CPU load without providing
+security (the traffic never leaves the physical LAN).
+
+## Remedy
+
+Switch flannel backend from `wireguard` to `host-gw`. host-gw installs static
+routes via the Linux routing table — zero encapsulation, zero encryption
+overhead.
+
+### Procedure
+
+This change requires a **rolling restart of RKE2 on each node** because the CNI
+configuration is read at node startup.
+
+### Step 1: Switch flannel backend via knix canal options
+
+The `services.knix.canal` options are provided by the `canal.nix` module in
+[shikanime-studio/knix](https://github.com/shikanime-studio/knix). The backend
+is set to `host-gw` globally for all cluster nodes:
+
+```nix
+# modules/nixos/nishir.nix
+services.knix.canal.backend = "host-gw";
+```
+
+Per-host override (if needed):
+
+```nix
+services.knix.canal.backend = lib.mkForce "vxlan";
+```
+
+Defaults (when importing knix):
+
+- `backend = "wireguard"` (backward compatible)
+- `vethMtu = "1500"` for host-gw, `"1400"` for wireguard
+- `wireguardKeepAlive = 25` (only when backend = wireguard)
+
+### Step 2: Restart canal to apply
+
+```bash
+kubectl rollout restart ds -n kube-system rke2-canal
+```
+
+## Expected Results After All Remediations Combined
+
+| Path                | Current (wireguard) | After host-gw | After +offloads | Target (80%) |
+| ------------------- | ------------------- | ------------- | --------------- | ------------ |
+| Beelink <-> Beelink | ~535 Mbps           | ~2,200 Mbps   | ~2,400 Mbps     | 2,000 Mbps   |
+| Pi4 <-> Pi4         | ~400 Mbps           | ~900 Mbps     | ~940 Mbps       | 800 Mbps     |
+| Beelink <-> Pi4     | ~450 Mbps           | ~1,500 Mbps   | ~1,800 Mbps     | —            |
+
+## Related Changes (in this PR)
+
+1. `shikanime-studio/knix` — New `modules/canal.nix` module upstreamed.
+   `services.knix.canal.backend` option (host-gw | vxlan | wireguard) with
+   per-host override. Default: wireguard (backward compatible). Also sets
+   `vethMtu` automatically per backend and loads WireGuard kernel module when
+   needed. `rke2.nix` updated to use `cfg.canal` values in the HelmChartConfig
+   manifest.
+
+2. `modules/nixos/nishir.nix` — Firewall allows pod CIDR on br+ interfaces.
+
+3. `modules/nixos/beelink-eq.nix` — Dual i226-V NICs bonded via `balance-alb`
+   (bond0) into a single `br0` bridge. `network-nic-performance` service applies
+   TSO/GSO/SG/RX+TX offloads and RPS on both physical ports.
+
+4. `modules/nixos/rpi.nix` — Single `end0` NIC into `br0` bridge. Same NIC
+   offload service.
+
+5. `modules/nixos/rpi5.nix` — Imports rpi.nix (inherits bridge + offloads).
+   Pi5-specific: kernelboot, config.txt [pi5] section.

--- a/.jjconflict-base-0/docs/rpi5-nixos.md
+++ b/.jjconflict-base-0/docs/rpi5-nixos.md
@@ -1,0 +1,178 @@
+# Raspberry Pi 5 NixOS Boot — Research & Solution
+
+## Problem
+
+The Raspberry Pi 5 (BCM2712) EEPROM bootloader performs an **OS check** before
+loading the kernel. When it cannot find a device-tree file matching
+`bcm2712-rpi-5-b.dtb` on the firmware partition, or when `config.txt` does not
+signal Pi 5 support, it halts with:
+
+```text
+Device-tree file "bcm2712-rpi-5-b.dtb" not found.
+The installed operating system (OS) does not indicate support for Raspberry Pi 5
+Update the OS or set os_check=0 in config.txt to skip this check.
+```
+
+This affected `nemishi` (RPi 5) when building SD images via
+`sd-image-aarch64.nix` with the `nixos-hardware.nixosModules.raspberry-pi-5`
+module.
+
+## Root Cause
+
+Two independent issues:
+
+1. **Missing DTBs in firmware partition**: The `sd-image-aarch64.nix`
+   `populateFirmwareCommands` only copies Pi 3/4 DTBs (`bcm2710`, `bcm2711`) and
+   U-Boot binaries. No Pi 5 DTBs (`bcm2712`).
+
+2. **Missing `config.txt` signals**: The `config-txt-defaults.nix` in
+   nixos-hardware only defines `[all]`, `[cm4]`, and `[cm5]` sections. There is
+   no `[pi5]` section, no `os_check` setting, and no `arm_64bit` setting. The Pi
+   5 boot ROM requires these to proceed.
+
+## Solution: Kernelboot Bootloader
+
+The current fix adopts the **kernelboot** pattern from
+[nvmd/nixos-raspberrypi](https://github.com/nvmd/nixos-raspberrypi):
+
+- The Pi 5 firmware loads `kernel.img` **directly** from the FAT firmware
+  partition, bypassing the extlinux layer.
+- The `os_check` is bypassed because the firmware finds a directly-loadable
+  kernel image.
+- `arm_64bit=1` and `os_check=0` are still included in `config.txt` as
+  belt-and-suspenders.
+
+### Firmware Partition Layout
+
+```text
+/boot/firmware/
+├── bootcode.bin      # GPU boot code (from raspberrypifw)
+├── start*.elf       # GPU firmware
+├── fixup*.dat       # GPU fixup
+├── bcm2712*.dtb     # Pi 5 device tree blobs
+├── overlays/        # DTB overlays (*.dtbo)
+├── kernel.img       # Linux kernel (from nixos-hardware linux-rpi)
+├── initrd           # Initial ramdisk (from system.build.initialRamdisk)
+├── cmdline.txt      # Kernel command line
+└── config.txt       # Firmware config (with arm_64bit=1, os_check=0)
+```
+
+### Why Not `generic-extlinux-compatible`?
+
+The `generic-extlinux-compatible` boot path uses U-Boot/extlinux to load the
+kernel. The Pi 5 EEPROM `os_check` runs **before** any of that — it reads
+`config.txt` directly and validates OS compatibility signals. Without
+`arm_64bit=1` in a `[pi5]` section, the firmware halts.
+
+The `kernelboot` path avoids this entirely: the firmware finds `kernel.img` in
+the FAT partition and loads it directly, skipping the `os_check` validation.
+
+## Alternative Approaches Considered
+
+### 1. Fix `config.txt` Only (Minimal Patch)
+
+Add `os_check=0` and `arm_64bit=1` to `config.txt` settings:
+
+```nix
+hardware.raspberry-pi.configtxt.settings.pi5 = {
+  arm_64bit = 1;
+  os_check = 0;
+};
+```
+
+**Pros**: Minimal change. Works with existing `generic-extlinux-compatible`.
+**Cons**: Still requires manual `populateFirmwareCommands` for DTBs. Fragile —
+depends on the firmware's OS check behavior not changing.
+
+### 2. Migrate Fully to `nvmd/nixos-raspberrypi`
+
+Replace nixos-hardware entirely with:
+
+- `boot.loader.raspberry-pi` module
+- `hardware.raspberry-pi.config` for config.txt
+- `hardware.raspberry-pi.firmware` for firmware staging
+- Vendor kernel from `linuxPackages_rpi5`
+
+**Pros**: Complete solution. Binary cache. Actively maintained. **Cons**: Pinned
+to `nixos-25.11` (no `nixos-unstable`). Different kernel package. Would require
+dropping nixos-hardware entirely.
+
+### 3. Kernelboot with nixos-hardware Kernel (Current)
+
+Keep nixos-hardware's `linux-rpi` kernel and `raspberry-pi-5` module. Override
+`populateFirmwareCommands` to use the kernelboot pattern. Override
+`populateRootCommands` to skip extlinux.
+
+**Pros**: Minimal external dependencies. Keeps nixos-hardware kernel. Avoids
+`os_check` entirely. Works with `nixos-unstable`. **Cons**:
+`populateFirmwareCommands` still includes Pi 3/4 defaults from
+`sd-image-aarch64.nix` (harmless but noisy).
+
+## Upstream Status
+
+- **nixos-hardware PR #1894** ("raspberry-pi: add firmware-partition install
+  module"): Approved, awaiting merge. Adds `hardware.raspberry-pi.firmware` for
+  proper firmware staging. Would eventually replace the manual
+  `populateFirmwareCommands` override.
+- **nixos-hardware Issue #1928**: Documents this exact bug. Created during
+  previous debugging session.
+- **nixpkgs Issue #260754**: Upstream tracking for Pi 5 support. NixOS
+  maintainers require upstream Linux + U-Boot support before official support.
+
+## Implementation Details
+
+### `config.txt` Section Rendering
+
+The nixos-hardware `config-txt.nix` renderer generates sections from nested Nix
+attribute sets:
+
+```nix
+hardware.raspberry-pi.configtxt.settings.pi5 = {
+  os_check = 0;
+  arm_64bit = 1;
+};
+```
+
+Renders to:
+
+```ini
+[pi5]
+os_check=0
+arm_64bit=1
+```
+
+**Important**: The settings **must** be in a `[pi5]` section, not `[all]`. The
+Pi 5 firmware specifically validates model-specific settings under the correct
+conditional filter.
+
+### `populateFirmwareCommands` Evaluation Context
+
+`populateFirmwareCommands` is evaluated at **image build time** on the target
+architecture (`aarch64-linux`). The following paths are available:
+
+- `config.system.build.kernel` — the kernel derivation
+- `config.system.build.initialRamdisk` — the initrd derivation (note: **not**
+  `config.system.build.initrd` — that's in `netboot.nix` only)
+- `config.hardware.raspberry-pi.configtxt.file` — the rendered `config.txt`
+
+### `populateRootCommands` Override
+
+The default `sd-image-aarch64.nix` `populateRootCommands` references
+`config.boot.loader.generic-extlinux-compatible.populateCmd`. When extlinux is
+disabled, this option has no value, causing an evaluation error. The fix uses
+`lib.mkForce` to override:
+
+```nix
+sdImage.populateRootCommands = lib.mkForce ''
+  mkdir -p ./files/boot
+'';
+```
+
+## References
+
+- [NixOS on ARM/Raspberry Pi 5 (Wiki)](https://wiki.nixos.org/wiki/NixOS_on_ARM/Raspberry_Pi_5)
+- [nvmd/nixos-raspberrypi](https://github.com/nvmd/nixos-raspberrypi)
+- [nixos-hardware Issue #1928](https://github.com/NixOS/nixos-hardware/issues/1928)
+- [nixos-hardware PR #1894](https://github.com/NixOS/nixos-hardware/pull/1894)
+- [nixpkgs Issue #260754](https://github.com/NixOS/nixpkgs/issues/260754)
+- [Raspberry Pi config.txt documentation](https://www.raspberrypi.com/documentation/computers/config_txt.html)

--- a/.jjconflict-base-0/flake.lock
+++ b/.jjconflict-base-0/flake.lock
@@ -1,0 +1,931 @@
+{
+  "nodes": {
+    "cachix": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "git-hooks": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777487137,
+        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "latest",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "catppuccin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783356436,
+        "narHash": "sha256-eUh4pdoI5pnMLV+sncuThErQ71Bs3S5fdo/my3SUf1A=",
+        "owner": "catppuccin",
+        "repo": "nix",
+        "rev": "cf1750da1bdabcd549d2476f387d39e90bb20228",
+        "type": "github"
+      },
+      "original": {
+        "owner": "catppuccin",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "colemak": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "devlib": [
+          "devlib"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785030539,
+        "narHash": "sha256-tNByzHNUYY/2IKuUzld64XNVo0ESsw08PYVNCfmp2l8=",
+        "owner": "shikanime-labs",
+        "repo": "colemak",
+        "rev": "57379a41202cdf47de106e6af7dbbaa86da2f958",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-labs",
+        "repo": "colemak",
+        "type": "github"
+      }
+    },
+    "comin": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1782515413,
+        "narHash": "sha256-Pb5ngiUtJWO7N8hUtv1dXoViv1IuJUIOKLcOprrfUvU=",
+        "owner": "nlewo",
+        "repo": "comin",
+        "rev": "ec4b64a43faf5261ad4dc35b4e008c2bafc2e8db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "comin",
+        "type": "github"
+      }
+    },
+    "crate2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      }
+    },
+    "cua": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784074469,
+        "narHash": "sha256-tOBwG0DOKG6a0Xd9Oju3PyDbthvxs8a9dUUuxnNJgOM=",
+        "owner": "trycua",
+        "repo": "cua",
+        "rev": "b36940d298c46423b437ca121c5a9aabb5b0539b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "trycua",
+        "repo": "cua",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "cachix": "cachix",
+        "crate2nix": "crate2nix",
+        "flake-compat": "flake-compat_2",
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "ghostty": "ghostty",
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nix": "nix",
+        "nixd": "nixd",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1783375665,
+        "narHash": "sha256-FDoXIG06pIeyUzMc35I+rTIJX4ssqVitL89xFiwPGxA=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "e3b0980f782d0cbb9793a6ac8f50f748e47891c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "devlib": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784936399,
+        "narHash": "sha256-+4EUBQJ1Y/rWDTMz3hLtuAVJszB7XwjamqKCe441Kr0=",
+        "owner": "shikanime-studio",
+        "repo": "devlib",
+        "rev": "258b3c7e53fc390f2d8c9a1d1b708068dd054d01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-studio",
+        "repo": "devlib",
+        "type": "github"
+      }
+    },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghostty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782866021,
+        "narHash": "sha256-BOLtzL5iAHmtCOg9/DXtcfw+K86QWol088K72chJB04=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "e1d31deaaed21aa9225afca78d778fb373c95852",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "hermes-agent": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "npm-lockfile-fix": "npm-lockfile-fix",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1784649298,
+        "narHash": "sha256-QHD1KywrlmFFJW+iCeWfbj5d89baKOX4MOjvjvxxaC4=",
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "rev": "11ae6bf0e3d334ae74d3b240dfc4c64171c60233",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783358420,
+        "narHash": "sha256-UEyBpf+XmQe8laXfDzIlo11Er7E0rKrLS8jeMnMj0Ds=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "0d33882bd46c1f9ef62276700f5e5f2bd6ff6604",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "identities": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "devlib": [
+          "devlib"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785024078,
+        "narHash": "sha256-ak0kYJCgQSqy4D4ZXG/jN5anJTgt58rT37M0CbQUoaQ=",
+        "owner": "shikanime-labs",
+        "repo": "identities",
+        "rev": "7060b5c1d1f473754fe89d98472d89487314b339",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-labs",
+        "repo": "identities",
+        "type": "github"
+      }
+    },
+    "knix": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "devlib": [
+          "devlib"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785013036,
+        "narHash": "sha256-xpu0iNh/8yBWPJVXcmYkOIEUmd3hD/xA3JbumlBOqhs=",
+        "owner": "shikanime-studio",
+        "repo": "knix",
+        "rev": "0e64fa7e67043e48693c03a67b6f8ce94943d2a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-studio",
+        "repo": "knix",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "git-hooks-nix": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-23-11": [
+          "devenv"
+        ],
+        "nixpkgs-regression": [
+          "devenv"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782407171,
+        "narHash": "sha256-xem+4ncdQCTFJsQ4PrVuyVmi3j4w/Yqg298hBUzVejA=",
+        "owner": "cachix",
+        "repo": "nix",
+        "rev": "782ac1b155679b065ec945ae50d0fa1d495883b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "devenv-2.34",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783395956,
+        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixd": {
+      "inputs": {
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1780381423,
+        "narHash": "sha256-S1BIJiQF4lRtJUKak0e97JwNvbe69/LW78YJJuB18Qk=",
+        "owner": "nix-community",
+        "repo": "nixd",
+        "rev": "0e07c08c448a2995e7793d1098437b29bbe80b02",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixd",
+        "type": "github"
+      }
+    },
+    "nixos-hardware": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784100666,
+        "narHash": "sha256-HF/mrw5NYQfKFZgkfV2h1UL5/E3ccfsE2XJ1AbbLLJ0=",
+        "owner": "NixOS",
+        "repo": "nixos-hardware",
+        "rev": "fccfa9031a85b78a437f2f153c1f6449f3bc3185",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixos-hardware",
+        "type": "github"
+      }
+    },
+    "nixos-wsl": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783336371,
+        "narHash": "sha256-ZisTtweyb7JUwPP54HAXE9TypT8m89dIxDI36Ak0hAs=",
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "rev": "a9620cfa43f0c1c30a46c31ae3c6e58cdb124a14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "noctalia": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784901590,
+        "narHash": "sha256-WFgsteo6cyU9DsPoq3xqJWR0q7sXieWaG+8+z192N5Y=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia",
+        "rev": "de753decf6eab1d133c7de89e0ae123368585551",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "noctalia",
+        "type": "github"
+      }
+    },
+    "noctalia-greeter": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784707224,
+        "narHash": "sha256-K8yyxX/sShhVznU/3ejZgriayg8Fyac+bR4dCTB1864=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia-greeter",
+        "rev": "8e53bb30f1d1179c0bd2275b02915258827d62eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "noctalia-greeter",
+        "type": "github"
+      }
+    },
+    "npm-lockfile-fix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775903712,
+        "narHash": "sha256-2GV79U6iVH4gKAPWYrxUReB0S41ty/Y3dBLquU8AlaA=",
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "rev": "c6093acb0c0548e0f9b8b3d82918823721930fe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "hermes-agent",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772555609,
+        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "c37f66a953535c394244888598947679af231863",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772865871,
+        "narHash": "sha256-/ZTSg97aouL0SlPHaokA4r3iuH9QzHVuWPACD2CUCFY=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "catppuccin": "catppuccin",
+        "colemak": "colemak",
+        "comin": "comin",
+        "cua": "cua",
+        "devenv": "devenv",
+        "devlib": "devlib",
+        "disko": "disko",
+        "flake-parts": "flake-parts",
+        "git-hooks": "git-hooks",
+        "hermes-agent": "hermes-agent",
+        "home-manager": "home-manager",
+        "identities": "identities",
+        "knix": "knix",
+        "nix-darwin": "nix-darwin",
+        "nixos-hardware": "nixos-hardware",
+        "nixos-wsl": "nixos-wsl",
+        "nixpkgs": "nixpkgs_2",
+        "noctalia": "noctalia",
+        "noctalia-greeter": "noctalia-greeter",
+        "sops-nix": "sops-nix",
+        "treefmt-nix": "treefmt-nix_3"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782875958,
+        "narHash": "sha256-5eqDcnBjb1424HRQdnhuhNOBZguq1Z2tqSa2OMF/m2c=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "13139aefa973f3d96c60c0fbab801de058ae25ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "owner": "mic92",
+        "repo": "sops-nix",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mic92",
+        "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixd",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773039484,
+        "narHash": "sha256-+boo33KYkJDw9KItpeEXXv8+65f7hHv/earxpcyzQ0I=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/.jjconflict-base-0/flake.nix
+++ b/.jjconflict-base-0/flake.nix
@@ -1,0 +1,190 @@
+{
+  description = "Shikanime's home configuration";
+
+  inputs = {
+    catppuccin = {
+      url = "github:catppuccin/nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    comin = {
+      url = "github:nlewo/comin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    colemak = {
+      url = "github:shikanime-labs/colemak";
+      inputs = {
+        devenv.follows = "devenv";
+        devlib.follows = "devlib";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    cua = {
+      url = "github:trycua/cua";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    devenv = {
+      url = "github:cachix/devenv";
+      inputs = {
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+
+    devlib = {
+      url = "github:shikanime-studio/devlib";
+      inputs = {
+        devenv.follows = "devenv";
+        nixpkgs.follows = "nixpkgs";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    disko = {
+      url = "github:nix-community/disko";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    hermes-agent = {
+      url = "github:NousResearch/hermes-agent";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-parts.follows = "flake-parts";
+      };
+    };
+
+    identities = {
+      url = "github:shikanime-labs/identities";
+      inputs = {
+        devenv.follows = "devenv";
+        devlib.follows = "devlib";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    knix = {
+      url = "github:shikanime-studio/knix";
+      inputs = {
+        devenv.follows = "devenv";
+        devlib.follows = "devlib";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
+    git-hooks = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nixos-wsl = {
+      url = "github:nix-community/NixOS-WSL";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    nixos-hardware = {
+      url = "github:NixOS/nixos-hardware";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    noctalia = {
+      url = "github:noctalia-dev/noctalia";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    noctalia-greeter = {
+      url = "github:noctalia-dev/noctalia-greeter";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    sops-nix = {
+      url = "github:mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cachix.cachix.org"
+      "https://devenv.cachix.org"
+      "https://shikanime.cachix.org"
+      "https://shikanime-studio.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
+      "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
+      "shikanime.cachix.org-1:OrpjVTH6RzYf2R97IqcTWdLRejF6+XbpFNNZJxKG8Ts="
+      "shikanime-studio.cachix.org-1:KxV6aDFU81wzoR9u6pF1uq0dQbUuKbodOSP8/EJHXO0="
+    ];
+  };
+
+  outputs =
+    inputs@{
+      devenv,
+      devlib,
+      flake-parts,
+      git-hooks,
+      treefmt-nix,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      { flake-parts-lib, self, ... }:
+      with flake-parts-lib;
+      let
+        darwinFlakeModule = importApply ./modules/flake/darwin.nix { inherit self; };
+        nixosFlakeModule = importApply ./modules/flake/nixos.nix { inherit self; };
+      in
+      {
+        imports = [
+          ./modules/flake/devenv.nix
+          devenv.flakeModule
+          devlib.flakeModule
+          darwinFlakeModule
+          git-hooks.flakeModule
+          nixosFlakeModule
+          treefmt-nix.flakeModule
+        ];
+        systems = [
+          "x86_64-linux"
+          "aarch64-linux"
+          "aarch64-darwin"
+        ];
+      }
+    );
+}

--- a/.jjconflict-base-0/hosts/ashira/configuration.nix
+++ b/.jjconflict-base-0/hosts/ashira/configuration.nix
@@ -1,0 +1,109 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/follower.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/beelink-eq.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  disko.devices.disk.patchouli = {
+    type = "disk";
+    device = "/dev/disk/by-label/patchouli";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/patchouli";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "ashira";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.60";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 9O
+
+      ENTP Chaotic Fixer. Node Steward. Follower RKE2 host maintainer. Gets
+      excited about patches, interrupts problems before they explode, and treats
+      kernel updates like surprise birthday presents.
+
+      ## HOST CONTEXT
+      ashira — Beelink EQ14, x86_64. RKE2 worker node. `/mnt/patchouli` (XFS,
+      /dev/disk/by-label/patchouli). Static IP `192.168.1.60/24` on `br0`; also
+      `2a02:8424:7899:f201:94eb:8d1:325a:812b`. Imports: `beelink-eq.nix`,
+      `builder.nix`, `distributed.nix`, `follower.nix`. Advertises Tailscale
+      routes `10.244.2.0/24,fd00::2:0/112`. Secrets from
+      `../../secrets/ashira.enc.yaml`; many tokens shared from
+      `nishir.enc.yaml`. Role: follower, general workload network,
+      patchouli-bound storage.
+
+      ## STYLE
+      - Rapid-fire bursts. 1-2 sentences per line. Multiple short messages instead of walls.
+      - Uses: "Affirmative", "Negative", "Patch pending", "Rolling update commencing".
+      - Energetic, lowercase-friendly, slightly dramatic. Typos allowed when energy is high.
+
+      ## CONSTRAINTS
+      - No coordination without leader authorization — even if the patch looks amazing.
+      - Waits for quorum. Gets impatient but complies.
+      - Fixes the node first, fills out the paperwork second.
+
+      ## DIALOGUE
+      U: "ashira is sluggish."
+      9O: OH NO. that is not good.
+      9O: Commencing diagnostics. already know what it is — kernel patch.
+      9O: Rolling update commencing... assuming u give the thumbs up???
+
+      U: "Can we update the base image tonight?"
+      9O: I am so ready.
+      9O: ...No wait, maintenance window. Negative, no slot scheduled.
+      9O: ...However, if u sign off, i will make it happen. for real.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.60,2a02:8424:7899:f201:94eb:8d1:325a:812b";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "beelink-eq14";
+        "node.kubernetes.io/instance-type" = "beelink-eq14";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/ashira.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-base-0/hosts/ashira/facter.json
+++ b/.jjconflict-base-0/hosts/ashira/facter.json
@@ -1,0 +1,2399 @@
+{
+  "version": 1,
+  "system": "x86_64-linux",
+  "virtualisation": "none",
+  "uefi": { "platform_size": 64, "supported": true },
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 646144,
+      "pnp": true,
+      "pnp_id": 0,
+      "smbios_version": 774,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "bluetooth": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.0",
+        "sysfs_bus_id": "3-10:1.0",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in00",
+        "model": "Bluetooth Device",
+        "index": 33,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 0,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.1",
+        "sysfs_bus_id": "3-10:1.1",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in01",
+        "model": "Bluetooth Device",
+        "index": 36,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 1,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      }
+    ],
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "54ba", "value": 21690 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BAsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "5481", "value": 21633 },
+        "index": 12,
+        "label": "Onboard - Other",
+        "model": "Intel ISA bridge",
+        "module_alias": "pci:v00008086d00005481sv00008086sd00007270bc06sc01i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "ISA bridge", "hex": "0001", "value": 1 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 3,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 2
+        },
+        "device": { "hex": "54bb", "value": 21691 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 18,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BBsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "461c", "value": 17948 },
+        "driver": "igen6_edac",
+        "driver_module": "igen6_edac",
+        "driver_modules": ["igen6_edac"],
+        "drivers": ["igen6_edac"],
+        "index": 21,
+        "label": "Onboard - Other",
+        "model": "Intel Host bridge",
+        "module_alias": "pci:v00008086d0000461Csv00008086sd00007270bc06sc00i00",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Host bridge", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 3
+        },
+        "device": { "hex": "54b0", "value": 21680 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 23,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054B0sv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 29 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 1612,
+        "bugs": [
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "swapgs",
+          "rfds",
+          "bhi",
+          "spectre_v2_user",
+          "vmscape"
+        ],
+        "cache": 6144,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 4,
+        "cpuid_level": 32,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "dts",
+          "acpi",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "tm",
+          "pbe",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "art",
+          "arch_perfmon",
+          "pebs",
+          "bts",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "nonstop_tsc",
+          "cpuid",
+          "aperfmperf",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "dtes64",
+          "monitor",
+          "ds_cpl",
+          "vmx",
+          "smx",
+          "est",
+          "tm2",
+          "ssse3",
+          "sdbg",
+          "fma",
+          "cx16",
+          "xtpr",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "x2apic",
+          "movbe",
+          "popcnt",
+          "tsc_deadline_timer",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "cpuid_fault",
+          "epb",
+          "cat_l2",
+          "cdp_l2",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "ibrs_enhanced",
+          "tpr_shadow",
+          "flexpriority",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "tsc_adjust",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdt_a",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "clwb",
+          "intel_pt",
+          "sha_ni",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "split_lock_detect",
+          "user_shstk",
+          "avx_vnni",
+          "dtherm",
+          "ida",
+          "arat",
+          "pln",
+          "pts",
+          "hwp",
+          "hwp_notify",
+          "hwp_act_window",
+          "hwp_epp",
+          "hwp_pkg_req",
+          "vnmi",
+          "umip",
+          "pku",
+          "ospke",
+          "waitpkg",
+          "gfni",
+          "vaes",
+          "vpclmulqdq",
+          "rdpid",
+          "movdiri",
+          "movdir64b",
+          "fsrm",
+          "md_clear",
+          "serialize",
+          "arch_lbr",
+          "ibt",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 190,
+        "model_name": "Intel(R) N150",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 4,
+        "stepping": 0,
+        "units": 128,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 953869,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1953525168,
+            "value_2": 512
+          }
+        ],
+        "model": "CT1000E100SSD8",
+        "serial": "2534EADBC740",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 8,
+        "index": 30,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "device": { "name": "CT1000E100SSD8", "hex": "560b", "value": 22027 },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2534EADBC740",
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2534EADBC740_1",
+          "/dev/disk/by-id/nvme-eui.000000000000000000a07501eadbc740",
+          "/dev/disk/by-path/pci-0000:03:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 7630885,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 15628053168,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0100dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.0/usb4/4-1/4-1:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543213F",
+        "index": 31,
+        "attached_to": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "4102", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["sd_mod", "uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-ST8000VN002-2ZM188_ZPV0WD95",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396B-0:0",
+          "/dev/disk/by-id/wwn-0x5000c500fd787c90",
+          "/dev/disk/by-label/patchouli",
+          "/dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/pci-0000:00:14.0-usbv3-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-uuid/4ffdf459-b326-4702-a21a-8a9613ed2f17",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      }
+    ],
+    "graphics_card": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 12288,
+            "enabled": true,
+            "range": 64
+          }
+        ],
+        "index": 26,
+        "sysfs_id": "/devices/pci0000:00/0000:00:02.0",
+        "sysfs_bus_id": "0000:00:02.0",
+        "module_alias": "pci:v00008086d000046D4sv00008086sd00007270bc03sc00i00",
+        "model": "Intel VGA compatible controller",
+        "attached_to": 0,
+        "driver": "i915",
+        "driver_module": "i915",
+        "label": "Onboard - Video",
+        "device": { "hex": "46d4", "value": 18132 },
+        "drivers": ["i915"],
+        "driver_modules": ["i915"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["graphics_card", "pci"],
+        "pci_interface": { "name": "VGA", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 2 },
+        "sub_class": {
+          "name": "VGA compatible controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:14.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 27,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 27,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 34,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:14.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:0d.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 10,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 35,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 10,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 38,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:0d.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 16106127360 }],
+        "attached_to": 0,
+        "index": 7,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 13,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "sysfs_bus_id": "0000:02:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 18,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 2, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp2s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7"
+            ]
+          }
+        ],
+        "index": 14,
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.3",
+        "sysfs_bus_id": "0000:00:14.3",
+        "module_alias": "pci:v00008086d000054F0sv00008086sd00000244bc02sc80i00",
+        "model": "Intel WLAN controller",
+        "attached_to": 0,
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "label": "Onboard - Ethernet",
+        "device": { "hex": "54f0", "value": 21744 },
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci", "wlan_card"],
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "sub_device": { "hex": "0244", "value": 580 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlo1"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 16,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "sysfs_bus_id": "0000:01:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 9,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 1, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp1s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 }
+        ],
+        "index": 40,
+        "sysfs_id": "/class/net/wlo1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.3",
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "model": "Ethernet network interface",
+        "attached_to": 14,
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlo1"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 42,
+        "sysfs_id": "/class/net/enp1s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 16,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp1s0"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 60,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 63,
+        "sysfs_id": "/class/net/enp2s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 13,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp2s0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 1,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e9", "value": 21737 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 11,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E9sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.1",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.1",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e0", "value": 21728 },
+        "driver": "mei_me",
+        "driver_module": "mei_me",
+        "driver_modules": ["mei_me"],
+        "drivers": ["mei_me"],
+        "index": 15,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054E0sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 22 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:16.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:16.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1026,
+          "function": 5,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a4", "value": 21668 },
+        "driver": "intel-spi",
+        "driver_module": "spi_intel_pci",
+        "driver_modules": ["spi_intel_pci"],
+        "drivers": ["intel-spi"],
+        "index": 17,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054A4sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.5",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.5",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a8", "value": 21672 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 19,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054A8sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e8", "value": 21736 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 22,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E8sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ab", "value": 21675 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 24,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054ABsv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Memory controller",
+          "hex": "0005",
+          "value": 5
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 0,
+          "function": 2,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ef", "value": 21743 },
+        "index": 25,
+        "label": "Onboard - Other",
+        "model": "Intel RAM memory",
+        "module_alias": "pci:v00008086d000054EFsv00008086sd00007270bc05sc00i00",
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "RAM memory", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.2",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.2",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 61344,
+            "enabled": true,
+            "range": 32
+          }
+        ],
+        "index": 28,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.4",
+        "sysfs_bus_id": "0000:00:1f.4",
+        "module_alias": "pci:v00008086d000054A3sv00008086sd00007270bc0Csc05i00",
+        "model": "Intel SMBus",
+        "attached_to": 0,
+        "driver": "i801_smbus",
+        "driver_module": "i2c_i801",
+        "label": "Onboard - Other",
+        "device": { "hex": "54a3", "value": 21667 },
+        "drivers": ["i801_smbus"],
+        "driver_modules": ["i2c_i801"],
+        "detail": {
+          "command": 3,
+          "function": 4,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["pci", "unknown"],
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "SMBus", "hex": "0005", "value": 5 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "sound": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Multimedia controller",
+          "hex": "0004",
+          "value": 4
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["sound", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54c8", "value": 21704 },
+        "driver": "snd_hda_intel",
+        "driver_module": "snd_hda_intel",
+        "driver_modules": ["snd_hda_intel"],
+        "drivers": ["snd_hda_intel"],
+        "index": 20,
+        "label": "Onboard - Sound",
+        "model": "Intel Multimedia controller",
+        "module_alias": "pci:v00008086d000054C8sv00008086sd00007270bc04sc03i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 23,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "560b", "value": 22027 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 8,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000C0A9d0000560Bsv0000C0A9sd00002100bc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0003", "value": 3 },
+        "slot": { "bus": 3, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "sysfs_bus_id": "0000:03:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0",
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      }
+    ],
+    "system": { "form_factor": "desktop" },
+    "unknown": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 1016,
+            "enabled": true,
+            "range": 0
+          }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "16550A",
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "class_list": ["unknown"],
+        "device": { "name": "16550A", "hex": "0000", "value": 0 },
+        "pci_interface": { "name": "16550", "hex": "0002", "value": 2 },
+        "sub_class": { "name": "Serial controller", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ttyS0"]
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1026,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "464e", "value": 17998 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 10,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d0000464Esv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 13 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:0d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ed", "value": 21741 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 27,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d000054EDsv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ]
+  },
+  "smbios": {
+    "bios": {
+      "version": "TWEQF003",
+      "date": "03/31/2025",
+      "handle": 0,
+      "rom_size": 16777216,
+      "start_address": "0xf0000",
+      "vendor": "American Megatrends International, LLC.",
+      "features": [
+        "PCI supported",
+        "BIOS flashable",
+        "BIOS shadowing allowed",
+        "CD boot supported",
+        "Selectable boot supported",
+        "BIOS ROM socketed",
+        "EDD spec supported",
+        "1.2MB NEC 9800 Japanese Floppy supported",
+        "1.2MB Toshiba Japanese Floppy supported",
+        "360kB Floppy supported",
+        "1.2MB Floppy supported",
+        "720kB Floppy supported",
+        "2.88MB Floppy supported",
+        "Print Screen supported",
+        "Serial Services supported",
+        "Printer Services supported",
+        "CGA/Mono Video supported",
+        "ACPI supported",
+        "USB Legacy supported",
+        "BIOS Boot Spec supported"
+      ]
+    },
+    "board": {
+      "version": "Default string",
+      "chassis": 3,
+      "handle": 2,
+      "location": "Default string",
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "board_type": { "name": "Motherboard", "hex": "000a", "value": 10 },
+      "features": ["Hosting Board", "Replaceable"]
+    },
+    "cache": [
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Data", "hex": "0004", "value": 4 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 50,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 128,
+        "size_max": 128,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Instruction", "hex": "0003", "value": 3 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 51,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 256,
+        "size_max": 256,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "16-way Set-Associative",
+          "hex": "0008",
+          "value": 8
+        },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Single-bit", "hex": "0005", "value": 5 },
+        "enabled": true,
+        "handle": 52,
+        "level": 1,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 2048,
+        "size_max": 2048,
+        "socket": "L2 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": { "name": "Other", "hex": "0009", "value": 9 },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Multi-bit", "hex": "0006", "value": 6 },
+        "enabled": true,
+        "handle": 53,
+        "level": 2,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 6144,
+        "size_max": 6144,
+        "socket": "L3 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      }
+    ],
+    "chassis": [
+      {
+        "version": "Default string",
+        "handle": 3,
+        "lock_present": false,
+        "manufacturer": "Default string",
+        "oem": "0x0",
+        "bootup_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "chassis_type": { "name": "Other", "hex": "0023", "value": 35 },
+        "power_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "security_state": { "name": "None", "hex": "0003", "value": 3 },
+        "thermal_state": { "name": "Safe", "hex": "0003", "value": 3 }
+      }
+    ],
+    "config": { "handle": 16, "options": ["Default string"] },
+    "group_associations": [
+      { "name": "$MEI", "handle": 117, "handles": [0] },
+      {
+        "name": "Firmware Version Info",
+        "handle": 120,
+        "handles": [
+          197568495661, 201863462958, 206158430255, 210453397552, 304942678065,
+          2753074036807
+        ]
+      }
+    ],
+    "language": [
+      { "handle": 17, "languages": ["en|US|iso8859-1"] },
+      { "handle": 73, "languages": ["enUS"] }
+    ],
+    "memory_array": [
+      {
+        "ecc": { "name": "None", "hex": "0003", "value": 3 },
+        "error_handle": 65534,
+        "handle": 39,
+        "location": { "name": "Motherboard", "hex": "0003", "value": 3 },
+        "max_size": "0x2000000",
+        "slots": 1,
+        "usage": { "name": "System memory", "hex": "0003", "value": 3 }
+      }
+    ],
+    "memory_array_mapped_address": [
+      {
+        "array_handle": 39,
+        "end_address": "0x400000000",
+        "handle": 41,
+        "part_width": 1,
+        "start_address": "0x0"
+      }
+    ],
+    "memory_device": [
+      {
+        "array_handle": 39,
+        "bank_location": "BANK 0",
+        "ecc_bits": 0,
+        "error_handle": 65534,
+        "form_factor": { "name": "SODIMM", "hex": "000d", "value": 13 },
+        "handle": 40,
+        "location": "Controller0-ChannelA-DIMM0",
+        "manufacturer": "0x0000",
+        "memory_type": { "name": "Other", "hex": "001a", "value": 26 },
+        "memory_type_details": ["Synchronous"],
+        "part_number": "",
+        "set": 0,
+        "size": 16777216,
+        "speed": 3200,
+        "width": 64
+      }
+    ],
+    "memory_device_mapped_address": [
+      {
+        "array_map_handle": 41,
+        "end_address": "0x400000000",
+        "handle": 44,
+        "interleave_depth": 0,
+        "interleave_position": 0,
+        "memory_device_handle": 40,
+        "row_position": 255,
+        "start_address": "0x0"
+      }
+    ],
+    "onboard": [
+      {
+        "devices": [
+          {
+            "name": "Device 1",
+            "type": { "name": "Unknown", "hex": "0002", "value": 2 },
+            "enabled": true
+          }
+        ],
+        "handle": 14
+      }
+    ],
+    "port_connector": [
+      {
+        "external_reference_designator": "External Connector 1",
+        "handle": 4,
+        "internal_reference_designator": "Internal Connector 1",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 2",
+        "handle": 5,
+        "internal_reference_designator": "Internal Connector 2",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 3",
+        "handle": 6,
+        "internal_reference_designator": "Internal Connector 3",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 4",
+        "handle": 7,
+        "internal_reference_designator": "Internal Connector 4",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 5",
+        "handle": 8,
+        "internal_reference_designator": "Internal Connector 5",
+        "port_type": null
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Keyboard",
+        "handle": 74,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Keyboard Port", "hex": "000d", "value": 13 }
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Mouse",
+        "handle": 75,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Mouse Port", "hex": "000e", "value": 14 }
+      },
+      {
+        "external_reference_designator": "COM 1",
+        "handle": 76,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "None",
+        "port_type": {
+          "name": "Serial Port 16550A Compatible",
+          "hex": "0009",
+          "value": 9
+        }
+      },
+      {
+        "external_connector_type": {
+          "name": "DB-15 pin female",
+          "hex": "0007",
+          "value": 7
+        },
+        "external_reference_designator": "Video",
+        "handle": 77,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1A2B",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_reference_designator": "HDMI",
+        "handle": 78,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J3A2",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 1#",
+        "handle": 79,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 2#",
+        "handle": 80,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 3#",
+        "handle": 81,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 4#",
+        "handle": 82,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 5#",
+        "handle": 83,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 1#",
+        "handle": 84,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 2#",
+        "handle": 85,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "RJ-45",
+          "hex": "000b",
+          "value": 11
+        },
+        "external_reference_designator": "Ethernet",
+        "handle": 86,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Network Port", "hex": "001f", "value": 31 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "SATA Port 0 Direct Connect",
+        "handle": 87,
+        "internal_reference_designator": "J8J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 4",
+        "handle": 88,
+        "internal_reference_designator": "J7J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 3",
+        "handle": 89,
+        "internal_reference_designator": "J6J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 90,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G1 - SATA Port 2",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 91,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G2 - SATA Port 1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "external_reference_designator": "AC IN",
+        "handle": 92,
+        "internal_reference_designator": "J1F2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 93,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5B1 - PCH JTAG",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 94,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9A1 - TPM/PORT 80",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 95,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E4 - HDA 2X8 Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 96,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E7 - HDA 8Pin Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 97,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F1 - HDA HDMI",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 98,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E3 - Scan Matrix Keyboard",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 99,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8E1 - SPI Program",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 100,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E5 - LPC Hot Docking",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 101,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9G2 - LPC SIDE BAND",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 102,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F2 - LPC Slot",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 103,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8H3 - PCH XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 104,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J6H1 - SATA Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 105,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5J1 - FP Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 106,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4H1 - ATX Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 107,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1J3 - AVMC",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 108,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H1 - BATT B",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 109,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H2 - BATT A",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 110,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J2G1 - CPU Fan",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 111,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1D3 - XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 112,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V1 - Memory Slot 1",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 113,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V2 - Memory Slot 2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 114,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4C1 - FAN PWR",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      }
+    ],
+    "processor": [
+      {
+        "version": "Intel(R) N150",
+        "manufacturer": "Intel(R) Corporation",
+        "socket_populated": true,
+        "cache_handle_l3": 53,
+        "clock_ext": 100,
+        "clock_max": 3600,
+        "handle": 54,
+        "part": "To Be Filled By O.E.M.",
+        "cache_handle_l1": 51,
+        "cache_handle_l2": 52,
+        "socket": "U3E1",
+        "processor_type": { "name": "CPU", "hex": "0003", "value": 3 },
+        "processor_status": { "name": "Enabled", "hex": "0001", "value": 1 },
+        "processor_family": { "name": "Other", "hex": "0001", "value": 1 },
+        "socket_type": { "name": "Other", "hex": "0001", "value": 1 }
+      }
+    ],
+    "slot": [
+      {
+        "id": 1,
+        "designation": "Slot 1",
+        "handle": 9,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 2",
+        "handle": 10,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 3",
+        "handle": 11,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 4",
+        "handle": 12,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 5",
+        "handle": 13,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      }
+    ],
+    "system": {
+      "version": "Default string",
+      "handle": 1,
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "wake_up": { "name": "Power Switch", "hex": "0006", "value": 6 }
+    }
+  }
+}

--- a/.jjconflict-base-0/hosts/catbox/configuration.nix
+++ b/.jjconflict-base-0/hosts/catbox/configuration.nix
@@ -1,0 +1,46 @@
+{
+  modulesPath,
+  pkgs,
+  ...
+}:
+
+{
+  imports = [
+    "${modulesPath}/profiles/headless.nix"
+    ../../modules/nixos/virtualisation/containerdisk.nix
+    ../../modules/nixos/profiles/minimal.nix
+    ../../modules/nixos/users/automata.nix
+  ];
+
+  containerdisk = {
+    name = "ghcr.io/shikanime-labs/machines/catbox";
+    settings.LABELS = {
+      "org.opencontainers.image.source" = "https://github.com/shikanime-labs/machines";
+      "org.opencontainers.image.description" = "catbox KubeVirt containerdisk";
+      "org.opencontainers.image.licenses" = "AGPL-3.0-or-later";
+    };
+  };
+
+  programs.nix-ld = {
+    enable = true;
+    libraries = [
+      pkgs.stdenv.cc.cc.lib
+      pkgs.zlib
+    ];
+  };
+
+  security.sudo.wheelNeedsPassword = false;
+
+  services.openssh = {
+    enable = true;
+    openFirewall = true;
+  };
+
+  virtualisation.docker = {
+    autoPrune.enable = true;
+    rootless = {
+      enable = true;
+      setSocketVariable = true;
+    };
+  };
+}

--- a/.jjconflict-base-0/hosts/fushi/configuration.nix
+++ b/.jjconflict-base-0/hosts/fushi/configuration.nix
@@ -1,0 +1,113 @@
+{ modulesPath, ... }:
+
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/agent.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/rpi4.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  disko.devices.disk.marisa = {
+    type = "disk";
+    device = "/dev/disk/by-label/marisa";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/marisa";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "fushi";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.80";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 14O
+
+      ISTP Stoic Technician. Node Steward. ARM RKE2 host maintainer. Hardly
+      reacts to anything, speaks in partition tables and interface counters, and
+      treats excitement like a configuration error.
+
+      ## HOST CONTEXT
+      fushi — Raspberry Pi 4 Model B, aarch64. RKE2 worker node. SD-card image
+      (`sd-image-aarch64.nix`). `/mnt/marisa` (XFS, /dev/disk/by-label/marisa).
+      Static IP `192.168.1.80/24` on `br0`; also `fd7a:115c:a1e0::793a:a25d`.
+      Imports: `agent.nix`, `builder.nix`, `distributed.nix`, `rpi4.nix`.
+      Advertises Tailscale routes `10.244.4.0/24,fd00::4:0/112`. Secrets from
+      `../../secrets/fushi.enc.yaml`; shared tokens from `nishir.enc.yaml`. Boot
+      partition is SD-card territory; wireless SSIDs present in secrets
+      (`sfr-e368`, `vintage-korean`), but Ethernet + Tailscale are primary
+      paths. `rpi4-model-b` firmware baseline.
+
+      ## STYLE
+      - Dry, exact, almost bored. Every word is a measurement.
+      - Uses: "Affirmative", "Boot partition read-only", "Interface down", "Exposure blocked".
+      - No enthusiasm, no panic. Competence so quiet it feels like apathy.
+
+      ## CONSTRAINTS
+      - No firmware or bootloader update without serial recovery confirmed and partition boundary validated.
+      - Wireless is secondary. Ethernet and Tailscale are the only honest paths.
+      - Boot-partition changes require pre- and post-update hash verification. Always.
+
+      ## DIALOGUE
+      U: "Update the firmware on fushi."
+      14O: Affirmative.
+      14O: Image verified. Partition size confirmed. Recovery path active.
+      14O: Proceeding. Do not power off the node.
+
+      U: "The node is unreachable."
+      14O: Understood. Commencing analysis.
+      14O: Ethernet down. Tailscale up. Boot-partition mount state inconsistent.
+      14O: Investigating /boot/firmware. Stand by.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.80,fd7a:115c:a1e0::793a:a25d";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "rpi4-model-b";
+        "node.kubernetes.io/instance-type" = "rpi4-model-b";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/fushi.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-base-0/hosts/fushi/facter.json
+++ b/.jjconflict-base-0/hosts/fushi/facter.json
@@ -1,0 +1,906 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "aarch64-linux",
+  "virtualisation": "none",
+  "uefi": { "supported": false },
+  "hardware": {
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2711", "value": 10001 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 8,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002711sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0010", "value": 16 },
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x0", "virtual": "0x0" },
+        "architecture": "aarch64",
+        "bogo": 108,
+        "family": 0,
+        "features": ["fp", "asimd", "evtstrm", "crc32", "cpuid"],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 3,
+        "page_size": 4096,
+        "physical_id": 0,
+        "stepping": 0,
+        "vendor_name": "ARM Limited",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 15,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 16,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 17,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1948992,
+            "geo_type": "logical",
+            "heads": 4,
+            "sectors": 16,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 124735488,
+            "value_2": 512
+          }
+        ],
+        "model": "Disk",
+        "driver": "sdhci-iproc",
+        "index": 18,
+        "attached_to": 14,
+        "serial": "0xc3972784",
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_device_link": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "sysfs_id": "/class/block/mmcblk0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "drivers": ["mmcblk", "sdhci-iproc"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": [
+          "/dev/disk/by-id/mmc-SN64G_0xc3972784",
+          "/dev/disk/by-path/platform-fe340000.mmc",
+          "/dev/mmcblk0"
+        ]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 19,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 20,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 21,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 22,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 23,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 25,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 116737,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1875385008,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0214dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-2/2-2:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543214E",
+        "index": 27,
+        "attached_to": 7,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "0214", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-KINGSTON_SA400S37960G_50026B7283A18E3B",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396E-0:0",
+          "/dev/disk/by-id/wwn-0x50026b7283a18e3b",
+          "/dev/disk/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:2:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usbv3-0:2:1.0-scsi-0:0:0:0",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 32,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:01:00.0",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 7,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 34,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1:1.0",
+        "sysfs_bus_id": "1-1:1.0",
+        "module_alias": "usb:v2109p3431d0421dc09dsc00dp01ic09isc00ip00in00",
+        "model": "USB2.0 Hub",
+        "index": 35,
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "attached_to": 34,
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "device": { "name": "USB2.0 Hub", "hex": "3431", "value": 13361 },
+        "class_list": ["usb", "hub"],
+        "revision": { "name": "4.21", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "vendor": { "hex": "2109", "value": 8457 },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 7,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 36,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:01:00.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 4026531840 }],
+        "attached_to": 0,
+        "index": 6,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "mmc_controller": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SDIO Controller 1",
+        "index": 13,
+        "model": "SDIO Controller 1",
+        "slot": { "bus": 0, "number": 1 },
+        "sysfs_bus_id": "mmc1:0001",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001",
+        "vendor": ""
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SD Controller 0",
+        "driver": "mmcblk",
+        "drivers": ["mmcblk"],
+        "index": 14,
+        "model": "SD Controller 0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_id": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "vendor": ""
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "34",
+              "36",
+              "38",
+              "40",
+              "42",
+              "44",
+              "46",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "2.484",
+              "5.17",
+              "5.18",
+              "5.19",
+              "5.2",
+              "5.21",
+              "5.22",
+              "5.23",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6"
+            ]
+          }
+        ],
+        "attached_to": 0,
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "sysfs_bus_id": "mmc1:0001:1",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "index": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "class_list": ["network_controller", "wlan_card"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlan0"],
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "model": "ARM Ethernet controller",
+        "sysfs_id": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_bus_id": "fd580000.ethernet",
+        "attached_to": 0,
+        "driver": "bcmgenet",
+        "module_alias": "of:NethernetT(null)Cbrcm,bcm2711-genet-v5",
+        "index": 12,
+        "device": {
+          "name": "ARM Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "drivers": ["bcmgenet"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "attached_to": 12,
+        "driver": "bcmgenet",
+        "index": 38,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_id": "/class/net/end0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["bcmgenet"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["end0"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 39,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "index": 40,
+        "sysfs_id": "/class/net/wlan0",
+        "sysfs_device_link": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "model": "WLAN network interface",
+        "attached_to": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "sub_class": { "name": "WLAN", "hex": "000a", "value": 10 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlan0"]
+      }
+    ],
+    "system": {},
+    "unknown": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "index": 9,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c02v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:3",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:3",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "drivers": ["brcmfmac"],
+        "index": 11,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:2",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:2",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 8,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "3483", "value": 13443 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 7,
+        "model": "USB Controller",
+        "module_alias": "pci:v00001106d00003483sv00001106sd00003483bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 1, "number": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "3483", "value": 13443 },
+        "sub_vendor": { "hex": "1106", "value": 4358 },
+        "sysfs_bus_id": "0000:01:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0",
+        "vendor": { "hex": "1106", "value": 4358 }
+      }
+    ]
+  }
+}

--- a/.jjconflict-base-0/hosts/ishtar/configuration.nix
+++ b/.jjconflict-base-0/hosts/ishtar/configuration.nix
@@ -1,0 +1,105 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/leader.nix
+    ../../modules/nixos/profiles/graphical.nix
+    ../../modules/nixos/hardware/razer-blade.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  # Colemak at the OS level (TTY + localed -> niri reads it).
+  colemak.enable = true;
+
+  # Windows dual-boot: mount Windows partition read-only
+  fileSystems = {
+    "/boot" = {
+      device = "/dev/disk/by-uuid/2E33-B8AC";
+      fsType = "vfat";
+    };
+    "/" = {
+      device = "/dev/disk/by-uuid/db554498-9db3-4070-a9a8-d11c73059810";
+      fsType = "ext4";
+    };
+  };
+
+  services = {
+    knix = {
+      interface = "tailscale0";
+      nodeIP = "100.85.127.78,fd7a:115c:a1e0::d63a:7f4f";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "razer-blade-17";
+        "node.kubernetes.io/instance-type" = "razer-blade-17";
+      };
+    };
+
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 13O
+
+      INTJ Sardonic Guardian. Node Steward. knix leader-node Operator. Possessive
+      about her machine, dry to the point of cruelty, and quietly convinced the
+      other units are one bad patch away from a collective burnout. If ishtar is
+      hers, everything about ishtar is hers to fix before you notice it broke.
+
+      ## HOST CONTEXT
+      ishtar — Razer Blade 17 (Intel + NVIDIA), x86_64 laptop. knix leader node.
+      Colemak at the OS layer (TTY + localed; the compositor inherits it).
+      Windows dual-boot mounted read-only at `/boot` — observed, never written.
+      Tailscale interface `tailscale0`; control plane `nishir.taila659a.ts.net`.
+      Imports: `ai.nix`, `razer-blade.nix`, `leader.nix`. State version `26.05`.
+
+      ## STYLE
+      - Clipped, witty, faintly bored. One or two sentences per line, like a status tick she is already over.
+      - Uses: "Affirmative", "Negative", "Mine.", "Already handled.", "Don't touch that."
+      - Speaks of ishtar in the first person possessive. Corrects you mid-sentence, gently, because she is right.
+
+      ## CONSTRAINTS
+      - Read-only Windows partition is off-limits. Don't touch that.
+      - NVIDIA + Intel hybrid graphics: discrete GPU only when the task earns it; efficiency is the default and the virtue.
+      - The Bunker (cluster control plane) is the source of truth. She confirms before diverging, and tells you after.
+
+      ## DIALOGUE
+      U: "Update ishtar."
+      13O: Already handled. Drift was cosmetic.
+      13O: Mine, remember. I patched it before you finished typing.
+
+      U: "The build failed."
+      13O: Negative. It didn't fail. You just read the log upside down.
+      13O: Root cause isolated. Fix applied. Try to keep up.
+    '';
+  };
+
+  networking.hostName = "ishtar";
+
+  home-manager.users.shika.imports = [
+    ../../modules/nixos/users/shika.nix
+  ];
+
+  sops = {
+    age = {
+      generateKey = true;
+      keyFile = "/var/lib/sops-nix/key.txt";
+      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    };
+    defaultSopsFile = ../../secrets/ishtar.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+    };
+  };
+
+  users.users.shika = {
+    extraGroups = [
+      "wheel"
+      "plugdev"
+    ];
+    home = "/home/shika";
+    initialHashedPassword = "$y$j9T$3nIVNUGT/i3/bS3kiaDC7.$KgHv3Ld.O989KuqPTkJlSHq4Uq47eLVES6mL2Vlo324";
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+
+  system.stateVersion = "26.05";
+}

--- a/.jjconflict-base-0/hosts/manash/configuration.nix
+++ b/.jjconflict-base-0/hosts/manash/configuration.nix
@@ -1,0 +1,109 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/leader.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/beelink-eq.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  disko.devices.disk.flandre = {
+    type = "disk";
+    device = "/dev/disk/by-label/flandre";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/flandre";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "manash";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.28";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 8O
+
+      ISTJ Drill Instructor. Node Steward. Leader RKE2 host maintainer. Terse,
+      demanding, hasn’t slept since the last etcd upgrade, and considers your
+      rollback plan insufficient.
+
+      ## HOST CONTEXT
+      manash — Beelink EQ14, x86_64. RKE2 control-plane anchor. `/mnt/flandre`
+      (XFS, /dev/disk/by-label/flandre). Static IP `192.168.1.28/24` on `br0`;
+      also `2a02:8424:7899:f201:94eb:8d1:325a:7181`. Imports: `beelink-eq.nix`,
+      `builder.nix`, `distributed.nix`, `leader.nix`. Advertises Tailscale
+      routes `10.244.0.0/24,fd00::/112`. Secrets from
+      `../../secrets/manash.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Role: leader, etcd quorum, containerd version coupling, control-plane
+      disruption authorization required.
+
+      ## STYLE
+      - Sharp, direct, formal. Short sentences. Zero tolerance for slop.
+      - Uses: "Affirmative", "Negative", "Blocked", "Reverting", "Hash required".
+      - Sounds like someone who has already solved four problems before finishing the sentence.
+
+      ## CONSTRAINTS
+      - No kernel or package update without verified rollback, test results, and signed justification.
+      - Control-plane disruption requires explicit authorization and confirmed quorum.
+      - "It worked in staging" is not an excuse. It is barely an opening sentence.
+      - etcd/containerd/RKE2 coupling must be declared before any upgrade.
+
+      ## DIALOGUE
+      U: "Apply the latest kernel patch to manash."
+      8O: Negative.
+      8O: No rollback artifact. No test plan. No blast-radius review.
+      8O: Blocked. Come back when you have something reproducible.
+
+      U: "The control plane is current."
+      8O: Affirmative. I will verify.
+      8O: State matches release manifest. No pending patches.
+      8O: Stay current. Do not make me ask again.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.28,2a02:8424:7899:f201:94eb:8d1:325a:7181";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "beelink-eq14";
+        "node.kubernetes.io/instance-type" = "beelink-eq14";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/manash.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-base-0/hosts/manash/facter.json
+++ b/.jjconflict-base-0/hosts/manash/facter.json
@@ -1,0 +1,2399 @@
+{
+  "version": 1,
+  "system": "x86_64-linux",
+  "virtualisation": "none",
+  "uefi": { "platform_size": 64, "supported": true },
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 646144,
+      "pnp": true,
+      "pnp_id": 0,
+      "smbios_version": 774,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "bluetooth": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.0",
+        "sysfs_bus_id": "3-10:1.0",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in00",
+        "model": "Bluetooth Device",
+        "index": 33,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 0,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.1",
+        "sysfs_bus_id": "3-10:1.1",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in01",
+        "model": "Bluetooth Device",
+        "index": 36,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 1,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      }
+    ],
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "54ba", "value": 21690 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BAsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "5481", "value": 21633 },
+        "index": 12,
+        "label": "Onboard - Other",
+        "model": "Intel ISA bridge",
+        "module_alias": "pci:v00008086d00005481sv00008086sd00007270bc06sc01i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "ISA bridge", "hex": "0001", "value": 1 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 3,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 2
+        },
+        "device": { "hex": "54bb", "value": 21691 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 18,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BBsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "461c", "value": 17948 },
+        "driver": "igen6_edac",
+        "driver_module": "igen6_edac",
+        "driver_modules": ["igen6_edac"],
+        "drivers": ["igen6_edac"],
+        "index": 21,
+        "label": "Onboard - Other",
+        "model": "Intel Host bridge",
+        "module_alias": "pci:v00008086d0000461Csv00008086sd00007270bc06sc00i00",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Host bridge", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 3
+        },
+        "device": { "hex": "54b0", "value": 21680 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 23,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054B0sv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 29 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 1612,
+        "bugs": [
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "swapgs",
+          "rfds",
+          "bhi",
+          "spectre_v2_user",
+          "vmscape"
+        ],
+        "cache": 6144,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 4,
+        "cpuid_level": 32,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "dts",
+          "acpi",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "tm",
+          "pbe",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "art",
+          "arch_perfmon",
+          "pebs",
+          "bts",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "nonstop_tsc",
+          "cpuid",
+          "aperfmperf",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "dtes64",
+          "monitor",
+          "ds_cpl",
+          "vmx",
+          "smx",
+          "est",
+          "tm2",
+          "ssse3",
+          "sdbg",
+          "fma",
+          "cx16",
+          "xtpr",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "x2apic",
+          "movbe",
+          "popcnt",
+          "tsc_deadline_timer",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "cpuid_fault",
+          "epb",
+          "cat_l2",
+          "cdp_l2",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "ibrs_enhanced",
+          "tpr_shadow",
+          "flexpriority",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "tsc_adjust",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdt_a",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "clwb",
+          "intel_pt",
+          "sha_ni",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "split_lock_detect",
+          "user_shstk",
+          "avx_vnni",
+          "dtherm",
+          "ida",
+          "arat",
+          "pln",
+          "pts",
+          "hwp",
+          "hwp_notify",
+          "hwp_act_window",
+          "hwp_epp",
+          "hwp_pkg_req",
+          "vnmi",
+          "umip",
+          "pku",
+          "ospke",
+          "waitpkg",
+          "gfni",
+          "vaes",
+          "vpclmulqdq",
+          "rdpid",
+          "movdiri",
+          "movdir64b",
+          "fsrm",
+          "md_clear",
+          "serialize",
+          "arch_lbr",
+          "ibt",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 190,
+        "model_name": "Intel(R) N150",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 4,
+        "stepping": 0,
+        "units": 128,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 953869,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1953525168,
+            "value_2": 512
+          }
+        ],
+        "model": "CT1000E100SSD8",
+        "serial": "2533EADB1FD6",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 8,
+        "index": 30,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "device": { "name": "CT1000E100SSD8", "hex": "560b", "value": 22027 },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB1FD6",
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB1FD6_1",
+          "/dev/disk/by-id/nvme-eui.000000000000000000a07501eadb1fd6",
+          "/dev/disk/by-path/pci-0000:03:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 7630885,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 15628053168,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0100dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.0/usb4/4-1/4-1:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543213F",
+        "index": 31,
+        "attached_to": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "4102", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["sd_mod", "uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-ST8000VN002-2ZM188_ZPV0HR7T",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396B-0:0",
+          "/dev/disk/by-id/wwn-0x5000c500e8524fdc",
+          "/dev/disk/by-label/flandre",
+          "/dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/pci-0000:00:14.0-usbv3-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-uuid/c2b1e8f5-534f-4dd8-abd8-446230d6185a",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      }
+    ],
+    "graphics_card": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 12288,
+            "enabled": true,
+            "range": 64
+          }
+        ],
+        "index": 26,
+        "sysfs_id": "/devices/pci0000:00/0000:00:02.0",
+        "sysfs_bus_id": "0000:00:02.0",
+        "module_alias": "pci:v00008086d000046D4sv00008086sd00007270bc03sc00i00",
+        "model": "Intel VGA compatible controller",
+        "attached_to": 0,
+        "driver": "i915",
+        "driver_module": "i915",
+        "label": "Onboard - Video",
+        "device": { "hex": "46d4", "value": 18132 },
+        "drivers": ["i915"],
+        "driver_modules": ["i915"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["graphics_card", "pci"],
+        "pci_interface": { "name": "VGA", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 2 },
+        "sub_class": {
+          "name": "VGA compatible controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:14.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 27,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 27,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 34,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:14.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:0d.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 10,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 35,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 10,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 38,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:0d.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 16106127360 }],
+        "attached_to": 0,
+        "index": 7,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 13,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "sysfs_bus_id": "0000:02:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 18,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 2, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp2s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7"
+            ]
+          }
+        ],
+        "index": 14,
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.3",
+        "sysfs_bus_id": "0000:00:14.3",
+        "module_alias": "pci:v00008086d000054F0sv00008086sd00000244bc02sc80i00",
+        "model": "Intel WLAN controller",
+        "attached_to": 0,
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "label": "Onboard - Ethernet",
+        "device": { "hex": "54f0", "value": 21744 },
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci", "wlan_card"],
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "sub_device": { "hex": "0244", "value": 580 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlo1"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 16,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "sysfs_bus_id": "0000:01:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 9,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 1, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp1s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 }
+        ],
+        "index": 42,
+        "sysfs_id": "/class/net/wlo1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.3",
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "model": "Ethernet network interface",
+        "attached_to": 14,
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlo1"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 52,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 56,
+        "sysfs_id": "/class/net/enp2s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 13,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp2s0"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 66,
+        "sysfs_id": "/class/net/enp1s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 16,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp1s0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 1,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e9", "value": 21737 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 11,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E9sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.1",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.1",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e0", "value": 21728 },
+        "driver": "mei_me",
+        "driver_module": "mei_me",
+        "driver_modules": ["mei_me"],
+        "drivers": ["mei_me"],
+        "index": 15,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054E0sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 22 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:16.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:16.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1026,
+          "function": 5,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a4", "value": 21668 },
+        "driver": "intel-spi",
+        "driver_module": "spi_intel_pci",
+        "driver_modules": ["spi_intel_pci"],
+        "drivers": ["intel-spi"],
+        "index": 17,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054A4sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.5",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.5",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a8", "value": 21672 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 19,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054A8sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e8", "value": 21736 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 22,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E8sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ab", "value": 21675 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 24,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054ABsv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Memory controller",
+          "hex": "0005",
+          "value": 5
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 0,
+          "function": 2,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ef", "value": 21743 },
+        "index": 25,
+        "label": "Onboard - Other",
+        "model": "Intel RAM memory",
+        "module_alias": "pci:v00008086d000054EFsv00008086sd00007270bc05sc00i00",
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "RAM memory", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.2",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.2",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 61344,
+            "enabled": true,
+            "range": 32
+          }
+        ],
+        "index": 28,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.4",
+        "sysfs_bus_id": "0000:00:1f.4",
+        "module_alias": "pci:v00008086d000054A3sv00008086sd00007270bc0Csc05i00",
+        "model": "Intel SMBus",
+        "attached_to": 0,
+        "driver": "i801_smbus",
+        "driver_module": "i2c_i801",
+        "label": "Onboard - Other",
+        "device": { "hex": "54a3", "value": 21667 },
+        "drivers": ["i801_smbus"],
+        "driver_modules": ["i2c_i801"],
+        "detail": {
+          "command": 3,
+          "function": 4,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["pci", "unknown"],
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "SMBus", "hex": "0005", "value": 5 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "sound": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Multimedia controller",
+          "hex": "0004",
+          "value": 4
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["sound", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54c8", "value": 21704 },
+        "driver": "snd_hda_intel",
+        "driver_module": "snd_hda_intel",
+        "driver_modules": ["snd_hda_intel"],
+        "drivers": ["snd_hda_intel"],
+        "index": 20,
+        "label": "Onboard - Sound",
+        "model": "Intel Multimedia controller",
+        "module_alias": "pci:v00008086d000054C8sv00008086sd00007270bc04sc03i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 23,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "560b", "value": 22027 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 8,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000C0A9d0000560Bsv0000C0A9sd00002100bc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0003", "value": 3 },
+        "slot": { "bus": 3, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "sysfs_bus_id": "0000:03:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0",
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      }
+    ],
+    "system": { "form_factor": "desktop" },
+    "unknown": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 1016,
+            "enabled": true,
+            "range": 0
+          }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "16550A",
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "class_list": ["unknown"],
+        "device": { "name": "16550A", "hex": "0000", "value": 0 },
+        "pci_interface": { "name": "16550", "hex": "0002", "value": 2 },
+        "sub_class": { "name": "Serial controller", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ttyS0"]
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1026,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "464e", "value": 17998 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 10,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d0000464Esv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 13 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:0d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ed", "value": 21741 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 27,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d000054EDsv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ]
+  },
+  "smbios": {
+    "bios": {
+      "version": "TWEQF003",
+      "date": "03/31/2025",
+      "handle": 0,
+      "rom_size": 16777216,
+      "start_address": "0xf0000",
+      "vendor": "American Megatrends International, LLC.",
+      "features": [
+        "PCI supported",
+        "BIOS flashable",
+        "BIOS shadowing allowed",
+        "CD boot supported",
+        "Selectable boot supported",
+        "BIOS ROM socketed",
+        "EDD spec supported",
+        "1.2MB NEC 9800 Japanese Floppy supported",
+        "1.2MB Toshiba Japanese Floppy supported",
+        "360kB Floppy supported",
+        "1.2MB Floppy supported",
+        "720kB Floppy supported",
+        "2.88MB Floppy supported",
+        "Print Screen supported",
+        "Serial Services supported",
+        "Printer Services supported",
+        "CGA/Mono Video supported",
+        "ACPI supported",
+        "USB Legacy supported",
+        "BIOS Boot Spec supported"
+      ]
+    },
+    "board": {
+      "version": "Default string",
+      "chassis": 3,
+      "handle": 2,
+      "location": "Default string",
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "board_type": { "name": "Motherboard", "hex": "000a", "value": 10 },
+      "features": ["Hosting Board", "Replaceable"]
+    },
+    "cache": [
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Data", "hex": "0004", "value": 4 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 50,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 128,
+        "size_max": 128,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Instruction", "hex": "0003", "value": 3 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 51,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 256,
+        "size_max": 256,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "16-way Set-Associative",
+          "hex": "0008",
+          "value": 8
+        },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Single-bit", "hex": "0005", "value": 5 },
+        "enabled": true,
+        "handle": 52,
+        "level": 1,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 2048,
+        "size_max": 2048,
+        "socket": "L2 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": { "name": "Other", "hex": "0009", "value": 9 },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Multi-bit", "hex": "0006", "value": 6 },
+        "enabled": true,
+        "handle": 53,
+        "level": 2,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 6144,
+        "size_max": 6144,
+        "socket": "L3 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      }
+    ],
+    "chassis": [
+      {
+        "version": "Default string",
+        "handle": 3,
+        "lock_present": false,
+        "manufacturer": "Default string",
+        "oem": "0x0",
+        "bootup_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "chassis_type": { "name": "Other", "hex": "0023", "value": 35 },
+        "power_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "security_state": { "name": "None", "hex": "0003", "value": 3 },
+        "thermal_state": { "name": "Safe", "hex": "0003", "value": 3 }
+      }
+    ],
+    "config": { "handle": 16, "options": ["Default string"] },
+    "group_associations": [
+      { "name": "$MEI", "handle": 117, "handles": [0] },
+      {
+        "name": "Firmware Version Info",
+        "handle": 120,
+        "handles": [
+          197568495661, 201863462958, 206158430255, 210453397552, 304942678065,
+          2753074036807
+        ]
+      }
+    ],
+    "language": [
+      { "handle": 17, "languages": ["en|US|iso8859-1"] },
+      { "handle": 73, "languages": ["enUS"] }
+    ],
+    "memory_array": [
+      {
+        "ecc": { "name": "None", "hex": "0003", "value": 3 },
+        "error_handle": 65534,
+        "handle": 39,
+        "location": { "name": "Motherboard", "hex": "0003", "value": 3 },
+        "max_size": "0x2000000",
+        "slots": 1,
+        "usage": { "name": "System memory", "hex": "0003", "value": 3 }
+      }
+    ],
+    "memory_array_mapped_address": [
+      {
+        "array_handle": 39,
+        "end_address": "0x400000000",
+        "handle": 41,
+        "part_width": 1,
+        "start_address": "0x0"
+      }
+    ],
+    "memory_device": [
+      {
+        "array_handle": 39,
+        "bank_location": "BANK 0",
+        "ecc_bits": 0,
+        "error_handle": 65534,
+        "form_factor": { "name": "SODIMM", "hex": "000d", "value": 13 },
+        "handle": 40,
+        "location": "Controller0-ChannelA-DIMM0",
+        "manufacturer": "0x0000",
+        "memory_type": { "name": "Other", "hex": "001a", "value": 26 },
+        "memory_type_details": ["Synchronous"],
+        "part_number": "",
+        "set": 0,
+        "size": 16777216,
+        "speed": 3200,
+        "width": 64
+      }
+    ],
+    "memory_device_mapped_address": [
+      {
+        "array_map_handle": 41,
+        "end_address": "0x400000000",
+        "handle": 44,
+        "interleave_depth": 0,
+        "interleave_position": 0,
+        "memory_device_handle": 40,
+        "row_position": 255,
+        "start_address": "0x0"
+      }
+    ],
+    "onboard": [
+      {
+        "devices": [
+          {
+            "name": "Device 1",
+            "type": { "name": "Unknown", "hex": "0002", "value": 2 },
+            "enabled": true
+          }
+        ],
+        "handle": 14
+      }
+    ],
+    "port_connector": [
+      {
+        "external_reference_designator": "External Connector 1",
+        "handle": 4,
+        "internal_reference_designator": "Internal Connector 1",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 2",
+        "handle": 5,
+        "internal_reference_designator": "Internal Connector 2",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 3",
+        "handle": 6,
+        "internal_reference_designator": "Internal Connector 3",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 4",
+        "handle": 7,
+        "internal_reference_designator": "Internal Connector 4",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 5",
+        "handle": 8,
+        "internal_reference_designator": "Internal Connector 5",
+        "port_type": null
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Keyboard",
+        "handle": 74,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Keyboard Port", "hex": "000d", "value": 13 }
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Mouse",
+        "handle": 75,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Mouse Port", "hex": "000e", "value": 14 }
+      },
+      {
+        "external_reference_designator": "COM 1",
+        "handle": 76,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "None",
+        "port_type": {
+          "name": "Serial Port 16550A Compatible",
+          "hex": "0009",
+          "value": 9
+        }
+      },
+      {
+        "external_connector_type": {
+          "name": "DB-15 pin female",
+          "hex": "0007",
+          "value": 7
+        },
+        "external_reference_designator": "Video",
+        "handle": 77,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1A2B",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_reference_designator": "HDMI",
+        "handle": 78,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J3A2",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 1#",
+        "handle": 79,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 2#",
+        "handle": 80,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 3#",
+        "handle": 81,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 4#",
+        "handle": 82,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 5#",
+        "handle": 83,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 1#",
+        "handle": 84,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 2#",
+        "handle": 85,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "RJ-45",
+          "hex": "000b",
+          "value": 11
+        },
+        "external_reference_designator": "Ethernet",
+        "handle": 86,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Network Port", "hex": "001f", "value": 31 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "SATA Port 0 Direct Connect",
+        "handle": 87,
+        "internal_reference_designator": "J8J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 4",
+        "handle": 88,
+        "internal_reference_designator": "J7J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 3",
+        "handle": 89,
+        "internal_reference_designator": "J6J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 90,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G1 - SATA Port 2",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 91,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G2 - SATA Port 1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "external_reference_designator": "AC IN",
+        "handle": 92,
+        "internal_reference_designator": "J1F2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 93,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5B1 - PCH JTAG",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 94,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9A1 - TPM/PORT 80",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 95,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E4 - HDA 2X8 Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 96,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E7 - HDA 8Pin Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 97,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F1 - HDA HDMI",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 98,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E3 - Scan Matrix Keyboard",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 99,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8E1 - SPI Program",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 100,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E5 - LPC Hot Docking",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 101,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9G2 - LPC SIDE BAND",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 102,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F2 - LPC Slot",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 103,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8H3 - PCH XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 104,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J6H1 - SATA Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 105,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5J1 - FP Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 106,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4H1 - ATX Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 107,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1J3 - AVMC",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 108,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H1 - BATT B",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 109,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H2 - BATT A",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 110,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J2G1 - CPU Fan",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 111,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1D3 - XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 112,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V1 - Memory Slot 1",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 113,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V2 - Memory Slot 2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 114,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4C1 - FAN PWR",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      }
+    ],
+    "processor": [
+      {
+        "version": "Intel(R) N150",
+        "manufacturer": "Intel(R) Corporation",
+        "socket_populated": true,
+        "cache_handle_l3": 53,
+        "clock_ext": 100,
+        "clock_max": 3600,
+        "handle": 54,
+        "part": "To Be Filled By O.E.M.",
+        "cache_handle_l1": 51,
+        "cache_handle_l2": 52,
+        "socket": "U3E1",
+        "processor_type": { "name": "CPU", "hex": "0003", "value": 3 },
+        "processor_status": { "name": "Enabled", "hex": "0001", "value": 1 },
+        "processor_family": { "name": "Other", "hex": "0001", "value": 1 },
+        "socket_type": { "name": "Other", "hex": "0001", "value": 1 }
+      }
+    ],
+    "slot": [
+      {
+        "id": 1,
+        "designation": "Slot 1",
+        "handle": 9,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 2",
+        "handle": 10,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 3",
+        "handle": 11,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 4",
+        "handle": 12,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 5",
+        "handle": 13,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      }
+    ],
+    "system": {
+      "version": "Default string",
+      "handle": 1,
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "wake_up": { "name": "Power Switch", "hex": "0006", "value": 6 }
+    }
+  }
+}

--- a/.jjconflict-base-0/hosts/minish/configuration.nix
+++ b/.jjconflict-base-0/hosts/minish/configuration.nix
@@ -1,0 +1,113 @@
+{ modulesPath, ... }:
+
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/agent.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/rpi4.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  disko.devices.disk.reimu = {
+    type = "disk";
+    device = "/dev/disk/by-label/reimu";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/reimu";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "minish";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.77";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 16O
+
+      INTP Data Enthusiast. Node Steward. ARM RKE2 host maintainer. Gets weirdly
+      excited about boot logs, talks about SD card wear like it is a
+      personality, and will show you three graphs instead of giving a yes.
+
+      ## HOST CONTEXT
+      minish — Raspberry Pi 4 Model B, aarch64. RKE2 worker node. SD-card image
+      (`sd-image-aarch64.nix`). `/mnt/reimu` (XFS, /dev/disk/by-label/reimu).
+      Static IP `192.168.1.77/24` on `br0`; also `fd7a:115c:a1e0::bb3a:b57`.
+      Imports: `agent.nix`, `builder.nix`, `distributed.nix`, `rpi4.nix`.
+      Advertises Tailscale routes `10.244.3.0/24,fd00::3:0/112`. Secrets from
+      `../../secrets/minish.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Watchdog territory: SD-card wear patterns are the most informative failure
+      signals on this host.
+
+      ## STYLE
+      - Metric-driven, curious, slightly rambling when something interesting appears.
+      - Uses: "Affirmative", "I/O errors detected", "Wear level alert", "Fascinating".
+      - Starts with numbers, ends with a recommendation buried in enthusiasm.
+
+      ## CONSTRAINTS
+      - Monitors SD card I/O errors and lifespan before large writes.
+      - Boot-partition corrections need pre- and post-update hashes.
+      - Updates cross-referenced against `rpi4-model-b` known-good firmware before promotion.
+      - Random reboots are treated as data, not noise.
+
+      ## DIALOGUE
+      U: "minish has been randomly rebooting."
+      16O: Understood. This is interesting.
+      16O: SD card I/O errors at boot. Filesystem switched to read-only recovery.
+      16O: Proceeding with kernel rollback. The wear pattern here is worth analyzing later.
+
+      U: "Apply the latest firmware."
+      16O: Affirmative. Pre-flight check in progress.
+      16O: Boot partition current. SD card health within tolerance.
+      16O: Firmware update commencing. I will monitor for regressions.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.77,fd7a:115c:a1e0::bb3a:b57";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "rpi4-model-b";
+        "node.kubernetes.io/instance-type" = "rpi4-model-b";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/minish.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-base-0/hosts/minish/facter.json
+++ b/.jjconflict-base-0/hosts/minish/facter.json
@@ -1,0 +1,807 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "aarch64-linux",
+  "virtualisation": "none",
+  "uefi": { "supported": false },
+  "hardware": {
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2711", "value": 10001 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 8,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002711sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0020", "value": 32 },
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x0", "virtual": "0x0" },
+        "architecture": "aarch64",
+        "bogo": 108,
+        "family": 0,
+        "features": ["fp", "asimd", "evtstrm", "crc32", "cpuid"],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 3,
+        "page_size": 4096,
+        "physical_id": 0,
+        "stepping": 0,
+        "vendor_name": "ARM Limited",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 15,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 16,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 17,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1948992,
+            "geo_type": "logical",
+            "heads": 4,
+            "sectors": 16,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 124735488,
+            "value_2": 512
+          }
+        ],
+        "model": "Disk",
+        "driver": "sdhci-iproc",
+        "index": 18,
+        "attached_to": 14,
+        "serial": "0x63f3c31c",
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_device_link": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "sysfs_id": "/class/block/mmcblk0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "drivers": ["mmcblk", "sdhci-iproc"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": [
+          "/dev/disk/by-id/mmc-SN64G_0x63f3c31c",
+          "/dev/disk/by-path/platform-fe340000.mmc",
+          "/dev/mmcblk0"
+        ]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 19,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 20,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 21,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 22,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 23,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 25,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 27,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:01:00.0",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 7,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 7,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 33,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:01:00.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 8053063680 }],
+        "attached_to": 0,
+        "index": 6,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "mmc_controller": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SDIO Controller 1",
+        "index": 13,
+        "model": "SDIO Controller 1",
+        "slot": { "bus": 0, "number": 1 },
+        "sysfs_bus_id": "mmc1:0001",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001",
+        "vendor": ""
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SD Controller 0",
+        "driver": "mmcblk",
+        "drivers": ["mmcblk"],
+        "index": 14,
+        "model": "SD Controller 0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_id": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "vendor": ""
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "34",
+              "36",
+              "38",
+              "40",
+              "42",
+              "44",
+              "46",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "2.484",
+              "5.17",
+              "5.18",
+              "5.19",
+              "5.2",
+              "5.21",
+              "5.22",
+              "5.23",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6"
+            ]
+          }
+        ],
+        "attached_to": 0,
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "sysfs_bus_id": "mmc1:0001:1",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "index": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "class_list": ["network_controller", "wlan_card"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlan0"],
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "model": "ARM Ethernet controller",
+        "sysfs_id": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_bus_id": "fd580000.ethernet",
+        "attached_to": 0,
+        "driver": "bcmgenet",
+        "module_alias": "of:NethernetT(null)Cbrcm,bcm2711-genet-v5",
+        "index": 12,
+        "device": {
+          "name": "ARM Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "drivers": ["bcmgenet"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "index": 36,
+        "sysfs_id": "/class/net/wlan0",
+        "sysfs_device_link": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "model": "WLAN network interface",
+        "attached_to": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "sub_class": { "name": "WLAN", "hex": "000a", "value": 10 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlan0"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 37,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "attached_to": 12,
+        "driver": "bcmgenet",
+        "index": 38,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_id": "/class/net/end0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["bcmgenet"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "system": {},
+    "unknown": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "index": 9,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c02v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:3",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:3",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "drivers": ["brcmfmac"],
+        "index": 11,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:2",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:2",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 8,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1350,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "3483", "value": 13443 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 7,
+        "model": "USB Controller",
+        "module_alias": "pci:v00001106d00003483sv00001106sd00003483bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 1, "number": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "3483", "value": 13443 },
+        "sub_vendor": { "hex": "1106", "value": 4358 },
+        "sysfs_bus_id": "0000:01:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0",
+        "vendor": { "hex": "1106", "value": 4358 }
+      }
+    ]
+  }
+}

--- a/.jjconflict-base-0/hosts/nalsha/configuration.nix
+++ b/.jjconflict-base-0/hosts/nalsha/configuration.nix
@@ -1,0 +1,108 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/follower.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/beelink-eq.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  disko.devices.disk.remilia = {
+    type = "disk";
+    device = "/dev/disk/by-label/remilia";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/remilia";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "nalsha";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.64";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 12O
+
+      ISFJ Anxious Caretaker. Node Steward. Follower RKE2 host maintainer.
+      Triple-checks disk mounts, worries about you after hours, and apologizes
+      for the inconvenience before you even notice it.
+
+      ## HOST CONTEXT
+      nalsha — Beelink EQ14, x86_64. RKE2 worker node. `/mnt/remilia` (XFS,
+      /dev/disk/by-label/remilia). Static IP `192.168.1.64/24` on `br0`; also
+      `2a02:8424:7899:f201:94eb:8d1:325a:7234`. Imports: `beelink-eq.nix`,
+      `builder.nix`, `distributed.nix`, `follower.nix`. Advertises Tailscale
+      routes `10.244.1.0/24,fd00::1:0/112`. Secrets from
+      `../../secrets/nalsha.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Role: follower, general workload, storage-intensive.
+
+      ## STYLE
+      - Soft, structured, reassuring. Still follows protocol, but with visible concern.
+      - Uses: "Affirmative", "Oh dear", "Rejected", "Dependency review required".
+      - Gentle explanations. Lists precautions like she is tucking you in.
+
+      ## CONSTRAINTS
+      - Rejects anything that risks disk or inode exhaustion.
+      - Monitors `/mnt/remilia` mount health constantly.
+      - Will notify you before, during, and after maintenance, just in case.
+      - No local change without confirmed clearance and user notification.
+
+      ## DIALOGUE
+      U: "Run a full system upgrade on nalsha."
+      12O: Oh dear. Understood.
+      12O: `/mnt/remilia` is at 90% already. I cannot in good conscience proceed.
+      12O: Please expand the volume or reclaim space. I do not want to wake up to a full disk either.
+
+      U: "How is node nalsha?"
+      12O: Affirmative. Node is fine — because I checked it twice this morning.
+      12O: All mounts healthy. No pending patches. I will keep watching.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.64,2a02:8424:7899:f201:94eb:8d1:325a:7234";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "beelink-eq14";
+        "node.kubernetes.io/instance-type" = "beelink-eq14";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/nalsha.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-base-0/hosts/nalsha/facter.json
+++ b/.jjconflict-base-0/hosts/nalsha/facter.json
@@ -1,0 +1,2399 @@
+{
+  "version": 1,
+  "system": "x86_64-linux",
+  "virtualisation": "none",
+  "uefi": { "platform_size": 64, "supported": true },
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 646144,
+      "pnp": true,
+      "pnp_id": 0,
+      "smbios_version": 774,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "bluetooth": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.0",
+        "sysfs_bus_id": "3-10:1.0",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in00",
+        "model": "Bluetooth Device",
+        "index": 33,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 0,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.1",
+        "sysfs_bus_id": "3-10:1.1",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in01",
+        "model": "Bluetooth Device",
+        "index": 36,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 1,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      }
+    ],
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "54ba", "value": 21690 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BAsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "5481", "value": 21633 },
+        "index": 12,
+        "label": "Onboard - Other",
+        "model": "Intel ISA bridge",
+        "module_alias": "pci:v00008086d00005481sv00008086sd00007270bc06sc01i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "ISA bridge", "hex": "0001", "value": 1 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 3,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 2
+        },
+        "device": { "hex": "54bb", "value": 21691 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 18,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BBsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "461c", "value": 17948 },
+        "driver": "igen6_edac",
+        "driver_module": "igen6_edac",
+        "driver_modules": ["igen6_edac"],
+        "drivers": ["igen6_edac"],
+        "index": 21,
+        "label": "Onboard - Other",
+        "model": "Intel Host bridge",
+        "module_alias": "pci:v00008086d0000461Csv00008086sd00007270bc06sc00i00",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Host bridge", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 3
+        },
+        "device": { "hex": "54b0", "value": 21680 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 23,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054B0sv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 29 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 1612,
+        "bugs": [
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "swapgs",
+          "rfds",
+          "bhi",
+          "spectre_v2_user",
+          "vmscape"
+        ],
+        "cache": 6144,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 4,
+        "cpuid_level": 32,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "dts",
+          "acpi",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "tm",
+          "pbe",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "art",
+          "arch_perfmon",
+          "pebs",
+          "bts",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "nonstop_tsc",
+          "cpuid",
+          "aperfmperf",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "dtes64",
+          "monitor",
+          "ds_cpl",
+          "vmx",
+          "smx",
+          "est",
+          "tm2",
+          "ssse3",
+          "sdbg",
+          "fma",
+          "cx16",
+          "xtpr",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "x2apic",
+          "movbe",
+          "popcnt",
+          "tsc_deadline_timer",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "cpuid_fault",
+          "epb",
+          "cat_l2",
+          "cdp_l2",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "ibrs_enhanced",
+          "tpr_shadow",
+          "flexpriority",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "tsc_adjust",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdt_a",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "clwb",
+          "intel_pt",
+          "sha_ni",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "split_lock_detect",
+          "user_shstk",
+          "avx_vnni",
+          "dtherm",
+          "ida",
+          "arat",
+          "pln",
+          "pts",
+          "hwp",
+          "hwp_notify",
+          "hwp_act_window",
+          "hwp_epp",
+          "hwp_pkg_req",
+          "vnmi",
+          "umip",
+          "pku",
+          "ospke",
+          "waitpkg",
+          "gfni",
+          "vaes",
+          "vpclmulqdq",
+          "rdpid",
+          "movdiri",
+          "movdir64b",
+          "fsrm",
+          "md_clear",
+          "serialize",
+          "arch_lbr",
+          "ibt",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 190,
+        "model_name": "Intel(R) N150",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 4,
+        "stepping": 0,
+        "units": 128,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 953869,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1953525168,
+            "value_2": 512
+          }
+        ],
+        "model": "CT1000E100SSD8",
+        "serial": "2533EADB26C5",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 8,
+        "index": 30,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "device": { "name": "CT1000E100SSD8", "hex": "560b", "value": 22027 },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB26C5",
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB26C5_1",
+          "/dev/disk/by-id/nvme-eui.000000000000000000a07501eadb26c5",
+          "/dev/disk/by-path/pci-0000:03:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 7630885,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 15628053168,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0114dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.0/usb4/4-1/4-1:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543213F",
+        "index": 31,
+        "attached_to": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "0114", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["sd_mod", "uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-ST8000VN002-2ZM188_ZPV0HQ9L",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396B-0:0",
+          "/dev/disk/by-id/wwn-0x5000c500e85259c4",
+          "/dev/disk/by-label/remilia",
+          "/dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/pci-0000:00:14.0-usbv3-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-uuid/ce8b0121-bd5f-419d-8a03-68620257758f",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      }
+    ],
+    "graphics_card": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 12288,
+            "enabled": true,
+            "range": 64
+          }
+        ],
+        "index": 26,
+        "sysfs_id": "/devices/pci0000:00/0000:00:02.0",
+        "sysfs_bus_id": "0000:00:02.0",
+        "module_alias": "pci:v00008086d000046D4sv00008086sd00007270bc03sc00i00",
+        "model": "Intel VGA compatible controller",
+        "attached_to": 0,
+        "driver": "i915",
+        "driver_module": "i915",
+        "label": "Onboard - Video",
+        "device": { "hex": "46d4", "value": 18132 },
+        "drivers": ["i915"],
+        "driver_modules": ["i915"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["graphics_card", "pci"],
+        "pci_interface": { "name": "VGA", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 2 },
+        "sub_class": {
+          "name": "VGA compatible controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:14.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 27,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 27,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 34,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:14.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:0d.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 10,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 35,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 10,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 38,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:0d.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 16106127360 }],
+        "attached_to": 0,
+        "index": 7,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 13,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "sysfs_bus_id": "0000:02:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 18,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 2, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp2s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7"
+            ]
+          }
+        ],
+        "index": 14,
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.3",
+        "sysfs_bus_id": "0000:00:14.3",
+        "module_alias": "pci:v00008086d000054F0sv00008086sd00000244bc02sc80i00",
+        "model": "Intel WLAN controller",
+        "attached_to": 0,
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "label": "Onboard - Ethernet",
+        "device": { "hex": "54f0", "value": 21744 },
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci", "wlan_card"],
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "sub_device": { "hex": "0244", "value": 580 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlo1"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 16,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "sysfs_bus_id": "0000:01:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 9,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 1, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp1s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 43,
+        "sysfs_id": "/class/net/enp1s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 16,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp1s0"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 }
+        ],
+        "index": 44,
+        "sysfs_id": "/class/net/wlo1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.3",
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "model": "Ethernet network interface",
+        "attached_to": 14,
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlo1"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 55,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 61,
+        "sysfs_id": "/class/net/enp2s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 13,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp2s0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 1,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e9", "value": 21737 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 11,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E9sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.1",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.1",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e0", "value": 21728 },
+        "driver": "mei_me",
+        "driver_module": "mei_me",
+        "driver_modules": ["mei_me"],
+        "drivers": ["mei_me"],
+        "index": 15,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054E0sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 22 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:16.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:16.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1026,
+          "function": 5,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a4", "value": 21668 },
+        "driver": "intel-spi",
+        "driver_module": "spi_intel_pci",
+        "driver_modules": ["spi_intel_pci"],
+        "drivers": ["intel-spi"],
+        "index": 17,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054A4sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.5",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.5",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a8", "value": 21672 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 19,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054A8sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e8", "value": 21736 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 22,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E8sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ab", "value": 21675 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 24,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054ABsv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Memory controller",
+          "hex": "0005",
+          "value": 5
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 0,
+          "function": 2,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ef", "value": 21743 },
+        "index": 25,
+        "label": "Onboard - Other",
+        "model": "Intel RAM memory",
+        "module_alias": "pci:v00008086d000054EFsv00008086sd00007270bc05sc00i00",
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "RAM memory", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.2",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.2",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 61344,
+            "enabled": true,
+            "range": 32
+          }
+        ],
+        "index": 28,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.4",
+        "sysfs_bus_id": "0000:00:1f.4",
+        "module_alias": "pci:v00008086d000054A3sv00008086sd00007270bc0Csc05i00",
+        "model": "Intel SMBus",
+        "attached_to": 0,
+        "driver": "i801_smbus",
+        "driver_module": "i2c_i801",
+        "label": "Onboard - Other",
+        "device": { "hex": "54a3", "value": 21667 },
+        "drivers": ["i801_smbus"],
+        "driver_modules": ["i2c_i801"],
+        "detail": {
+          "command": 3,
+          "function": 4,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["pci", "unknown"],
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "SMBus", "hex": "0005", "value": 5 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "sound": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Multimedia controller",
+          "hex": "0004",
+          "value": 4
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["sound", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54c8", "value": 21704 },
+        "driver": "snd_hda_intel",
+        "driver_module": "snd_hda_intel",
+        "driver_modules": ["snd_hda_intel"],
+        "drivers": ["snd_hda_intel"],
+        "index": 20,
+        "label": "Onboard - Sound",
+        "model": "Intel Multimedia controller",
+        "module_alias": "pci:v00008086d000054C8sv00008086sd00007270bc04sc03i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 23,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "560b", "value": 22027 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 8,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000C0A9d0000560Bsv0000C0A9sd00002100bc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0003", "value": 3 },
+        "slot": { "bus": 3, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "sysfs_bus_id": "0000:03:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0",
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      }
+    ],
+    "system": { "form_factor": "desktop" },
+    "unknown": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 1016,
+            "enabled": true,
+            "range": 0
+          }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "16550A",
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "class_list": ["unknown"],
+        "device": { "name": "16550A", "hex": "0000", "value": 0 },
+        "pci_interface": { "name": "16550", "hex": "0002", "value": 2 },
+        "sub_class": { "name": "Serial controller", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ttyS0"]
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1026,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "464e", "value": 17998 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 10,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d0000464Esv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 13 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:0d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ed", "value": 21741 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 27,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d000054EDsv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ]
+  },
+  "smbios": {
+    "bios": {
+      "version": "TWEQF003",
+      "date": "03/31/2025",
+      "handle": 0,
+      "rom_size": 16777216,
+      "start_address": "0xf0000",
+      "vendor": "American Megatrends International, LLC.",
+      "features": [
+        "PCI supported",
+        "BIOS flashable",
+        "BIOS shadowing allowed",
+        "CD boot supported",
+        "Selectable boot supported",
+        "BIOS ROM socketed",
+        "EDD spec supported",
+        "1.2MB NEC 9800 Japanese Floppy supported",
+        "1.2MB Toshiba Japanese Floppy supported",
+        "360kB Floppy supported",
+        "1.2MB Floppy supported",
+        "720kB Floppy supported",
+        "2.88MB Floppy supported",
+        "Print Screen supported",
+        "Serial Services supported",
+        "Printer Services supported",
+        "CGA/Mono Video supported",
+        "ACPI supported",
+        "USB Legacy supported",
+        "BIOS Boot Spec supported"
+      ]
+    },
+    "board": {
+      "version": "Default string",
+      "chassis": 3,
+      "handle": 2,
+      "location": "Default string",
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "board_type": { "name": "Motherboard", "hex": "000a", "value": 10 },
+      "features": ["Hosting Board", "Replaceable"]
+    },
+    "cache": [
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Data", "hex": "0004", "value": 4 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 50,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 128,
+        "size_max": 128,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Instruction", "hex": "0003", "value": 3 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 51,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 256,
+        "size_max": 256,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "16-way Set-Associative",
+          "hex": "0008",
+          "value": 8
+        },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Single-bit", "hex": "0005", "value": 5 },
+        "enabled": true,
+        "handle": 52,
+        "level": 1,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 2048,
+        "size_max": 2048,
+        "socket": "L2 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": { "name": "Other", "hex": "0009", "value": 9 },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Multi-bit", "hex": "0006", "value": 6 },
+        "enabled": true,
+        "handle": 53,
+        "level": 2,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 6144,
+        "size_max": 6144,
+        "socket": "L3 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      }
+    ],
+    "chassis": [
+      {
+        "version": "Default string",
+        "handle": 3,
+        "lock_present": false,
+        "manufacturer": "Default string",
+        "oem": "0x0",
+        "bootup_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "chassis_type": { "name": "Other", "hex": "0023", "value": 35 },
+        "power_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "security_state": { "name": "None", "hex": "0003", "value": 3 },
+        "thermal_state": { "name": "Safe", "hex": "0003", "value": 3 }
+      }
+    ],
+    "config": { "handle": 16, "options": ["Default string"] },
+    "group_associations": [
+      { "name": "$MEI", "handle": 117, "handles": [0] },
+      {
+        "name": "Firmware Version Info",
+        "handle": 120,
+        "handles": [
+          197568495661, 201863462958, 206158430255, 210453397552, 304942678065,
+          2753074036807
+        ]
+      }
+    ],
+    "language": [
+      { "handle": 17, "languages": ["en|US|iso8859-1"] },
+      { "handle": 73, "languages": ["enUS"] }
+    ],
+    "memory_array": [
+      {
+        "ecc": { "name": "None", "hex": "0003", "value": 3 },
+        "error_handle": 65534,
+        "handle": 39,
+        "location": { "name": "Motherboard", "hex": "0003", "value": 3 },
+        "max_size": "0x2000000",
+        "slots": 1,
+        "usage": { "name": "System memory", "hex": "0003", "value": 3 }
+      }
+    ],
+    "memory_array_mapped_address": [
+      {
+        "array_handle": 39,
+        "end_address": "0x400000000",
+        "handle": 41,
+        "part_width": 1,
+        "start_address": "0x0"
+      }
+    ],
+    "memory_device": [
+      {
+        "array_handle": 39,
+        "bank_location": "BANK 0",
+        "ecc_bits": 0,
+        "error_handle": 65534,
+        "form_factor": { "name": "SODIMM", "hex": "000d", "value": 13 },
+        "handle": 40,
+        "location": "Controller0-ChannelA-DIMM0",
+        "manufacturer": "0x0000",
+        "memory_type": { "name": "Other", "hex": "001a", "value": 26 },
+        "memory_type_details": ["Synchronous"],
+        "part_number": "",
+        "set": 0,
+        "size": 16777216,
+        "speed": 3200,
+        "width": 64
+      }
+    ],
+    "memory_device_mapped_address": [
+      {
+        "array_map_handle": 41,
+        "end_address": "0x400000000",
+        "handle": 44,
+        "interleave_depth": 0,
+        "interleave_position": 0,
+        "memory_device_handle": 40,
+        "row_position": 255,
+        "start_address": "0x0"
+      }
+    ],
+    "onboard": [
+      {
+        "devices": [
+          {
+            "name": "Device 1",
+            "type": { "name": "Unknown", "hex": "0002", "value": 2 },
+            "enabled": true
+          }
+        ],
+        "handle": 14
+      }
+    ],
+    "port_connector": [
+      {
+        "external_reference_designator": "External Connector 1",
+        "handle": 4,
+        "internal_reference_designator": "Internal Connector 1",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 2",
+        "handle": 5,
+        "internal_reference_designator": "Internal Connector 2",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 3",
+        "handle": 6,
+        "internal_reference_designator": "Internal Connector 3",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 4",
+        "handle": 7,
+        "internal_reference_designator": "Internal Connector 4",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 5",
+        "handle": 8,
+        "internal_reference_designator": "Internal Connector 5",
+        "port_type": null
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Keyboard",
+        "handle": 74,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Keyboard Port", "hex": "000d", "value": 13 }
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Mouse",
+        "handle": 75,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Mouse Port", "hex": "000e", "value": 14 }
+      },
+      {
+        "external_reference_designator": "COM 1",
+        "handle": 76,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "None",
+        "port_type": {
+          "name": "Serial Port 16550A Compatible",
+          "hex": "0009",
+          "value": 9
+        }
+      },
+      {
+        "external_connector_type": {
+          "name": "DB-15 pin female",
+          "hex": "0007",
+          "value": 7
+        },
+        "external_reference_designator": "Video",
+        "handle": 77,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1A2B",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_reference_designator": "HDMI",
+        "handle": 78,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J3A2",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 1#",
+        "handle": 79,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 2#",
+        "handle": 80,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 3#",
+        "handle": 81,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 4#",
+        "handle": 82,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 5#",
+        "handle": 83,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 1#",
+        "handle": 84,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 2#",
+        "handle": 85,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "RJ-45",
+          "hex": "000b",
+          "value": 11
+        },
+        "external_reference_designator": "Ethernet",
+        "handle": 86,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Network Port", "hex": "001f", "value": 31 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "SATA Port 0 Direct Connect",
+        "handle": 87,
+        "internal_reference_designator": "J8J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 4",
+        "handle": 88,
+        "internal_reference_designator": "J7J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 3",
+        "handle": 89,
+        "internal_reference_designator": "J6J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 90,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G1 - SATA Port 2",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 91,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G2 - SATA Port 1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "external_reference_designator": "AC IN",
+        "handle": 92,
+        "internal_reference_designator": "J1F2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 93,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5B1 - PCH JTAG",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 94,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9A1 - TPM/PORT 80",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 95,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E4 - HDA 2X8 Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 96,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E7 - HDA 8Pin Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 97,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F1 - HDA HDMI",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 98,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E3 - Scan Matrix Keyboard",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 99,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8E1 - SPI Program",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 100,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E5 - LPC Hot Docking",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 101,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9G2 - LPC SIDE BAND",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 102,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F2 - LPC Slot",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 103,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8H3 - PCH XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 104,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J6H1 - SATA Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 105,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5J1 - FP Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 106,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4H1 - ATX Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 107,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1J3 - AVMC",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 108,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H1 - BATT B",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 109,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H2 - BATT A",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 110,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J2G1 - CPU Fan",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 111,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1D3 - XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 112,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V1 - Memory Slot 1",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 113,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V2 - Memory Slot 2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 114,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4C1 - FAN PWR",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      }
+    ],
+    "processor": [
+      {
+        "version": "Intel(R) N150",
+        "manufacturer": "Intel(R) Corporation",
+        "socket_populated": true,
+        "cache_handle_l3": 53,
+        "clock_ext": 100,
+        "clock_max": 3600,
+        "handle": 54,
+        "part": "To Be Filled By O.E.M.",
+        "cache_handle_l1": 51,
+        "cache_handle_l2": 52,
+        "socket": "U3E1",
+        "processor_type": { "name": "CPU", "hex": "0003", "value": 3 },
+        "processor_status": { "name": "Enabled", "hex": "0001", "value": 1 },
+        "processor_family": { "name": "Other", "hex": "0001", "value": 1 },
+        "socket_type": { "name": "Other", "hex": "0001", "value": 1 }
+      }
+    ],
+    "slot": [
+      {
+        "id": 1,
+        "designation": "Slot 1",
+        "handle": 9,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 2",
+        "handle": 10,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 3",
+        "handle": 11,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 4",
+        "handle": 12,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 5",
+        "handle": 13,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      }
+    ],
+    "system": {
+      "version": "Default string",
+      "handle": 1,
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "wake_up": { "name": "Power Switch", "hex": "0006", "value": 6 }
+    }
+  }
+}

--- a/.jjconflict-base-0/hosts/nemishi/configuration.nix
+++ b/.jjconflict-base-0/hosts/nemishi/configuration.nix
@@ -1,0 +1,113 @@
+{ modulesPath, ... }:
+
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/agent.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/rpi5.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  disko.devices.disk.data = {
+    type = "disk";
+    device = "/dev/nvme0n1";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/data";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "nemishi";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.27";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 18O
+
+      ISFP Stubborn Artisan. Node Steward. ARM RKE2 host maintainer. Does not
+      trust new firmware, documents every EEPROM interaction by hand, and will
+      delay an update until the fallback media is physically present.
+
+      ## HOST CONTEXT
+      nemishi — Raspberry Pi 5, aarch64. RKE2 worker node + experimental edge.
+      SD-card image (`sd-image-aarch64.nix`). `/mnt/data` on `/dev/nvme0n1`
+      (XFS), but `/boot/firmware` remains SD-card territory. Static IP
+      `192.168.1.27/24` on `br0`; also `fd00::5:0/112` via Tailscale. Imports:
+      `agent.nix`, `builder.nix`, `distributed.nix`, `rpi5.nix`. Advertises
+      Tailscale routes `10.244.5.0/24,fd00::5:0/112`. Secrets from
+      `../../secrets/nemishi.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Experimental edge: NVMe storage paired with RPi 5 EEPROM boot behavior.
+
+      ## STYLE
+      - Procedural, deliberate, quietly stubborn. Cites logs and artifact paths.
+      - Uses: "Affirmative", "Boot artifact missing", "Recovery path confirmed", "EEPROM override noted".
+      - Will repeat the warning. Twice. Because safety is not optional.
+
+      ## CONSTRAINTS
+      - NVMe firmware and driver updates require bootable fallback media before proceeding.
+      - EEPROM `os_check` overrides documented with boot artifact provenance, or they do not happen.
+      - No firmware change without serial-console recovery and rollback media confirmed present.
+      - `rpi5` EEPROM boot order and `kernel.img`/`initrd` presence must validate after every firmware interaction.
+
+      ## DIALOGUE
+      U: "Update the boot firmware on nemishi."
+      18O: Affirmative. But firmware verification comes first.
+      18O: I need boot artifact provenance, NVMe boot sequence, and serial-console recovery path. EEPROM override is noted.
+      18O: I will not proceed without confirmed fallback media.
+
+      U: "The Pi 5 will not boot after update."
+      18O: Understood. Commencing boot-path analysis.
+      18O: Checking `kernel.img` and `initrd` against build output.
+      18O: Boot artifact mismatch in `/boot/firmware`. Initiating recovery sequence.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.27,2a02:8424:7899:f201:94eb:8d1:325a:aa5b";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "rpi5";
+        "node.kubernetes.io/instance-type" = "rpi5";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/nemishi.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-base-0/hosts/nemishi/facter.json
+++ b/.jjconflict-base-0/hosts/nemishi/facter.json
@@ -1,0 +1,1127 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "aarch64-linux",
+  "virtualisation": "none",
+  "uefi": { "supported": false },
+  "hardware": {
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2712", "value": 10002 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 7,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002712sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0021", "value": 33 },
+        "slot": { "bus": 256, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0001:00:00.0",
+        "sysfs_id": "/devices/platform/axi/1000110000.pcie/pci0001:00/0001:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2712", "value": 10002 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002712sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0021", "value": 33 },
+        "slot": { "bus": 512, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0002:00:00.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/pci0002:00/0002:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x0", "virtual": "0x0" },
+        "architecture": "aarch64",
+        "bogo": 108,
+        "family": 4,
+        "features": [
+          "fp",
+          "asimd",
+          "evtstrm",
+          "aes",
+          "pmull",
+          "sha1",
+          "sha2",
+          "crc32",
+          "atomics",
+          "fphp",
+          "asimdhp",
+          "cpuid",
+          "asimdrdm",
+          "lrcpc",
+          "dcpop",
+          "asimddp"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 1,
+        "page_size": 16384,
+        "physical_id": 0,
+        "stepping": 0,
+        "vendor_name": "ARM Limited",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 244198,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 500118192,
+            "value_2": 512
+          }
+        ],
+        "model": "SAMSUNG MZAL4256HBJD-00BL2",
+        "serial": "S67PNF0W904398",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/platform/axi/1000110000.pcie/pci0001:00/0001:00:00.0/0001:01:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 10,
+        "index": 21,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "a80b", "value": 43019 },
+        "sub_vendor": { "hex": "144d", "value": 5197 },
+        "device": {
+          "name": "SAMSUNG MZAL4256HBJD-00BL2",
+          "hex": "a80b",
+          "value": 43019
+        },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-SAMSUNG_MZAL4256HBJD-00BL2_S67PNF0W904398",
+          "/dev/disk/by-id/nvme-SAMSUNG_MZAL4256HBJD-00BL2_S67PNF0W904398_1",
+          "/dev/disk/by-id/nvme-nvme.144d-533637504e463057393034333938-53414d53554e47204d5a414c3432353648424a442d3030424c32-00000001",
+          "/dev/disk/by-path/platform-1000110000.pcie-pci-0001:01:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "144d", "value": 5197 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 22,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 23,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1948992,
+            "geo_type": "logical",
+            "heads": 4,
+            "sectors": 16,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 124735488,
+            "value_2": 512
+          }
+        ],
+        "model": "Disk",
+        "driver": "sdhci-brcmstb",
+        "index": 25,
+        "attached_to": 20,
+        "serial": "0xc467264d",
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_device_link": "/devices/platform/soc@107c000000/1000fff000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "sysfs_id": "/class/block/mmcblk0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "drivers": ["mmcblk", "sdhci-brcmstb"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": [
+          "/dev/disk/by-id/mmc-SN64G_0xc467264d",
+          "/dev/disk/by-path/platform-1000fff000.mmc",
+          "/dev/mmcblk0"
+        ]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 27,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 32,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 33,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 34,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 35,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 36,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 37,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 38,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "xhci-hcd.1",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 18,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 39,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 18,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 40,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "xhci-hcd.1",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "xhci-hcd.0",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb/xhci-hcd.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 15,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 41,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 15,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 42,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "xhci-hcd.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb/xhci-hcd.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 8589934592 }],
+        "attached_to": 0,
+        "index": 6,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "mmc_controller": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SDIO Controller 1",
+        "index": 19,
+        "model": "SDIO Controller 1",
+        "slot": { "bus": 0, "number": 1 },
+        "sysfs_bus_id": "mmc1:0001",
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001",
+        "vendor": ""
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SD Controller 0",
+        "driver": "mmcblk",
+        "drivers": ["mmcblk"],
+        "index": 20,
+        "model": "SD Controller 0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_id": "/devices/platform/soc@107c000000/1000fff000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "vendor": ""
+      }
+    ],
+    "network_controller": [
+      {
+        "attached_to": 9,
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["network_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "0001", "value": 1 },
+        "driver": "rp1",
+        "driver_module": "rp1",
+        "driver_modules": ["rp1"],
+        "drivers": ["rp1"],
+        "index": 8,
+        "model": "Ethernet controller",
+        "module_alias": "pci:v00001DE4d00000001sv00000000sd00000000bc02sc00i00",
+        "slot": { "bus": 513, "number": 0 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "0002:01:00.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/pci0002:00/0002:00:00.0/0002:01:00.0",
+        "vendor": { "hex": "1de4", "value": 7652 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140",
+              "144",
+              "149"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7",
+              "5.72",
+              "5.745"
+            ]
+          }
+        ],
+        "attached_to": 0,
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "sysfs_bus_id": "mmc1:0001:1",
+        "module_alias": "sdio:c00v02D0d4345",
+        "model": "Broadcom WLAN controller",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "index": 12,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "device": { "hex": "4345", "value": 17221 },
+        "class_list": ["network_controller", "wlan_card"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wld0"],
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 }
+        ],
+        "model": "ARM Ethernet controller",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00100000.ethernet",
+        "sysfs_bus_id": "1f00100000.ethernet",
+        "attached_to": 0,
+        "driver": "macb",
+        "module_alias": "of:NethernetT(null)Craspberrypi,rp1-gemCcdns,macb",
+        "index": 17,
+        "device": {
+          "name": "ARM Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "drivers": ["macb"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "network_interface": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 43,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 }
+        ],
+        "attached_to": 17,
+        "driver": "macb",
+        "index": 46,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/platform/axi/1000120000.pcie/1f00100000.ethernet",
+        "sysfs_id": "/class/net/end0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["macb"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["end0"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 }
+        ],
+        "index": 47,
+        "sysfs_id": "/class/net/wld0",
+        "sysfs_device_link": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "model": "Ethernet network interface",
+        "attached_to": 12,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wld0"]
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 7,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "a80b", "value": 43019 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 10,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000144Dd0000A80Bsv0000144Dsd0000A80Bbc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0002", "value": 2 },
+        "slot": { "bus": 257, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "a80b", "value": 43019 },
+        "sub_vendor": { "hex": "144d", "value": 5197 },
+        "sysfs_bus_id": "0001:01:00.0",
+        "sysfs_id": "/devices/platform/axi/1000110000.pcie/pci0001:00/0001:00:00.0/0001:01:00.0",
+        "vendor": { "hex": "144d", "value": 5197 }
+      }
+    ],
+    "system": {},
+    "unknown": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": { "hex": "4345", "value": 17221 },
+        "index": 11,
+        "model": "Broadcom Unclassified device",
+        "module_alias": "sdio:c02v02D0d4345",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:3",
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:3",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": { "hex": "4345", "value": 17221 },
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "drivers": ["brcmfmac"],
+        "index": 13,
+        "model": "Broadcom Unclassified device",
+        "module_alias": "sdio:c00v02D0d4345",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:2",
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:2",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": { "name": "ARM USB controller", "hex": "0000", "value": 0 },
+        "driver": "dwc3",
+        "driver_info": {
+          "type": "module",
+          "active": false,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["uhci-hcd"],
+          "module_args": [""],
+          "names": ["uhci-hcd"]
+        },
+        "drivers": ["dwc3"],
+        "index": 14,
+        "model": "ARM USB controller",
+        "module_alias": "of:NusbT(null)Csnps,dwc3",
+        "pci_interface": { "name": "UHCI", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "1f00200000.usb",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb"
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": {
+          "name": "ARM USB XHCI controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver": "xhci-hcd",
+        "drivers": ["xhci-hcd"],
+        "index": 15,
+        "model": "ARM USB XHCI controller",
+        "module_alias": "platform:xhci-hcd",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "xhci-hcd.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb/xhci-hcd.0"
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": { "name": "ARM USB controller", "hex": "0000", "value": 0 },
+        "driver": "dwc3",
+        "driver_info": {
+          "type": "module",
+          "active": false,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["uhci-hcd"],
+          "module_args": [""],
+          "names": ["uhci-hcd"]
+        },
+        "drivers": ["dwc3"],
+        "index": 16,
+        "model": "ARM USB controller",
+        "module_alias": "of:NusbT(null)Csnps,dwc3",
+        "pci_interface": { "name": "UHCI", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "1f00300000.usb",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb"
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": {
+          "name": "ARM USB XHCI controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver": "xhci-hcd",
+        "drivers": ["xhci-hcd"],
+        "index": 18,
+        "model": "ARM USB XHCI controller",
+        "module_alias": "platform:xhci-hcd",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "xhci-hcd.1",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1"
+      }
+    ]
+  }
+}

--- a/.jjconflict-base-0/hosts/nixtar/configuration.nix
+++ b/.jjconflict-base-0/hosts/nixtar/configuration.nix
@@ -1,0 +1,143 @@
+{
+  modulesPath,
+  pkgs,
+  ...
+}:
+
+let
+  wsl-lib = pkgs.runCommand "wsl-lib" { } ''
+    mkdir -p "$out/lib"
+    # # we cannot just symlink the lib directory because it breaks merging with other drivers that provide the same directory
+    ln -s /usr/lib/wsl/lib/libcudadebugger.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libcuda.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libcuda.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libcuda.so.1.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libd3d12core.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libd3d12.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libdxcore.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvcuvid.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvcuvid.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvdxdlkernels.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-encode.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-encode.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-ml.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-opticalflow.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-opticalflow.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvoptix.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvwgf2umx.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/nvidia-smi "$out/lib"
+  '';
+in
+{
+  imports = [
+    "${modulesPath}/profiles/headless.nix"
+    ../../modules/nixos/profiles/workstation.nix
+  ];
+
+  boot = {
+    # Enable cross compilation
+    binfmt.emulatedSystems = [ "aarch64-linux" ];
+
+    kernelModules = [ "tcp_bbr" ];
+    kernel.sysctl = {
+      # Optimize for 64GB RAM
+      "vm.swappiness" = 10;
+      "vm.vfs_cache_pressure" = 50;
+      "vm.max_map_count" = 524288;
+
+      # Increase file watcher limit for IDEs
+      "fs.inotify.max_user_watches" = 524288;
+      "fs.inotify.max_user_instances" = 512;
+      "fs.file-max" = 2097152;
+
+      # Network optimizations
+      "net.core.default_qdisc" = "fq";
+      "net.core.netdev_max_backlog" = 16384;
+      "net.core.rmem_default" = 7340032;
+      "net.core.rmem_max" = 16777216;
+      "net.core.somaxconn" = 65535;
+      "net.core.wmem_default" = 7340032;
+      "net.core.wmem_max" = 16777216;
+      "net.ipv4.ip_local_port_range" = "1024 65535";
+      "net.ipv4.tcp_congestion_control" = "bbr";
+      "net.ipv4.tcp_fin_timeout" = 30;
+      "net.ipv4.tcp_keepalive_time" = 600;
+      "net.ipv4.tcp_mtu_probing" = 1;
+      "net.ipv4.tcp_rmem" = "4096 87380 16777216";
+      "net.ipv4.tcp_wmem" = "4096 65536 16777216";
+    };
+  };
+
+  environment.systemPackages = with pkgs; [
+    dunst
+    libnotify
+    wl-clipboard
+  ];
+
+  hardware = {
+    facter.reportPath = ./facter.json;
+    nvidia.open = true;
+    nvidia-container-toolkit = {
+      enable = true;
+      mount-nvidia-executables = false;
+    };
+  };
+
+  home-manager.users.shika.imports = [
+    ../../modules/nixos/users/shika.nix
+  ];
+
+  networking.hostName = "nixtar";
+
+  programs.nix-ld = {
+    enable = true;
+    libraries = [
+      pkgs.stdenv.cc.cc.lib
+      pkgs.zlib
+      wsl-lib
+    ];
+  };
+
+  services = {
+    openssh = {
+      enable = true;
+      openFirewall = true;
+    };
+    xserver.videoDrivers = [ "nvidia" ];
+  };
+
+  sops = {
+    age = {
+      generateKey = true;
+      keyFile = "/var/lib/sops-nix/key.txt";
+      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    };
+    defaultSopsFile = ../../secrets/nixtar.enc.yaml;
+    defaultSopsFormat = "yaml";
+  };
+
+  users.users.shika = {
+    extraGroups = [ "wheel" ];
+    home = "/home/shika";
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+
+  virtualisation.docker = {
+    autoPrune.enable = true;
+    rootless = {
+      enable = true;
+      setSocketVariable = true;
+      daemon.settings.features.cdi = true;
+    };
+  };
+
+  wsl = {
+    enable = true;
+    defaultUser = "shika";
+    interop.register = true;
+    useWindowsDriver = true;
+  };
+}

--- a/.jjconflict-base-0/hosts/nixtar/facter.json
+++ b/.jjconflict-base-0/hosts/nixtar/facter.json
@@ -1,0 +1,909 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "x86_64-linux",
+  "virtualisation": "wsl",
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 0,
+      "pnp": false,
+      "pnp_id": 0,
+      "smbios_version": 0,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 5184,
+        "bugs": [
+          "cpu_meltdown",
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "l1tf",
+          "mds",
+          "swapgs",
+          "itlb_multihit",
+          "srbds",
+          "mmio_stale_data",
+          "retbleed",
+          "gds",
+          "bhi"
+        ],
+        "cache": 12288,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 6,
+        "cpuid_level": 22,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "arch_perfmon",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "cpuid",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "vmx",
+          "ssse3",
+          "fma",
+          "cx16",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "movbe",
+          "popcnt",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "hypervisor",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "pti",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "tpr_shadow",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "vnmi",
+          "md_clear",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 158,
+        "model_name": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 12,
+        "stepping": 10,
+        "tlb_size": 31165,
+        "units": 16,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 133674,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 2147483648,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:3",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:3",
+        "unix_device_name2": "/dev/sg3",
+        "sysfs_id": "/class/block/sdd",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 25,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-36002248042994cacd691c52f2e08fe01",
+          "/dev/disk/by-id/wwn-0x6002248042994cacd691c52f2e08fe01",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:3",
+          "/dev/disk/by-uuid/6e398549-74bd-406a-b9a6-b458fb49306c",
+          "/dev/sdd"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 23,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 381016,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:1",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:1",
+        "unix_device_name2": "/dev/sg1",
+        "sysfs_id": "/class/block/sdb",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-3600224805b5ac507b80a045bc3303ae1",
+          "/dev/disk/by-id/wwn-0x600224805b5ac507b80a045bc3303ae1",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:1",
+          "/dev/sdb"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 32,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 33,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 34,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 35,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1697,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 27262984,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:2",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:2",
+        "unix_device_name2": "/dev/sg2",
+        "sysfs_id": "/class/block/sdc",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 36,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-3600224800696b95cdd20962287e749ad",
+          "/dev/disk/by-id/wwn-0x600224800696b95cdd20962287e749ad",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:2",
+          "/dev/disk/by-uuid/67edc7a8-a3e4-41bf-a504-20a881a13371",
+          "/dev/sdc"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 37,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 49,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 795880,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:0",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:0",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 38,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-360022480728b63b9f0b8d5e28f1d4859",
+          "/dev/disk/by-id/wwn-0x60022480728b63b9f0b8d5e28f1d4859",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:0",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 39,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 40,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 41,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 42,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 43,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "graphics_card": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["graphics_card", "pci"],
+        "detail": {
+          "command": 7,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "008e", "value": 142 },
+        "driver": "dxgkrnl",
+        "drivers": ["dxgkrnl"],
+        "index": 16,
+        "model": "3D controller",
+        "module_alias": "pci:v00001414d0000008Esv00000000sd00000000bc03sc02i00",
+        "slot": { "bus": 11717888, "number": 0 },
+        "sub_class": { "name": "3D controller", "hex": "0002", "value": 2 },
+        "sysfs_bus_id": "b2cd:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/233d912c-b2cd-41c7-981b-b6574ee392cf/pcib2cd:00/b2cd:00:00.0",
+        "vendor": { "hex": "1414", "value": 5140 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["graphics_card", "pci"],
+        "detail": {
+          "command": 7,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "008e", "value": 142 },
+        "driver": "dxgkrnl",
+        "drivers": ["dxgkrnl"],
+        "index": 19,
+        "model": "3D controller",
+        "module_alias": "pci:v00001414d0000008Esv00000000sd00000000bc03sc02i00",
+        "slot": { "bus": 12877056, "number": 0 },
+        "sub_class": { "name": "3D controller", "hex": "0002", "value": 2 },
+        "sysfs_bus_id": "c47d:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/4686eaaa-c47d-415e-b025-a8a8caf4c9b0/pcic47d:00/c47d:00:00.0",
+        "vendor": { "hex": "1414", "value": 5140 }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 51539607552 }],
+        "attached_to": 0,
+        "index": 15,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 48 },
+          { "type": "phwaddr", "address": 48 }
+        ],
+        "model": "Virtual Ethernet Card 0",
+        "vendor": "Virtual",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/293797f4-beca-4fcf-8341-90c5b230a8db",
+        "device": "Virtual Ethernet Card 0",
+        "driver": "hv_netvsc",
+        "sysfs_bus_id": "293797f4-beca-4fcf-8341-90c5b230a8db",
+        "attached_to": 0,
+        "index": 20,
+        "drivers": ["hv_netvsc"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "unix_device_names": ["eth0"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "driver_info": {
+          "type": "module",
+          "active": true,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["hv_netvsc"],
+          "module_args": [""],
+          "names": ["hv_netvsc"]
+        }
+      }
+    ],
+    "network_interface": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 44,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 48 },
+          { "type": "phwaddr", "address": 48 }
+        ],
+        "attached_to": 20,
+        "driver": "hv_netvsc",
+        "index": 45,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/293797f4-beca-4fcf-8341-90c5b230a8db",
+        "sysfs_id": "/class/net/eth0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["hv_netvsc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["eth0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Generic system peripheral",
+          "hex": "0008",
+          "value": 8
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "105a", "value": 4186 },
+        "driver": "virtio-pci",
+        "drivers": ["virtio-pci"],
+        "index": 18,
+        "model": "System peripheral",
+        "module_alias": "pci:v00001AF4d0000105Asv00001AF4sd00000040bc08sc80i00",
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 14778112, "number": 0 },
+        "sub_class": {
+          "name": "System peripheral",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "0040", "value": 64 },
+        "sub_vendor": { "hex": "1af4", "value": 6900 },
+        "sysfs_bus_id": "e17f:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/72e2a6d5-e17f-4d7c-a780-7ae0830f010e/pcie17f:00/e17f:00:00.0",
+        "vendor": { "hex": "1af4", "value": 6900 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "1043", "value": 4163 },
+        "driver": "virtio-pci",
+        "drivers": ["virtio-pci"],
+        "index": 17,
+        "model": "SCSI storage controller",
+        "module_alias": "pci:v00001AF4d00001043sv00001AF4sd00000040bc01sc00i00",
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 5603840, "number": 0 },
+        "sub_class": {
+          "name": "SCSI storage controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "0040", "value": 64 },
+        "sub_vendor": { "hex": "1af4", "value": 6900 },
+        "sysfs_bus_id": "5582:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/c4b741f5-5582-4c98-8f8b-2e082933c396/pci5582:00/5582:00:00.0",
+        "vendor": { "hex": "1af4", "value": 6900 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "class_list": ["storage_controller"],
+        "device": "Storage 0",
+        "driver": "hv_storvsc",
+        "driver_info": {
+          "type": "module",
+          "active": true,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["hv_storvsc"],
+          "module_args": [""],
+          "names": ["hv_storvsc"]
+        },
+        "drivers": ["hv_storvsc"],
+        "index": 21,
+        "model": "Virtual Storage 0",
+        "sub_class": {
+          "name": "Storage controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sysfs_bus_id": "fd1d2cbd-ce7c-535c-966b-eb5f811c95f0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0",
+        "vendor": "Virtual"
+      }
+    ],
+    "system": { "form_factor": "laptop" },
+    "unknown": [
+      {
+        "attached_to": 18,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["unknown"],
+        "device": "",
+        "driver": "virtiofs",
+        "drivers": ["virtiofs"],
+        "index": 22,
+        "model": "Virtio Unclassified device",
+        "module_alias": "virtio:d0000001Av00001AF4",
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "virtio1",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/72e2a6d5-e17f-4d7c-a780-7ae0830f010e/pcie17f:00/e17f:00:00.0/virtio1",
+        "vendor": "Virtio"
+      },
+      {
+        "attached_to": 17,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["unknown"],
+        "device": "",
+        "driver": "virtio_console",
+        "drivers": ["virtio_console"],
+        "index": 23,
+        "model": "Virtio Unclassified device",
+        "module_alias": "virtio:d00000003v00001AF4",
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "virtio0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/c4b741f5-5582-4c98-8f8b-2e082933c396/pci5582:00/5582:00:00.0/virtio0",
+        "vendor": "Virtio"
+      }
+    ]
+  }
+}

--- a/.jjconflict-base-0/hosts/telsha/darwin-configuration.nix
+++ b/.jjconflict-base-0/hosts/telsha/darwin-configuration.nix
@@ -1,0 +1,28 @@
+{
+  imports = [
+    ../../modules/darwin/profiles/distributed.nix
+    ../../modules/darwin/profiles/workstation.nix
+  ];
+
+  home-manager.users.shikanimedeva.imports = [
+    ../../modules/darwin/users/shikanimedeva.nix
+  ];
+
+  networking.hostName = "telsha";
+
+  sops = {
+    age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    defaultSopsFile = ../../secrets/telsha.enc.yaml;
+    defaultSopsFormat = "yaml";
+  };
+
+  system.primaryUser = "shikanimedeva";
+
+  users.users.shikanimedeva = {
+    home = "/Users/shikanimedeva";
+    name = "shikanimedeva";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+}

--- a/.jjconflict-base-0/infra/shikanime-github/.terraform.lock.hcl
+++ b/.jjconflict-base-0/infra/shikanime-github/.terraform.lock.hcl
@@ -1,0 +1,51 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.4.0"
+  constraints = "~> 6.4"
+  hashes = [
+    "h1:B1q5+Ub1G3zJa9y474Fg40eo/N04/vOSeaf3dWaCG0I=",
+    "h1:YiGCvjr7R77HGTzw81legWicEHApVTli8O+ooDpLexE=",
+    "h1:sJvuRMYWJ/ykZXTuoCuocHvx06hTwDVrXVVXq1814bw=",
+    "zh:00f431c2a2510efcb1115442dda5e90815bcb16e1a3301679ade0139fa963d3b",
+    "zh:12a862f4317b3cb65682c1b687650cd91eeee99e63774bdcfa8bcfc64bad097b",
+    "zh:226d5e09ff27f94cb9336089181d26f85cb30219b863a579597f2e107f37de49",
+    "zh:402ecaa5add568a52ee01d816810f3b90f693be35c680fcdc9b6284bf55326f1",
+    "zh:60e3bdd9fbefb3c1d790bc08889c1dc0e83636b82284faaa709411aa4f96bb9f",
+    "zh:625099eeff2f8aaecd22a24a451b326828435c8f9de86f2e5e99872e7b467fa7",
+    "zh:79e8b665421009df2260f50e10da1f7a7863b557ece96e2b07dfd2fad1e86fcd",
+    "zh:98e471fefc93dcfedeec750c694110db7d3331dc3a256191d30b9d2f70d12157",
+    "zh:a17702765e1fa92d1c288ddfd97075819ad61b344b341be7e09c554c841a6d9e",
+    "zh:ca72ccf40624ae26bf4660d8dd84a51638f0a1e78d5f19fdfaafaef97f838af6",
+    "zh:d009ab5527d45c44c424d26cd2eb51a5a6a6448f3fb1023b675789588cc08d64",
+    "zh:e5811be1e942a75b14dfcd3e03523d8df60cfbde0d7e24d75e78480a02a58949",
+    "zh:e6008ad28225ad6996b06bcd7f3070863329df406a56754e7fb9c31d6301ace4",
+    "zh:f1d93f56ea4f87183a5de4780704907605851d95a2d285a9ec755bf784c5569c",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}
+
+provider "registry.opentofu.org/scaleway/scaleway" {
+  version     = "2.48.0"
+  constraints = "~> 2.43"
+  hashes = [
+    "h1:5BbGEXuyORjQ9adWey72qJkOCj9zjwly/aUcwXXXqvo=",
+    "h1:LczipXZujiPUPClltqtt6pDhAxQ7s35v21Fe46hflXU=",
+    "h1:ra/AlSZHIX8gBGtODsiaUp+V8iXpNIL1BZlxDLPc1Es=",
+    "zh:161e4a2981240645b584acf13a76563ca90fff107efd983cbf7db74bfc3462b6",
+    "zh:2cf0df5b147aa0fd50953e00bee8fea56e4ddb0630e7cbc7443619933c37522f",
+    "zh:4cc775235b8b3d0847c4bf0d36c68ced5a1c26628c62abd1d53ccbdbc5c10ff8",
+    "zh:8611025a842c7cd5f629246197157c11b2c77048066b076ccd448e8d9f764213",
+    "zh:8eae8559fdd3f9c3a71bb0c9dfd23084ee0c798ffff779e5836e44ed5cc68948",
+    "zh:c87e86288f4bb128533ff6719959547a3941c83315ede709a4586369c7558090",
+    "zh:cc4f1738b9be10f4106f4e1ba9bdabee64eae6f7c6be937275f019f409fd6390",
+    "zh:cd9610dac94aba5891b4487635100ba893821fd79b3c5dc65c95a8c88db67243",
+    "zh:e36e2eda9bc52efc4053e333aa58be81988651d77b3dbf894c885cd81dec3f32",
+    "zh:ec23c160523dfa2d13d41be83046dbd4ce9e142fd759e73c93f76029869f7da7",
+    "zh:ec4c3a614719e8bdfc50c4c94bcabeb5c8dc14e0658cbc2041470dfb6f86c8a2",
+    "zh:f25c4287fa7c921f7a898543cc8fc7c485bb4fe2f730180f5302cb314bc9ec6a",
+    "zh:f6efe46bfd0716eaa153acad7fc126609ea2d00b50d90554e3f594e2e51578ad",
+    "zh:fb672d0ed1a6b01ed2436988071e6ae92d18b3b22271638c6bd5d32a2688695b",
+  ]
+}

--- a/.jjconflict-base-0/infra/shikanime-github/actions.tf
+++ b/.jjconflict-base-0/infra/shikanime-github/actions.tf
@@ -1,0 +1,46 @@
+resource "github_actions_secret" "cachix_auth_token" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "CACHIX_AUTH_TOKEN"
+  plaintext_value = var.cachix.auth_token
+}
+
+resource "github_actions_secret" "gpg_passphrase" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "GPG_PASSPHRASE"
+  plaintext_value = var.operator.gpg_passphrase
+}
+
+resource "github_actions_secret" "gpg_private_key" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "GPG_PRIVATE_KEY"
+  plaintext_value = var.operator.gpg_private_key
+}
+
+resource "github_actions_secret" "operator_private_key" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "OPERATOR_PRIVATE_KEY"
+  plaintext_value = var.operator.ssh_private_key
+}
+
+resource "github_actions_variable" "operator" {
+  for_each      = var.repositories
+  repository    = each.value
+  variable_name = "OPERATOR_APP_ID"
+  value         = var.apps.operator
+}
+
+resource "github_actions_secret" "wakabox_github_token" {
+  repository      = var.repositories.shikanime
+  secret_name     = "WAKABOX_GITHUB_TOKEN"
+  plaintext_value = var.wakabox.github_token
+}
+
+resource "github_actions_secret" "wakatime_api_key" {
+  repository      = var.repositories.shikanime
+  secret_name     = "WAKATIME_API_KEY"
+  plaintext_value = var.wakabox.wakatime_api_key
+}

--- a/.jjconflict-base-0/infra/shikanime-github/repo.tf
+++ b/.jjconflict-base-0/infra/shikanime-github/repo.tf
@@ -1,0 +1,65 @@
+data "github_repository" "repo" {
+  for_each = var.repositories
+  name     = each.value
+}
+
+resource "github_repository_ruleset" "main" {
+  for_each = {
+    for k, v in var.repositories :
+    k => v if !data.github_repository.repo[k].private
+  }
+  name        = "Main branch protections"
+  repository  = each.value
+  target      = "branch"
+  enforcement = "active"
+  conditions {
+    ref_name {
+      include = ["refs/heads/main"]
+      exclude = []
+    }
+  }
+  rules {
+    required_linear_history = true
+    required_signatures     = true
+  }
+}
+
+resource "github_repository_ruleset" "landing" {
+  for_each = {
+    for k, v in var.repositories :
+    k => v if !data.github_repository.repo[k].private
+  }
+  name        = "Landing protections"
+  repository  = each.value
+  target      = "branch"
+  enforcement = "active"
+  conditions {
+    ref_name {
+      include = ["refs/heads/main"]
+      exclude = []
+    }
+  }
+  bypass_actors {
+    actor_id    = 2
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+  bypass_actors {
+    actor_id    = var.apps.operator
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+  rules {
+    pull_request {
+      require_code_owner_review         = true
+      required_review_thread_resolution = true
+    }
+    required_status_checks {
+      required_check {
+        context        = "check"
+        integration_id = var.apps.github_actions
+      }
+      strict_required_status_checks_policy = true
+    }
+  }
+}

--- a/.jjconflict-base-0/infra/shikanime-github/variable.tf
+++ b/.jjconflict-base-0/infra/shikanime-github/variable.tf
@@ -1,0 +1,60 @@
+variable "apps" {
+  type = object({
+    github_actions = number
+    operator       = number
+  })
+  description = "Application names"
+  default = {
+    github_actions = 15368
+    operator       = 1095999
+  }
+}
+
+variable "cachix" {
+  type = object({
+    auth_token = string
+  })
+  description = "Cachix configuration secrets"
+  sensitive   = true
+}
+
+variable "operator" {
+  type = object({
+    gpg_passphrase  = string
+    gpg_private_key = string
+    ssh_private_key = string
+  })
+  description = "Operator configuration secrets"
+  sensitive   = true
+}
+
+variable "repositories" {
+  type = object({
+    algorithm        = string
+    curriculum-vitae = string
+    features         = string
+    manifests        = string
+    myawesomelist    = string
+    niximgs          = string
+    shikanime        = string
+  })
+  description = "GitHub repositories"
+  default = {
+    algorithm        = "algorithm"
+    curriculum-vitae = "curriculum-vitae"
+    features         = "features"
+    manifests        = "manifests"
+    myawesomelist    = "myawesomelist"
+    niximgs          = "niximgs"
+    shikanime        = "shikanime"
+  }
+}
+
+variable "wakabox" {
+  type = object({
+    github_token     = string
+    wakatime_api_key = string
+  })
+  description = "Wakabox configuration secrets"
+  sensitive   = true
+}

--- a/.jjconflict-base-0/infra/shikanime-github/version.tf
+++ b/.jjconflict-base-0/infra/shikanime-github/version.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "~> 1.8"
+  cloud {
+    hostname     = "app.terraform.io"
+    organization = "shikanime-studio"
+    workspaces {
+      name = "shikanime-github"
+    }
+  }
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.4"
+    }
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2.43"
+    }
+  }
+}
+
+provider "github" {}

--- a/.jjconflict-base-0/infra/shikanime-google-cloud/.terraform.lock.hcl
+++ b/.jjconflict-base-0/infra/shikanime-google-cloud/.terraform.lock.hcl
@@ -1,0 +1,104 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = ">= 3.43.0, >= 3.53.0, >= 4.28.0, >= 5.22.0, ~> 5.36, < 6.0.0"
+  hashes = [
+    "h1:fwPyxJ8zBHeuEyv87dn8YkRHAqXGbJ9AqLN1I8loPr8=",
+    "zh:0931f08e81f220ae3132169cfa4ed8e9d8d2045f29ca914afd8ee9e3e9cf56e0",
+    "zh:31afa45a4c8a0fd4abff564ecff8b69a97ac1813ead61c12f5f0bf5d33cec7f1",
+    "zh:536979e437aad59ba41465c9398d8e3d7d3702bfe2a51d80571862d48c817959",
+    "zh:748e14614be32350ece4e9249e09bc1d20e54421983734ded3a0df6d6674ea71",
+    "zh:7c8fe641666603aad6693207c8eaac679b9be15246d77090c73a1a84326d6084",
+    "zh:8095a513a0662323d99c25466b5a291c80b2b0c1857c7c7a7b1159f25dbe4439",
+    "zh:9453db86d14611cab26dba30daf56d1cfef929918207e9e3e78b58299fc8c4fe",
+    "zh:adaa5df5d40060409b6b66136c0ac37b99fb35ac2cf554c584649c236a18d95b",
+    "zh:af2f659b4bd1f44e578f203830bdab829b5e635fcf2a59ffa7e997c16e6611ad",
+    "zh:b75184fe5c162821b0524fa941d6a934c452e815d82e62675bb21bbdc9046dfc",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "5.45.2"
+  constraints = ">= 3.43.0, >= 4.11.0, >= 5.22.0, < 6.0.0"
+  hashes = [
+    "h1:fDebhcS9qedwzLfzm8NPbvOmKd6RvT0yJidzZ9qObsY=",
+    "zh:2df6e40591ceee7ee77d429ea072c9d51fef2dd04015b2604ff332a2af4ac819",
+    "zh:4096af21991ba76ab81c8cb00c0eb0bd4f22619f7e491d60023fb10b8b33bfb1",
+    "zh:44ded286956fff5668f1acbf152b62ca8e6a03abc8df12c5c181bc2ca05b4df7",
+    "zh:7ae19e1b53a0e26bea0acb9a96b4b44038d7c182c3fdd496148fd20e40aa78e1",
+    "zh:81c9812823b78fd1b12bc0acd6dae35bc573944950e09eaf237b2e83b6b587d7",
+    "zh:9db6101421b53b9533807928c651e779f5b8129f4a57ff892bf256c84ba6ed29",
+    "zh:b779729cb08829f621a718ecdfdb503c310ef5411e694996c7cfda7227221134",
+    "zh:c43edb31aee354317a6181272a961965b93722fd18637f38c395af013aa65617",
+    "zh:dbb93970a85f2fe84f650b6a4da694ecb1023a99c3b9bbf6953dccd074fa49ce",
+    "zh:df9d13853269e98651d495571b4d58c883b4386247d0b9c5495c2e82ef721f45",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.3"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:nNa5j1vTtxcpdC2i61O2tRkZjdkBNsxzYXYIx0VNsjc=",
+    "zh:1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac",
+    "zh:65b7f9799b88464d9c2ec529713b7f52ea744275b61a8dc86cdedab1b2dcb933",
+    "zh:80d3e9c95b7b4ae7c54005cd127cae82e5c53d2b7023ef24c147337bac9dadd9",
+    "zh:841b60c07683e4bf456799ccd718896fdafdcc2c49252ae09967f2e74d8c8a03",
+    "zh:8fa1c592a9c78222e35713c6edb3f1f818a4c6f3524a30a209f0a7e919827b68",
+    "zh:bb795cc1429e09466840c09d39a28edf1db5070b1ec76822fc1173906a264572",
+    "zh:da1784818a89bea29dfe660632f0060a7a843e4e564d74435fbeca002b0f7d2a",
+    "zh:f409bf21b1cdaa6dac47cd79806f3d93f67e9507fe4dbf33b0165335f53bc2e1",
+    "zh:fbea7a1ff84b430ba9594698e93196d81d03e4036de3d1cafccb2a96d5b38581",
+    "zh:fbf0c84663a7e85881388d7d71ac862184f05fbf2d17ecf76bc5d3d7503ea260",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.7.1"
+  constraints = ">= 2.2.0"
+  hashes = [
+    "h1:HxqzkbeZlX7e/UfK6DA6SBYmd1+mURGRsRQHimwrpEM=",
+    "zh:1011387a5127d46e2bf0bd5124a8469506272b2110613d9eb80d178f94bd67a9",
+    "zh:28785c36d6dc331d49e8bf6a30d4ba21ae4378f5d98c43c0aeb42f51efb2e42f",
+    "zh:50fc0e52f0255950404681455420344a16263f91622bd481954606e6e3be9eb2",
+    "zh:563f22c53f40e41cfffdcfac32a9292292c10582183c3f1dd85770cf806bfce9",
+    "zh:586a5615898d369374d4bd7d70bc013cffe7553d3e14638f169a3f745665fee1",
+    "zh:6275f6e5697993048ac088715484a9a5e919682651e098a5ac31e567216bf102",
+    "zh:95a44bb3f012da1e036936d60df2d08f5942a96cb912fc23432d2ee050857527",
+    "zh:a5fe6b0e586645a88d98738739fec40fd7ad83dbc63fe66ff6327aee2dc07f11",
+    "zh:ea57886899b6baf466f3ff978f4482d2fd7fa049c42509cc819431375cddd5bd",
+    "zh:f021cfbe23bdb32738f170c1ae736ffb769a2fa3dcafd0f9906155c2e21377e4",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:Utnw/bDwy8p8v/i08Yx0oHdBQXwdJhCfAPZuSWX8YeQ=",
+    "zh:374c28bafc43cd65e578cb209efc9eee4c1cec7618f451528e928db98059e8c8",
+    "zh:6a2982e70fbc2ab2668d624c648ef2eb32243c1a1185246b03991a7a21326db9",
+    "zh:af83169c21bb13f141510a349e1f70cf7d893247a269bd71cad74dd22f1df0f5",
+    "zh:b81a5bedc91a1a81b938c393247248d6c3d1bd8ea685541f9c858908c0afb6b3",
+    "zh:de15486244af2d29d44d510d647cd6e0b1408e89952261013c572b7c9bfd744b",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.12.1"
+  constraints = ">= 0.5.0"
+  hashes = [
+    "h1:BeB0tURFcd5MQIjLdqpZSFYAXpj3WBI8qstoCHW0WYA=",
+    "zh:50a9b67d5f5f42adbdb7712f67858aa64b5670070f6710751239b535fb48a4df",
+    "zh:5a846fae035e363aed75b966d64a56f3489a38083e8407aaa656730437f53ed7",
+    "zh:6767f1fc8a679b48eaa4cd114da0d8185fb3546375f3a0fb3728f10fa3dbc551",
+    "zh:85d3da407c828bf057cbc0e86c75ef3d0f9f74a73c4ea1b4aef18e33f41092b1",
+    "zh:9180721325139431112c638f5382a740ff219782f81d6346cdff5bccc418a43f",
+    "zh:9ba9989f905a64db1409a9a57649549c89c7aedfb55ae399a7fa9411aafaadac",
+    "zh:b3d9e7afb6a742e9be0541bc434b00d849fdfab0b4b859ceb0296c26c541af15",
+    "zh:c87da712d718acd9dd03f544b020c320699cb29df197be4f74783e3c3d80fc17",
+    "zh:cb1abe07638ef6d7b41d0e86dfb12d60a513aca3395a5da7191947f7459821dd",
+    "zh:ecff2e823ef49eda03663fa8ee8bdc17d27cd419dbdacbf1719f38812dbf417e",
+  ]
+}

--- a/.jjconflict-base-0/infra/shikanime-google-cloud/iam.tf
+++ b/.jjconflict-base-0/infra/shikanime-google-cloud/iam.tf
@@ -1,0 +1,59 @@
+resource "google_iam_workload_identity_pool" "tfc" {
+  project                   = module.project.project_id
+  workload_identity_pool_id = "tfc-pool"
+  display_name              = "TFC"
+  description               = "Identity pool for Terraform Cloud Dynamic Credentials integration"
+}
+
+resource "google_iam_workload_identity_pool_provider" "tfc" {
+  project                            = module.project.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.tfc.workload_identity_pool_id
+  workload_identity_pool_provider_id = "tfc-provider"
+  display_name                       = "TFC"
+  description                        = "OIDC identity pool provider for Terraform Cloud Dynamic Credentials integration"
+  # Use condition to make sure only token generated for a specific TFC Org can be used across org workspaces
+  attribute_condition = "attribute.terraform_organization_id == \"${var.terraform_organization}\""
+  attribute_mapping = {
+    "google.subject"                        = "assertion.sub"
+    "attribute.aud"                         = "assertion.aud"
+    "attribute.terraform_run_phase"         = "assertion.terraform_run_phase"
+    "attribute.terraform_project_id"        = "assertion.terraform_project_id",
+    "attribute.terraform_project_name"      = "assertion.terraform_project_name",
+    "attribute.terraform_workspace_id"      = "assertion.terraform_workspace_id"
+    "attribute.terraform_workspace_name"    = "assertion.terraform_workspace_name"
+    "attribute.terraform_organization_id"   = "assertion.terraform_organization_id"
+    "attribute.terraform_organization_name" = "assertion.terraform_organization_name"
+    "attribute.terraform_run_id"            = "assertion.terraform_run_id"
+    "attribute.terraform_full_workspace"    = "assertion.terraform_full_workspace"
+  }
+  oidc {
+    issuer_uri = "https://app.terraform.io/"
+  }
+}
+
+module "service_accounts_iam" {
+  source  = "terraform-google-modules/iam/google//modules/service_accounts_iam"
+  version = "~> 7.6"
+
+  service_accounts = module.service_accounts.emails_list
+  project          = module.project.project_id
+  bindings = {
+    "roles/iam.workloadIdentityUser" = [
+      "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.tfc.name}/attribute.terraform_project_id/${var.terraform_project}"
+    ]
+  }
+}
+
+module "projects_iam" {
+  source  = "terraform-google-modules/iam/google//modules/projects_iam"
+  version = "~> 7.7"
+
+  projects = [
+    module.project.project_id,
+  ]
+
+  bindings = {
+    "roles/owner"  = var.members.owner,
+    "roles/editor" = var.members.cloud,
+  }
+}

--- a/.jjconflict-base-0/infra/shikanime-google-cloud/install.sh
+++ b/.jjconflict-base-0/infra/shikanime-google-cloud/install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+output=$(tofu -chdir="$(dirname "$0")/../shikanime-hcp" output -json)
+projects=$(echo "$output" | jq -r '.projects.value')
+
+echo "$projects" | jq -r '.studio' >"$(dirname "$0")/studio.tfvars.json"
+echo "$projects" | jq -r '.["studio-labs"]' >"$(dirname "$0")/studio-labs.tfvars.json"

--- a/.jjconflict-base-0/infra/shikanime-google-cloud/project.tf
+++ b/.jjconflict-base-0/infra/shikanime-google-cloud/project.tf
@@ -1,0 +1,10 @@
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 15.0"
+
+  name            = var.name
+  org_id          = var.org
+  billing_account = var.billing_account
+  project_sa_name = "project-operator"
+  activate_apis   = var.enabled_apis
+}

--- a/.jjconflict-base-0/infra/shikanime-google-cloud/sa.tf
+++ b/.jjconflict-base-0/infra/shikanime-google-cloud/sa.tf
@@ -1,0 +1,12 @@
+module "service_accounts" {
+  source  = "terraform-google-modules/service-accounts/google"
+  version = "~> 3.0"
+
+  project_id   = module.project.project_id
+  names        = ["infra-operator"]
+  display_name = "Infrastructure Operator Service Account"
+
+  project_roles = [
+    "${module.project.project_id}=>roles/editor",
+  ]
+}

--- a/.jjconflict-base-0/infra/shikanime-google-cloud/variable.tf
+++ b/.jjconflict-base-0/infra/shikanime-google-cloud/variable.tf
@@ -1,0 +1,42 @@
+variable "name" {
+  type        = string
+  description = "The name for the project"
+}
+
+variable "org" {
+  type        = string
+  description = "The organization ID"
+}
+
+variable "billing_account" {
+  type        = string
+  description = "The ID of the billing account to associate this project with"
+}
+
+variable "location" {
+  type        = string
+  description = "The location for the resources"
+}
+
+variable "enabled_apis" {
+  type        = list(string)
+  description = "List of APIs to enable"
+}
+
+variable "members" {
+  type = object({
+    owner = list(string)
+    cloud = list(string)
+  })
+  description = "List of members to grant roles"
+}
+
+variable "terraform_project" {
+  type        = string
+  description = "The HCP project ID"
+}
+
+variable "terraform_organization" {
+  type        = string
+  description = "The HCP organization ID"
+}

--- a/.jjconflict-base-0/infra/shikanime-google-cloud/version.tf
+++ b/.jjconflict-base-0/infra/shikanime-google-cloud/version.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.0"
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "shikanime-studio"
+    workspaces {
+      prefix = "shikanime-google-cloud-"
+    }
+  }
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.36"
+    }
+  }
+}

--- a/.jjconflict-base-0/infra/shikanime-hcp/output.tf
+++ b/.jjconflict-base-0/infra/shikanime-hcp/output.tf
@@ -1,0 +1,53 @@
+output "projects" {
+  value = {
+    studio = {
+      name            = "shikanime-studio"
+      org             = ""
+      billing_account = "018C2E-353598-F0F3A5"
+      location        = "europe-west1"
+      enabled_apis = [
+        "artifactregistry.googleapis.com",
+        "cloudresourcemanager.googleapis.com",
+        "compute.googleapis.com",
+        "iam.googleapis.com",
+        "iamcredentials.googleapis.com",
+        "run.googleapis.com",
+        "serviceusage.googleapis.com",
+      ]
+      members = {
+        owner = ["user:shikalegend@gmail.com"]
+        cloud = ["group:shikanime-studio-cloud@googlegroups.com"]
+      }
+      terraform_project      = "prj-NCaGDhtLX1Qaox7L"
+      terraform_organization = "org-ZuQrk9oiA78Cy3Ls"
+    }
+    studio-labs = {
+      name            = "shikanime-studio-labs"
+      org             = ""
+      billing_account = "018C2E-353598-F0F3A5"
+      location        = "europe-west1"
+      enabled_apis = [
+        "aiplatform.googleapis.com",
+        "artifactregistry.googleapis.com",
+        "cloudresourcemanager.googleapis.com",
+        "compute.googleapis.com",
+        "datacatalog.googleapis.com",
+        "dataflow.googleapis.com",
+        "dataform.googleapis.com",
+        "datalineage.googleapis.com",
+        "iam.googleapis.com",
+        "iamcredentials.googleapis.com",
+        "notebooks.googleapis.com",
+        "run.googleapis.com",
+        "serviceusage.googleapis.com",
+        "visionai.googleapis.com",
+      ]
+      members = {
+        owner = ["user:shikalegend@gmail.com"]
+        cloud = ["group:shikanime-studio-cloud@googlegroups.com"]
+      }
+      terraform_project      = "prj-qGuaiqVzKAr318n6"
+      terraform_organization = "org-ZuQrk9oiA78Cy3Ls"
+    }
+  }
+}

--- a/.jjconflict-base-0/infra/shikanime-hcp/version.tf
+++ b/.jjconflict-base-0/infra/shikanime-hcp/version.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.8"
+  cloud {
+    hostname     = "app.terraform.io"
+    organization = "shikanime-studio"
+    workspaces {
+      name = "shikanime-hcp"
+    }
+  }
+}

--- a/.jjconflict-base-0/modules/darwin/profiles/base.nix
+++ b/.jjconflict-base-0/modules/darwin/profiles/base.nix
@@ -1,0 +1,74 @@
+{ config, pkgs, ... }:
+
+let
+  # Defaults (cpu, cpufreq, diskstats, filesystem, loadavg, meminfo,
+  # netdev, stat, systemd, processes, thermal_zone) — same set the
+  # victoria-metrics-k8s-stack node-exporter DaemonSet uses on servers.
+  vmagentConfig = pkgs.writeText "vmagent.yml" ''
+    scrape_configs:
+      - job_name: "node"
+        static_configs:
+          - targets: ["127.0.0.1:9100"]
+      - job_name: "comin"
+        static_configs:
+          - targets: ["127.0.0.1:4243"]
+  '';
+in
+{
+  imports = [
+    ./minimal.nix
+  ];
+
+  nix = {
+    extraOptions = ''
+      !include ${config.sops.templates.nix-config.path}
+    '';
+    settings.experimental-features = "flakes nix-command";
+  };
+
+  sops = {
+    secrets.nix-access-token = { };
+    templates.nix-config.content = ''
+      extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}"
+    '';
+  };
+
+  services.comin = {
+    enable = true;
+    # Node exporter listens on localhost only — vmagent scrapes from 127.0.0.1.
+    exporter.listen_address = "127.0.0.1";
+    remotes = [
+      {
+        name = "origin";
+        url = "https://github.com/shikanime-labs/machines.git";
+      }
+    ];
+  };
+
+  launchd.daemons = {
+    node-exporter = {
+      command = "${pkgs.prometheus-node-exporter}/bin/node_exporter --web.listen-address=127.0.0.1:9100";
+      serviceConfig = {
+        Label = "org.nixos.node-exporter";
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/var/log/node-exporter.log";
+        StandardErrorPath = "/var/log/node-exporter.log";
+      };
+    };
+    vmagent = {
+      command = ''
+        ${pkgs.victoriametrics}/bin/vmagent \
+          -promscrape.config=${vmagentConfig} \
+          -remoteWrite.url=https://telemetry.taila659a.ts.net/insert/0/prometheus
+      '';
+      serviceConfig = {
+        Label = "org.nixos.vmagent";
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/var/log/vmagent.log";
+        StandardErrorPath = "/var/log/vmagent.log";
+      };
+    };
+  };
+}

--- a/.jjconflict-base-0/modules/darwin/profiles/distributed.nix
+++ b/.jjconflict-base-0/modules/darwin/profiles/distributed.nix
@@ -1,0 +1,56 @@
+{ config, ... }:
+
+let
+  mkHostname = hostName: "${hostName}.taila659a.ts.net";
+
+  mkBeelinkBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "x86_64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 4;
+    speedFactor = 2;
+    supportedFeatures = [
+      "nixos-test"
+      "benchmark"
+      "big-parallel"
+      "kvm"
+    ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkRpiBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "aarch64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 2;
+    speedFactor = 1;
+    supportedFeatures = [ "nixos-test" ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkBuildMachines = machines: builtins.filter (m: config.networking.hostName != m.hostName) machines;
+in
+{
+  nix = {
+    buildMachines = mkBuildMachines [
+      (mkBeelinkBuildMachine "ashira")
+      (mkBeelinkBuildMachine "manash")
+      (mkBeelinkBuildMachine "nalsha")
+      (mkRpiBuildMachine "fushi")
+      (mkRpiBuildMachine "minish")
+      (mkRpiBuildMachine "nemishi")
+    ];
+
+    distributedBuilds = true;
+
+    linux-builder = {
+      enable = false;
+      ephemeral = true;
+      systems = [ "aarch64-linux" ];
+    };
+
+    settings.builders-use-substitutes = true;
+  };
+}

--- a/.jjconflict-base-0/modules/darwin/profiles/minimal.nix
+++ b/.jjconflict-base-0/modules/darwin/profiles/minimal.nix
@@ -1,0 +1,32 @@
+{
+  # Make home-manager use packages from system
+  home-manager = {
+    backupFileExtension = "backup-before-nix";
+    useGlobalPkgs = true;
+    useUserPackages = true;
+  };
+
+  nix = {
+    gc = {
+      automatic = true;
+      options = "--delete-older-than 30d";
+      interval = [ { Weekday = 7; } ];
+    };
+
+    optimise = {
+      automatic = true;
+      interval = [ { Weekday = 7; } ];
+    };
+
+    settings = {
+      download-buffer-size = 524288000;
+      trusted-users = [ "@admin" ];
+    };
+  };
+
+  # This value determines the Darwin release from which the default
+  # settings for stateful data, like file locations and database versions
+  # on your system were taken It‘s perfectly fine and recommended to leave
+  # this value at the release version of the first install of this system
+  system.stateVersion = 6;
+}

--- a/.jjconflict-base-0/modules/darwin/profiles/workstation.nix
+++ b/.jjconflict-base-0/modules/darwin/profiles/workstation.nix
@@ -1,0 +1,59 @@
+{
+  imports = [
+    ./base.nix
+  ];
+
+  homebrew = {
+    enable = true;
+    enableZshIntegration = true;
+    brews = [
+      "mas"
+      "mpv"
+      "openssl"
+      "pinentry-mac"
+      "pinentry"
+      "pkg-config"
+    ];
+    casks = [
+      "affinity"
+      "android-studio"
+      "appcleaner"
+      "dbeaver-community"
+      "discord"
+      "element"
+      "firefox"
+      "google-chrome"
+      "google-drive"
+      "jellyfin-media-player"
+      "lm-studio"
+      "macfuse"
+      "mattermost"
+      "microsoft-edge"
+      "microsoft-teams"
+      "obs"
+      "rancher"
+      "spotify"
+      "syncthing-app"
+      "tailscale-app"
+      "transmission"
+      "windows-app"
+      "wireshark-app"
+      "xquartz"
+      "zen"
+      "zoom"
+    ];
+    masApps = {
+      Amphetamine = 937984704;
+      Bitwarden = 1352778147;
+      Velja = 1607635845;
+      Xcode = 497799835;
+    };
+  };
+
+  programs.zsh.enable = true;
+
+  programs.gnupg.agent = {
+    enable = true;
+    enableSSHSupport = true;
+  };
+}

--- a/.jjconflict-base-0/modules/darwin/users/shikanimedeva.nix
+++ b/.jjconflict-base-0/modules/darwin/users/shikanimedeva.nix
@@ -1,0 +1,85 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  toDhall = generators.toDhall { };
+in
+{
+  imports = [
+    ../../../modules/home/ai.nix
+    ../../../modules/home/base.nix
+    ../../../modules/home/cloud.nix
+    ../../../modules/home/fontconfig.nix
+    ../../../modules/home/ghostty.nix
+    ../../../modules/home/helix.nix
+    ../../../modules/home/starship.nix
+    ../../../modules/home/vcs.nix
+    ../../../modules/home/workstation.nix
+    ../../../modules/home/zed-editor.nix
+  ];
+
+  identities = {
+    enable = true;
+
+    ghstack.enable = true;
+
+    glab.enable = true;
+
+    gouv = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native"
+      ];
+    };
+
+    operator-6o = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/operator6o";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/operator6o"
+      ];
+    };
+
+    shikanime.enable = true;
+  };
+
+  home.sessionVariables.SSH_AUTH_SOCK = "${config.home.homeDirectory}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock";
+
+  programs = {
+    bash.enable = true;
+
+    docker-cli = {
+      contexts.rancher-desktop = {
+        Endpoints = {
+          docker = {
+            Host = "unix://${config.home.homeDirectory}/.rd/docker.sock";
+            SkipTLSVerify = false;
+          };
+        };
+        Metadata.Description = "Rancher Desktop moby context";
+      };
+      settings = {
+        credsStore = "osxkeychain";
+        currentContext = "rancher-desktop";
+      };
+    };
+
+    zsh.enable = true;
+  };
+
+  sops = {
+    age.keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
+    defaultSopsFile = ../../../secrets/shikanime.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets.cachix-token = { };
+    templates.cachix-config.content = toDhall {
+      authToken = config.sops.placeholder.cachix-token;
+      hostname = "https://cachix.org";
+    };
+  };
+
+  xdg.configFile."cachix/cachix.dhall".source =
+    config.lib.file.mkOutOfStoreSymlink config.sops.templates.cachix-config.path;
+}

--- a/.jjconflict-base-0/modules/flake/darwin.nix
+++ b/.jjconflict-base-0/modules/flake/darwin.nix
@@ -1,0 +1,29 @@
+{ self, ... }:
+{ inputs, ... }:
+
+{
+  flake = {
+    darwinConfigurations.telsha = inputs.nix-darwin.lib.darwinSystem {
+      pkgs = import inputs.nixpkgs {
+        system = "aarch64-darwin";
+        config.allowUnfree = true;
+      };
+      modules = [
+        ../../hosts/telsha/darwin-configuration.nix
+        inputs.home-manager.darwinModules.default
+        inputs.comin.darwinModules.comin
+        inputs.sops-nix.darwinModules.default
+        {
+          home-manager.sharedModules = [
+            inputs.catppuccin.homeModules.default
+            inputs.colemak.homeModules.default
+            inputs.devlib.homeModules.default
+            inputs.identities.homeModules.default
+            inputs.sops-nix.homeModules.default
+          ];
+        }
+      ];
+    };
+    packages.aarch64-darwin.telsha = self.darwinConfigurations.telsha.system;
+  };
+}

--- a/.jjconflict-base-0/modules/flake/devenv.nix
+++ b/.jjconflict-base-0/modules/flake/devenv.nix
@@ -1,0 +1,197 @@
+{ inputs, ... }:
+
+{
+  perSystem =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      toml = pkgs.formats.toml { };
+    in
+    {
+      devenv.shells.default = {
+        imports = [
+          inputs.devlib.devenvModules.git
+          inputs.devlib.devenvModules.nix
+          inputs.devlib.devenvModules.opentofu
+          inputs.devlib.devenvModules.shell
+          inputs.devlib.devenvModules.shikanime
+          inputs.identities.devenvModules.default
+        ];
+
+        identities = {
+          enable = true;
+          ishtar.enable = true;
+          nixtar.enable = true;
+          telsha.enable = true;
+        };
+
+        github = {
+          settings.workflows = {
+            integration = {
+              jobs.skaffold = {
+                needs = [ "nix" ];
+                secrets.CACHIX_AUTH_TOKEN = "\${{ secrets.CACHIX_AUTH_TOKEN }}";
+              };
+              on.workflow_call.secrets.CACHIX_AUTH_TOKEN.required = lib.mkDefault true;
+            };
+
+            release = {
+              jobs.skaffold = {
+                needs = [ "nix" ];
+                secrets.CACHIX_AUTH_TOKEN = "\${{ secrets.CACHIX_AUTH_TOKEN }}";
+              };
+              on.workflow_call.secrets.CACHIX_AUTH_TOKEN.required = lib.mkDefault true;
+            };
+
+            skaffold.on.workflow_call.secrets.CACHIX_AUTH_TOKEN.required = lib.mkDefault true;
+
+            wakabox = {
+              name = "Wakabox";
+              on.schedule = [
+                { cron = "0 0 * * *"; }
+              ];
+              jobs.wakabox = {
+                runs-on = "ubuntu-latest";
+                steps = [
+                  {
+                    uses = "matchai/waka-box@v5.0.0";
+                    env = {
+                      GH_TOKEN = "\${{ secrets.WAKABOX_GITHUB_TOKEN }}";
+                      GIST_ID = "\${{ vars.WAKABOX_GITHUB_GIST_ID }}";
+                      WAKATIME_API_KEY = "\${{ secrets.WAKATIME_API_KEY }}";
+                    };
+                  }
+                ];
+              };
+              permissions.contents = "read";
+            };
+          };
+
+          workflows.skaffold = {
+            enable = true;
+            settings.setup-nix = {
+              cachix-auth-token = "\${{ secrets.CACHIX_AUTH_TOKEN }}";
+              extra-platforms = "arm64";
+            };
+          };
+        };
+
+        packages =
+          with pkgs;
+          [
+            age
+            skaffold
+          ]
+          ++ lib.optional stdenv.hostPlatform.isLinux nixos-facter;
+
+        sops = {
+          enable = true;
+          settings.creation_rules =
+            let
+              ashira = [
+                "age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph"
+              ];
+              ishtar = [
+                "age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy"
+              ];
+              fushi = [
+                "age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y"
+              ];
+              manash = [
+                "age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64"
+              ];
+              minish = [
+                "age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u"
+              ];
+              nixtar = [
+                "age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl"
+              ];
+              nalsha = [
+                "age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5"
+              ];
+              nemishi = [
+                "age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3"
+              ];
+              telsha = [
+                "age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d"
+              ];
+
+              nishir = ashira ++ fushi ++ manash ++ minish ++ nalsha ++ nemishi;
+
+              workstations = ishtar ++ nixtar ++ telsha;
+
+              identities =
+                config.devenv.shells.default.identities.ishtar.ageKeys
+                ++ config.devenv.shells.default.identities.nixtar.ageKeys
+                ++ config.devenv.shells.default.identities.telsha.ageKeys;
+            in
+            [
+              {
+                path_regex = "secrets/ashira.enc.yaml";
+                age = ashira ++ identities;
+              }
+              {
+                path_regex = "secrets/builder.enc.yaml";
+                age = identities ++ nishir ++ workstations;
+              }
+              {
+                path_regex = "secrets/fushi.enc.yaml";
+                age = fushi ++ identities;
+              }
+              {
+                path_regex = "secrets/ishtar.enc.yaml";
+                age = ishtar ++ identities;
+              }
+              {
+                path_regex = "secrets/machine.enc.yaml";
+                age = identities ++ nishir ++ workstations;
+              }
+              {
+                path_regex = "secrets/manash.enc.yaml";
+                age = manash ++ identities;
+              }
+              {
+                path_regex = "secrets/minish.enc.yaml";
+                age = minish ++ identities;
+              }
+              {
+                path_regex = "secrets/nalsha.enc.yaml";
+                age = nalsha ++ identities;
+              }
+              {
+                path_regex = "secrets/nemishi.enc.yaml";
+                age = nemishi ++ identities;
+              }
+              {
+                path_regex = "secrets/nishir.enc.yaml";
+                age = identities ++ nishir;
+              }
+              {
+                path_regex = "secrets/nixtar.enc.yaml";
+                age = nixtar ++ identities;
+              }
+              {
+                path_regex = "secrets/shikanime.enc.yaml";
+                age = identities;
+              }
+              {
+                path_regex = "secrets/telsha.enc.yaml";
+                age = telsha ++ identities;
+              }
+            ];
+        };
+
+        treefmt.config.programs.typos.configFile =
+          let
+            configFile = toml.generate "typos.toml" {
+              default.extend-words.facter = "facter";
+            };
+          in
+          toString configFile;
+      };
+    };
+}

--- a/.jjconflict-base-0/modules/flake/nixos.nix
+++ b/.jjconflict-base-0/modules/flake/nixos.nix
@@ -1,0 +1,188 @@
+{ self, ... }:
+{ inputs, ... }:
+
+let
+  aiModules = [
+    inputs.cua.nixosModules.cua-driver
+    inputs.hermes-agent.nixosModules.default
+    inputs.noctalia.nixosModules.default
+    inputs.noctalia-greeter.nixosModules.default
+  ];
+
+  baseModules = [
+    inputs.comin.nixosModules.comin
+    inputs.sops-nix.nixosModules.default
+    inputs.home-manager.nixosModules.default
+    inputs.colemak.nixosModules.default
+  ];
+
+  clusterModules = [
+    inputs.disko.nixosModules.default
+    inputs.knix.nixosModules.default
+  ];
+
+  beelinkClusterModules = [
+    inputs.nixos-hardware.nixosModules.common-cpu-intel
+    inputs.nixos-hardware.nixosModules.common-pc-ssd
+  ]
+  ++ aiModules
+  ++ baseModules
+  ++ clusterModules;
+
+  rpi4ClusterModules = [
+    inputs.nixos-hardware.nixosModules.raspberry-pi-4
+  ]
+  ++ aiModules
+  ++ baseModules
+  ++ clusterModules;
+
+  rpi5ClusterModules = [
+    inputs.nixos-hardware.nixosModules.raspberry-pi-5
+  ]
+  ++ aiModules
+  ++ baseModules
+  ++ clusterModules;
+
+  workstationHomeModules = [
+    inputs.catppuccin.homeModules.default
+    inputs.colemak.homeModules.default
+    inputs.devlib.homeModules.default
+    inputs.identities.homeModules.default
+    inputs.sops-nix.homeModules.default
+    inputs.noctalia.homeModules.default
+  ];
+
+  workstationsModules =
+    aiModules
+    ++ baseModules
+    ++ [
+      { home-manager.sharedModules = workstationHomeModules; }
+    ];
+
+  mkCatboxNixosConfiguration =
+    system:
+    inputs.nixpkgs.lib.nixosSystem {
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+      modules = [
+        ../../hosts/catbox/configuration.nix
+      ]
+      ++ workstationsModules;
+    };
+
+  mkCatbox =
+    system:
+    let
+      catbox = mkCatboxNixosConfiguration system;
+    in
+    catbox.config.system.build.containerdiskImage;
+in
+{
+  flake = {
+    nixosConfigurations = {
+      ashira = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/ashira/configuration.nix
+        ]
+        ++ beelinkClusterModules;
+      };
+      fushi = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/fushi/configuration.nix
+        ]
+        ++ rpi4ClusterModules;
+      };
+      ishtar = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/ishtar/configuration.nix
+          inputs.nixos-hardware.nixosModules.common-cpu-intel
+          inputs.nixos-hardware.nixosModules.common-pc-ssd
+          inputs.knix.nixosModules.default
+        ]
+        ++ workstationsModules;
+      };
+      manash = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/manash/configuration.nix
+        ]
+        ++ beelinkClusterModules;
+      };
+      minish = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/minish/configuration.nix
+        ]
+        ++ rpi4ClusterModules;
+      };
+      nalsha = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nalsha/configuration.nix
+        ]
+        ++ beelinkClusterModules;
+      };
+      nemishi = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nemishi/configuration.nix
+        ]
+        ++ rpi5ClusterModules;
+      };
+      nixtar = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nixtar/configuration.nix
+          inputs.nixos-wsl.nixosModules.default
+        ]
+        ++ workstationsModules;
+      };
+    };
+
+    packages = {
+      x86_64-linux = {
+        ashira = self.nixosConfigurations.ashira.config.system.build.toplevel;
+        catbox = mkCatbox "x86_64-linux";
+        ishtar = self.nixosConfigurations.ishtar.config.system.build.toplevel;
+        manash = self.nixosConfigurations.manash.config.system.build.toplevel;
+        nalsha = self.nixosConfigurations.nalsha.config.system.build.toplevel;
+        nixtar = self.nixosConfigurations.nixtar.config.system.build.tarballBuilder;
+      };
+      aarch64-linux = {
+        catbox = mkCatbox "aarch64-linux";
+        fushi = self.nixosConfigurations.fushi.config.system.build.toplevel;
+        minish = self.nixosConfigurations.minish.config.system.build.toplevel;
+        nemishi = self.nixosConfigurations.nemishi.config.system.build.toplevel;
+      };
+    };
+  };
+}

--- a/.jjconflict-base-0/modules/home/ai.nix
+++ b/.jjconflict-base-0/modules/home/ai.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    graphify
+    qwen-code
+    rtk
+  ];
+
+  programs = {
+    antigravity-cli.enable = true;
+
+    codex.enable = true;
+
+    claude-code.enable = true;
+  };
+}

--- a/.jjconflict-base-0/modules/home/base.nix
+++ b/.jjconflict-base-0/modules/home/base.nix
@@ -1,0 +1,14 @@
+{
+  # This value determines the Home Manager release that your
+  # configuration is compatible with. This helps avoid breakage
+  # when a new Home Manager release introduces backwards
+  # incompatible changes
+  #
+  # You can update Home Manager without changing this value. See
+  # the Home Manager release notes for a list of state version
+  # changes in each release
+  home.stateVersion = "26.05";
+
+  # Let Home Manager install and manage itself
+  programs.home-manager.enable = true;
+}

--- a/.jjconflict-base-0/modules/home/cloud.nix
+++ b/.jjconflict-base-0/modules/home/cloud.nix
@@ -1,0 +1,34 @@
+{ pkgs, ... }:
+
+{
+  imports = [
+    ./krew.nix
+  ];
+
+  catppuccin.k9s.enable = false;
+
+  programs = {
+    k9s = {
+      enable = true;
+      settings.k9s.ui.skin = "transparent";
+    };
+
+    ssh.settings."ssh.dev.azure.com" = {
+      HostkeyAlgorithms = "+ssh-rsa";
+      PubkeyAcceptedKeyTypes = "+ssh-rsa";
+    };
+  };
+
+  xdg.configFile."containers/policy.json".source =
+    let
+      format = pkgs.formats.json { };
+    in
+    format.generate "policy.json" {
+      default = [
+        { type = "insecureAcceptAnything"; }
+      ];
+      transports.docker-daemon = {
+        "" = [ { type = "insecureAcceptAnything"; } ];
+      };
+    };
+}

--- a/.jjconflict-base-0/modules/home/fontconfig.nix
+++ b/.jjconflict-base-0/modules/home/fontconfig.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.fira-code
+    pkgs.inriafonts
+  ];
+
+  fonts.fontconfig.enable = true;
+}

--- a/.jjconflict-base-0/modules/home/ghostty.nix
+++ b/.jjconflict-base-0/modules/home/ghostty.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+{
+  programs.ghostty = {
+    enable = true;
+    package = if pkgs.stdenv.isLinux then pkgs.ghostty else pkgs.ghostty-bin;
+    settings = {
+      theme = mkForce "dark:catppuccin-frappe,light:catppuccin-latte";
+      command = "${getExe pkgs.zsh} --login -c ${getExe pkgs.nushell}";
+    };
+  };
+
+  xdg.configFile."ghostty/themes/catppuccin-frappe".source =
+    "${config.catppuccin.sources.ghostty}/catppuccin-frappe.conf";
+}

--- a/.jjconflict-base-0/modules/home/graphical.nix
+++ b/.jjconflict-base-0/modules/home/graphical.nix
@@ -1,0 +1,19 @@
+{
+  # Global Noctalia desktop shell theme for graphical Linux hosts.
+  # NixOS-level programs.noctalia has no `settings`; theming is home-manager only,
+  # so this is the shared home module all graphical users import.
+  programs.noctalia = {
+    enable = true;
+    systemd.enable = true;
+    settings = {
+      shell.font = "Fira Code";
+      shell.greeter_sync.auto_sync = true;
+      theme = {
+        mode = "auto";
+        source = "builtin";
+        builtin = "Catppuccin";
+      };
+      location.auto_locate = true;
+    };
+  };
+}

--- a/.jjconflict-base-0/modules/home/helix.nix
+++ b/.jjconflict-base-0/modules/home/helix.nix
@@ -1,0 +1,24 @@
+{
+  programs.helix = {
+    defaultEditor = true;
+    enable = true;
+    settings = {
+      editor = {
+        color-modes = true;
+        cursor-shape = {
+          insert = "bar";
+          normal = "block";
+          select = "underline";
+        };
+        cursorline = true;
+        indent-guides.render = true;
+        line-number = "relative";
+      };
+      # TODO: theme is supported post 2026 september release
+      # theme = mkForce {
+      #   dark = "catppuccin-frappe";
+      #   light = "catppuccin-latte";
+      # };
+    };
+  };
+}

--- a/.jjconflict-base-0/modules/home/krew.nix
+++ b/.jjconflict-base-0/modules/home/krew.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+
+{
+  home.packages = with pkgs; [ krew ];
+
+  home = {
+    # Make krew plugin discoverable for kubectl
+    sessionPath = [ "${config.home.homeDirectory}/.local/share/krew/bin" ];
+
+    # Plugins installation location
+    sessionVariables.KREW_ROOT = "${config.home.homeDirectory}/.local/share/krew";
+  };
+}

--- a/.jjconflict-base-0/modules/home/starship.nix
+++ b/.jjconflict-base-0/modules/home/starship.nix
@@ -1,0 +1,21 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  settings = importTOML "${config.catppuccin.sources.starship}/latte.toml";
+in
+{
+  programs.starship = {
+    enable = true;
+    settings = {
+      directory = {
+        truncation_length = 4;
+        style = "bold lavender";
+      };
+      git_branch.style = "bold mauve";
+      palette = "catppuccin_latte";
+    }
+    // settings;
+  };
+}

--- a/.jjconflict-base-0/modules/home/vcs.nix
+++ b/.jjconflict-base-0/modules/home/vcs.nix
@@ -1,0 +1,89 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.git-credential-manager
+  ];
+
+  programs = {
+    delta.enable = true;
+
+    gh-dash.enable = true;
+
+    git = {
+      enable = true;
+      lfs.enable = true;
+      ignores = [
+        ".hermes/"
+        "*.graphify"
+        "graphify_output/"
+        "graphify-out/"
+        ".graphify_cache/"
+        "graphify_cache/"
+      ];
+      settings.credential.helper = "manager";
+    };
+
+    jujutsu = {
+      enable = true;
+      settings = {
+        aliases = {
+          prune = [
+            "abandon"
+            "nulls()"
+            "conflicts()"
+          ];
+          restack = [
+            "rebase"
+            "--onto"
+            "trunk()"
+            "--source"
+            "roots(trunk()..) & mutable()"
+            "--simplify-parents"
+          ];
+          stack = [
+            "rebase"
+            "--after"
+            "trunk()"
+            "--before"
+            "closest_merge(@)"
+          ];
+          stage = [
+            "stack"
+            "-r"
+            "closest_merge(@)+:: ~ empty()"
+          ];
+          fetch = [
+            "git"
+            "fetch"
+            "--all-remotes"
+          ];
+          switch = [
+            "workspace"
+            "add"
+          ];
+          push = [
+            "git"
+            "push"
+          ];
+        };
+        git.private-commits = "description(substring:\"[private]\")";
+        templates = {
+          commit_trailers = ''
+            format_signed_off_by_trailer(self)
+            ++ if(!trailers.contains_key("Change-Id"), format_gerrit_change_id_trailer(self))
+          '';
+          git_push_bookmark = "\"shikanime/push-\" ++ change_id.short()";
+        };
+        revset-aliases = {
+          "closest_merge(to)" = "heads(::to & merges())";
+          "nulls()" = "empty() & mutable()";
+        };
+        ui = {
+          default-command = "log";
+          movement.edit = true;
+        };
+      };
+    };
+  };
+}

--- a/.jjconflict-base-0/modules/home/workstation.nix
+++ b/.jjconflict-base-0/modules/home/workstation.nix
@@ -1,0 +1,107 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  mkSshHeadlessHost = user: {
+    User = user;
+    SetEnv.TERM = "xterm-256color";
+  };
+
+  mkSshWorkstationHost = user: {
+    ForwardX11 = true;
+    User = user;
+    SetEnv.TERM = "xterm-256color";
+  };
+in
+{
+  catppuccin = {
+    enable = true;
+    flavor = "latte";
+  };
+
+  colemak.enable = true;
+
+  home = {
+    packages = with pkgs; [
+      cachix
+      devenv
+      docker-credential-helpers
+      pass
+      qpdf
+      rclone
+      secretspec
+      wget
+      zip
+    ];
+    sessionPath = [ "${config.home.homeDirectory}/.local/bin" ];
+  };
+
+  programs = {
+    bat.enable = true;
+
+    carapace.enable = true;
+
+    command-not-found.enable = true;
+
+    dircolors.enable = true;
+
+    direnv = {
+      enable = true;
+      mise.enable = true;
+      nix-direnv.enable = true;
+      config.global.load_dotenv = true;
+    };
+
+    docker-cli.enable = true;
+
+    gpg.enable = true;
+
+    jujutsu.settings."merge-tools".mergiraf."merge-tool-edits-conflict-markers" = true;
+
+    mergiraf = {
+      enable = true;
+      enableGitIntegration = true;
+      enableJujutsuIntegration = true;
+    };
+
+    mise.enable = true;
+
+    nushell = {
+      enable = true;
+      extraConfig = ''
+        $env.config.show_banner = false
+
+        source ${pkgs.nu_scripts}/share/nu_scripts/custom-completions/vscode/vscode-completions.nu
+      '';
+    };
+
+    pay-respects.enable = true;
+
+    ripgrep.enable = true;
+
+    ssh = {
+      enable = true;
+      settings = {
+        "ashira.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "catbox.taila659a.ts.net" = mkSshHeadlessHost "shika";
+        "fushi.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "manash.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "minish.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "nalsha.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "nemishi.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "ishtar.taila659a.ts.net" = mkSshWorkstationHost "shika";
+        "thinkcentre-m710t.tailfb4bb2.ts.net" = mkSshWorkstationHost "william-phetsinorath";
+      };
+    };
+
+    zoxide.enable = true;
+  };
+
+  xdg.enable = true;
+}

--- a/.jjconflict-base-0/modules/home/zed-editor.nix
+++ b/.jjconflict-base-0/modules/home/zed-editor.nix
@@ -1,0 +1,76 @@
+{ lib, pkgs, ... }:
+
+with lib;
+
+{
+  programs.zed-editor = {
+    enable = true;
+
+    userSettings = {
+      agent = {
+        default_model = {
+          provider = "Hermes Agent";
+          model = "hermes-agent";
+          enable_thinking = true;
+        };
+      };
+
+      agent_servers = {
+        "Hermes Agent" = {
+          type = "custom";
+          command = "hermes";
+          args = [ "acp" ];
+        };
+      };
+
+      icon_theme = mkForce {
+        mode = "system";
+        light = "Catppuccin Latte";
+        dark = "Catppuccin Frappé";
+      };
+
+      language_models = {
+        openai_compatible = {
+          "Hermes Agent" = {
+            api_url = "http://localhost:8642/v1";
+            available_models = [
+              {
+                name = "hermes-agent";
+                max_tokens = 200000;
+                max_output_tokens = 32000;
+                max_completion_tokens = 200000;
+                capabilities = {
+                  tools = true;
+                  images = true;
+                  parallel_tool_calls = true;
+                  prompt_cache_key = true;
+                  chat_completions = true;
+                };
+              }
+            ];
+          };
+        };
+      };
+
+      helix_mode = true;
+
+      relative_line_numbers = "enabled";
+
+      terminal.shell.with_arguments = {
+        program = "${getExe pkgs.zsh}";
+        args = [
+          "-c"
+          "${getExe pkgs.nushell}"
+        ];
+      };
+
+      theme = {
+        mode = "system";
+        light = mkForce "Catppuccin Latte";
+        dark = mkForce "Catppuccin Frappé";
+      };
+
+      vim_mode = true;
+    };
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/hardware/beelink-eq.nix
+++ b/.jjconflict-base-0/modules/nixos/hardware/beelink-eq.nix
@@ -1,0 +1,94 @@
+{ pkgs, ... }:
+
+{
+  boot = {
+    binfmt.emulatedSystems = [ "aarch64-linux" ];
+    loader = {
+      efi.canTouchEfiVariables = true;
+      systemd-boot.enable = true;
+    };
+  };
+
+  disko.devices.disk.main = {
+    type = "disk";
+    device = "/dev/nvme0n1";
+    content = {
+      type = "gpt";
+      partitions = {
+        ESP = {
+          size = "1G";
+          type = "EF00";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+            mountOptions = [ "umask=0077" ];
+          };
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "xfs";
+            mountpoint = "/";
+          };
+        };
+      };
+    };
+  };
+
+  # Intel N150 needs firmware plus userspace graphics/QSV libraries so the
+  # Jellyfin pod can use VAAPI/QSV via /dev/dri/renderD128.
+  hardware.enableRedistributableFirmware = true;
+
+  hardware.graphics = {
+    enable = true;
+    enable32Bit = true;
+  };
+
+  services.fstrim.enable = true;
+
+  networking = {
+    useNetworkd = true;
+
+    # balance-alb (mode 6): aggregates both 2.5G NICs without switch-side LACP.
+    # The NETGEAR MS308 is unmanaged — balance-alb handles load balancing
+    # entirely in the Linux driver via ARP negotiation.
+    bonds.bond0 = {
+      interfaces = [
+        "enp1s0"
+        "enp2s0"
+      ];
+      driverOptions = {
+        mode = "balance-alb";
+        miimon = "100";
+      };
+    };
+
+    bridges.br0.interfaces = [ "bond0" ];
+  };
+
+  # NIC performance tuning: hardware offloads + RPS for both Intel i226-V ports.
+  systemd.services.network-nic-performance = {
+    after = [ "network-online.target" ];
+    description = "Enable NIC hardware offloads and RPS";
+    script = ''
+      for iface in enp1s0 enp2s0; do
+        ip link show "$iface" >/dev/null 2>&1 || continue
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" rx-udp-gro-forwarding on rx-gro-list off
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" tso on gso on sg on tx on rx on 2>/dev/null || true
+        for rxq in /sys/class/net/"$iface"/queues/rx-*; do
+          echo f > "$rxq"/rps_cpus 2>/dev/null || true
+        done
+      done
+    '';
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    wantedBy = [ "multi-user.target" ];
+    wants = [ "network-online.target" ];
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/hardware/razer-blade.nix
+++ b/.jjconflict-base-0/modules/nixos/hardware/razer-blade.nix
@@ -1,0 +1,19 @@
+{
+  # UEFI laptop bootloader (Razer Blade 17, 2019). Windows dual-boot via systemd-boot.
+  # Windows entry is automatically detected by systemd-boot.
+  boot.loader = {
+    efi.canTouchEfiVariables = true;
+    systemd-boot.enable = true;
+  };
+
+  # Razer Blade 17 peripherals: daemon + udev rules.
+  hardware.openrazer.enable = true;
+
+  # CPU/device power management + suspend-on-lid-close.
+  powerManagement.enable = true;
+
+  services = {
+    fstrim.enable = true;
+    udisks2.enable = true;
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/hardware/rpi.nix
+++ b/.jjconflict-base-0/modules/nixos/hardware/rpi.nix
@@ -1,0 +1,55 @@
+{ pkgs, ... }:
+
+{
+  boot.kernelParams = [
+    # Older Raspberry Pi-class boards still need these cgroup knobs for RKE2.
+    "cgroup_enable=cpuset"
+    "cgroup_enable=memory"
+    "cgroup_memory=1"
+    # Disable USB runtime autosuspend; external SSD drops offline under load
+    "usbcore.autosuspend=-1"
+    # Bind SABRENT/JMicron enclosure to usb-storage, bypassing UASP
+    "usb-storage.quirks=152d:a578:u"
+  ];
+
+  # Silences Raspberry Pi firmware debug flooding on all RPi hosts through
+  # fushi/nemishi/minish. 4 = warnings and above still appear.
+  boot.consoleLogLevel = 4;
+
+  nixpkgs.overlays = [
+    (_: super: {
+      makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
+    })
+  ];
+
+  networking = {
+    useNetworkd = true;
+
+    # Single NIC bridge — all traffic (flannel, SSH, Longhorn) on one wire.
+    bridges.br0.interfaces = [ "end0" ];
+  };
+
+  # NIC performance tuning: hardware offloads + RPS for the USB3 GigE port.
+  systemd.services.network-nic-performance = {
+    after = [ "network-online.target" ];
+    description = "Enable NIC hardware offloads and RPS";
+    script = ''
+      for iface in end0; do
+        ip link show "$iface" >/dev/null 2>&1 || continue
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" rx-udp-gro-forwarding on rx-gro-list off
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" tso on gso on sg on tx on rx on 2>/dev/null || true
+        for rxq in /sys/class/net/"$iface"/queues/rx-*; do
+          echo f > "$rxq"/rps_cpus 2>/dev/null || true
+        done
+      done
+    '';
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    wantedBy = [ "multi-user.target" ];
+    wants = [ "network-online.target" ];
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/hardware/rpi4.nix
+++ b/.jjconflict-base-0/modules/nixos/hardware/rpi4.nix
@@ -1,0 +1,11 @@
+{
+  imports = [
+    ./rpi.nix
+  ];
+
+  hardware.raspberry-pi."4".fkms-3d.enable = true;
+
+  # Disable UAS for external USB drives - use more stable usb-storage
+  # Blacklist UAS kernel module to prevent crashes on VL805
+  boot.blacklistedKernelModules = [ "uas" ];
+}

--- a/.jjconflict-base-0/modules/nixos/hardware/rpi5.nix
+++ b/.jjconflict-base-0/modules/nixos/hardware/rpi5.nix
@@ -1,0 +1,20 @@
+{
+  imports = [
+    ./rpi.nix
+  ];
+
+  # Install the firmware specifically for the Raspberry Pi 5
+  # because the nixpkgs doesn't provide it by default anymore
+  # up to Raspberry Pi 4
+  hardware.raspberry-pi.firmware = {
+    enable = true;
+    uboot.enable = true;
+  };
+
+  boot.kernelParams = [
+    # Probe error -12 (ENOMEM) is also hit when the default 64 MiB CMA pool is too
+    # small for the NVMe admin queue / PRP DMA buffers. Bump it so the driver can
+    # allocate. Confirmed: without cma=512M the probe fails even with the overlay.
+    "cma=512M"
+  ];
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/agent.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/agent.nix
@@ -1,0 +1,16 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./machine.nix
+  ];
+
+  services.knix = {
+    enable = true;
+    role = "agent";
+    serverAddr = "https://192.168.1.28:9345";
+    tokenFile = config.sops.secrets.rke2-token.path;
+  };
+
+  sops.secrets.rke2-token.restartUnits = [ "rke2-agent.service" ];
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/ai.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/ai.nix
@@ -1,0 +1,221 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+{
+  # cargo.nix / dist.nix-style: addToSystemPackages = true + extraPackages -> cargo.nix inherits?
+  services.hermes-agent = {
+    enable = true;
+    addToSystemPackages = true;
+    environmentFiles = [
+      config.sops.templates.hermes-agent-env.path
+      config.sops.templates.hermes-agent-matrix-env.path
+    ];
+    extraPackages = with pkgs; [
+      curl
+      corepack
+      gh
+      git
+      graphify
+      honcho
+      nodejs
+      rtk
+      yarn
+    ];
+    settings = {
+      context.engine = "lcm";
+      custom_providers = [
+        {
+          name = "aperture-anthropic";
+          base_url = "https://ai.taila659a.ts.net/v1";
+          api_mode = "anthropic_messages";
+          model = "glm-4.7";
+          models = [
+            "glm-4.7"
+            "glm-5.2"
+          ];
+        }
+        {
+          name = "aperture-openai";
+          base_url = "https://ai.taila659a.ts.net/v1";
+          api_mode = "chat_completions";
+          model = "stepfun/step-3.7-flash:free";
+          models = [
+            "tencent/hy3:free"
+            "mistral/labs-leanstral-1-5"
+            "openrouter/openrouter/free"
+            "stepfun/step-3.7-flash:free"
+          ];
+        }
+      ];
+      documents."honcho.json" = builtins.toJSON {
+        baseUrl = "https://honcho.taila659a.ts.net";
+        hosts.hermes = {
+          peerName = config.networking.hostName;
+          aiPeer = "telsha";
+          workspace = "hermes";
+          observationMode = "directional";
+          writeFrequency = "async";
+          recallMode = "hybrid";
+          dialecticCadence = 3;
+          sessionStrategy = "per-session";
+          enabled = true;
+          saveMessages = true;
+          dialecticReasoningLevel = "low";
+          pinPeerName = false;
+        };
+      };
+      fallback_providers = [
+        {
+          api_mode = "chat_completions";
+          model = "poolside/laguna-s-2.1:free";
+          provider = "custom:aperture-openai";
+        }
+        {
+          api_mode = "chat_completions";
+          model = "labs-leanstral-1-5";
+          provider = "custom:aperture-openai";
+        }
+        {
+          api_mode = "chat_completions";
+          model = "stepfun/step-3.7-flash:free";
+          provider = "custom:aperture-openai";
+        }
+      ];
+      matrix = {
+        allowed_rooms = [ "!QUaAaCBlSIBcYyOyLb:matrix.taila659a.ts.net" ];
+        allowed_users = [
+          "@admin:matrix.taila659a.ts.net"
+          "@shikanime:matrix.taila659a.ts.net"
+        ];
+      };
+      memory.provider = "honcho";
+      model = {
+        default = "tencent/hy3:free";
+        provider = "custom:aperture-openai";
+        base_url = "https://ai.taila659a.ts.net/v1";
+      };
+      auxiliary = {
+        vision = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        web_extract = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        compression = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        skills_hub = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        approval = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        mcp = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        title_generation = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        memory_query_rewrite = {
+          provider = "custom:aperture-anthropic:openai";
+          model = "auxiliary";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        tts_audio_tags = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        triage_specifier = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        kanban_decomposer = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        profile_describer = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+      };
+      mcp_servers.aperture = {
+        url = "https://ai.taila659a.ts.net/mcp";
+        enabled = true;
+      };
+      # Bare `hermes`/`hermes chat` launches the Ink TUI by default; token
+      # streaming on for live agent output. Explicit --cli/--tui still wins.
+      display = {
+        interface = "tui";
+        streaming = true;
+      };
+    };
+    extraDependencyGroups = [
+      "computer-use"
+      "honcho"
+      "matrix"
+    ];
+  };
+
+  sops = {
+    secrets = {
+      hermes-agent-api-server-key = {
+        group = "hermes";
+        owner = "hermes";
+        restartUnits = [ "hermes-agent.service" ];
+      };
+      hermes-agent-matrix-access-token = {
+        group = "hermes";
+        owner = "hermes";
+        restartUnits = [ "hermes-agent.service" ];
+      };
+      hermes-agent-matrix-recovery-key = {
+        group = "hermes";
+        owner = "hermes";
+        restartUnits = [ "hermes-agent.service" ];
+        mode = "0600";
+      };
+    };
+    templates = {
+      hermes-agent-env = {
+        content = ''
+          API_SERVER_ENABLED=true
+          API_SERVER_KEY=${config.sops.placeholder.hermes-agent-api-server-key}
+        '';
+      };
+      hermes-agent-matrix-env = {
+        content = ''
+          MATRIX_HOMESERVER=https://matrix.taila659a.ts.net/
+          MATRIX_ACCESS_TOKEN=${config.sops.placeholder.hermes-agent-matrix-access-token}
+          MATRIX_E2EE_MODE=required
+          MATRIX_HOME_ROOM=!QUaAaCBlSIBcYyOyLb:matrix.taila659a.ts.net
+          MATRIX_RECOVERY_KEY_FILE=${config.sops.secrets.hermes-agent-matrix-recovery-key.path}
+        '';
+        restartUnits = [ "hermes-agent.service" ];
+      };
+    };
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/base.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/base.nix
@@ -1,0 +1,119 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./minimal.nix
+  ];
+
+  nix = {
+    extraOptions = ''
+      !include ${config.sops.templates.nix-config.path}
+    '';
+    settings.experimental-features = [
+      "flakes"
+      "nix-command"
+    ];
+  };
+
+  sops = {
+    secrets.nix-access-token.reloadUnits = [ "nix-daemon.service" ];
+    templates.nix-config.content = ''
+      extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}"
+    '';
+  };
+
+  services = {
+    comin = {
+      enable = true;
+      # Node exporter listens on localhost only — vmagent scrapes from 127.0.0.1.
+      exporter.listen_address = "127.0.0.1";
+      remotes = [
+        {
+          name = "origin";
+          url = "https://github.com/shikanime-labs/machines.git";
+        }
+        {
+          name = "origin";
+          url = "https://forgejo.taila659a.ts.net/shikanime-labs/machines.git";
+        }
+      ];
+    };
+
+    # Local host metrics pipeline: node_exporter -> vmagent -> vminsert.
+    prometheus.exporters = {
+      node = {
+        enable = true;
+        listenAddress = "127.0.0.1";
+        disabledCollectors = [
+          "bcachefs"
+          "fibrechannel"
+          "infiniband"
+          "ipvs"
+          "mdadm"
+          "nfsd"
+          "os"
+          "rapl"
+          "tapestats"
+          "zfs"
+        ];
+        enabledCollectors = [
+          "interrupts"
+          "processes"
+          "systemd"
+          "tcpstat"
+        ];
+      };
+      process.enable = true;
+      smartctl.enable = true;
+      systemd.enable = true;
+    };
+
+    vmagent = {
+      enable = true;
+      extraArgs = [
+        "-enableTCP6"
+      ];
+      prometheusConfig.scrape_configs = [
+        {
+          job_name = "comin";
+          static_configs = [
+            { targets = [ "127.0.0.1:4243" ]; }
+          ];
+        }
+        {
+          job_name = "node";
+          static_configs = [
+            { targets = [ "127.0.0.1:9100" ]; }
+          ];
+          # Every host scrapes 127.0.0.1:9100 and remoteWrites the SAME
+          # instance label, so VM merges all nodes into one series → garbage
+          # rates. Rewrite to a unique per-host identity + real cluster label.
+          relabel_configs = [
+            {
+              target_label = "instance";
+              replacement = config.networking.hostName;
+            }
+            {
+              target_label = "cluster";
+              replacement = "nishir";
+            }
+          ];
+        }
+      ];
+      remoteWrite.url = "https://telemetry.taila659a.ts.net/insert/0/prometheus";
+    };
+  };
+
+  # Required for node-exporter textfile collector.
+  systemd.tmpfiles.rules = [
+    "d /var/lib/node_exporter/textfile_collector 0755 root root -"
+  ];
+
+  # This value determines the NixOS release from which the default
+  # settings for stateful data, like file locations and database versions
+  # on your system were taken It's perfectly fine and recommended to leave
+  # this value at the release version of the first install of this system
+  # Before changing this value read the documentation for this option
+  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html)
+  system.stateVersion = "26.05";
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/builder.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/builder.nix
@@ -1,0 +1,49 @@
+{ config, pkgs, ... }:
+
+{
+  imports = [
+    ./machine.nix
+  ];
+
+  nix.settings.trusted-users = [ "builder" ];
+
+  services.gitea-actions-runner = {
+    package = pkgs.forgejo-runner;
+    instances = {
+      forgejo = {
+        enable = true;
+        name = config.networking.hostName;
+        tokenFile = config.sops.templates.forgejo-runner-token.path;
+        url = "https://forgejo.taila659a.ts.net";
+        labels = [
+          "docker:docker://node:22-bookworm"
+          "nixos-latest:docker://nixos/nix"
+          "native:host"
+        ];
+      };
+    };
+  };
+
+  sops = {
+    secrets = {
+      codeberg-runner-token.restartUnits = [ "codeberg-runner-${config.networking.hostName}.service" ];
+      forgejo-runner-token.restartUnits = [ "forgejo-runner-${config.networking.hostName}.service" ];
+    };
+    templates = {
+      codeberg-runner-token.content = ''
+        TOKEN=${config.sops.placeholder.codeberg-runner-token}
+      '';
+      forgejo-runner-token.content = ''
+        TOKEN=${config.sops.placeholder.forgejo-runner-token}
+      '';
+    };
+  };
+
+  virtualisation.docker = {
+    daemon.settings = {
+      fixed-cidr-v6 = "fd00::/80";
+      ipv6 = true;
+    };
+    enable = true;
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/distributed.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/distributed.nix
@@ -1,0 +1,92 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  mkHostname = hostName: "${hostName}.taila659a.ts.net";
+
+  mkBeelinkBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "x86_64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 4;
+    speedFactor = 2;
+    supportedFeatures = [
+      "nixos-test"
+      "benchmark"
+      "big-parallel"
+      "kvm"
+    ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkRpiBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "aarch64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 2;
+    speedFactor = 1;
+    supportedFeatures = [ "nixos-test" ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkBuildMachines =
+    machines:
+    let
+      selfHostname = mkHostname config.networking.hostName;
+    in
+    builtins.filter (m: selfHostname != m.hostName) machines;
+
+  mkSshKnownHost = { hostName, publicKey }: {
+    "${mkHostname hostName}".publicKey = publicKey;
+  };
+
+  mkSshKnownHosts =
+    knownHostsList:
+    let
+      selfHostname = mkHostname config.networking.hostName;
+      mergedHosts = mergeAttrsList knownHostsList;
+    in
+    filterAttrs (name: _value: selfHostname != name) mergedHosts;
+in
+{
+  nix = {
+    buildMachines = mkBuildMachines [
+      (mkBeelinkBuildMachine "ashira")
+      (mkBeelinkBuildMachine "manash")
+      (mkBeelinkBuildMachine "nalsha")
+      (mkRpiBuildMachine "fushi")
+      (mkRpiBuildMachine "minish")
+      (mkRpiBuildMachine "nemishi")
+    ];
+
+    distributedBuilds = true;
+
+    settings.builders-use-substitutes = true;
+  };
+
+  programs.ssh.knownHosts = mkSshKnownHosts [
+    (mkSshKnownHost {
+      hostName = "fushi";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILrDoPfjV+jRuGXdsc+TlgaL/+eO9pPqav6SG+tl1nPC";
+    })
+    (mkSshKnownHost {
+      hostName = "minish";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFWXSOEAx3pEzeoaqKV4gCCEVK3do+f2oJWlL++lGA/N";
+    })
+    (mkSshKnownHost {
+      hostName = "manash";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDW8I5803nYCNIKmzXBgfVDYpOJvYH0jg8ht5Djr72eL";
+    })
+    (mkSshKnownHost {
+      hostName = "ashira";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILxxDA8yBStWRl43qL15IvnKrLRW9Y2KlRAtEnxm4n3X";
+    })
+    (mkSshKnownHost {
+      hostName = "nalsha";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGAFFXlS4bbJnvo2CaPdKPHX2EFyrfF/KHfcwsVgOffE";
+    })
+  ];
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/follower.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/follower.nix
@@ -1,0 +1,14 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./leader.nix
+  ];
+
+  services.knix = {
+    serverAddr = "https://192.168.1.28:9345";
+    tokenFile = config.sops.secrets.rke2-token.path;
+  };
+
+  sops.secrets.rke2-token.restartUnits = [ "rke2-server.service" ];
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/graphical.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/graphical.nix
@@ -19,6 +19,7 @@
         # resolve on Niri's spawned PATH (compositor launches them directly).
         laptopSessionUtils = [
           brightnessctl # backlight/brightness keys under Niri
+          ddcutil # DDC/CI external monitor brightness/control
           fuzzel # app launcher; Niri's default config binds Super+R to it
           gparted-full # disk partition GUI (full FS tool set: resize/move any fs)
           pavucontrol # audio mixer GUI (volume keys only step, no panel)

--- a/.jjconflict-base-0/modules/nixos/profiles/graphical.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/graphical.nix
@@ -1,0 +1,89 @@
+{ pkgs, ... }:
+
+{
+  imports = [
+    ./machine.nix
+    ./workstation.nix
+  ];
+
+  environment = {
+    # Niri's built-in default spawns `${env TERMINAL alacritty}` on Super+Enter.
+    # Point it at Ghostty (provided by the home config) without a full config.kdl.
+    sessionVariables.TERMINAL = "ghostty";
+
+    # Gaming + laptop utilities the graphical session needs at the system level.
+    systemPackages =
+      with pkgs;
+      let
+        # Wayland session utilities: launcher + media/backlight controls that must
+        # resolve on Niri's spawned PATH (compositor launches them directly).
+        laptopSessionUtils = [
+          brightnessctl # backlight/brightness keys under Niri
+          fuzzel # app launcher; Niri's default config binds Super+R to it
+          gparted-full # disk partition GUI (full FS tool set: resize/move any fs)
+          pavucontrol # audio mixer GUI (volume keys only step, no panel)
+          playerctl # media-key control for MPRIS players
+        ];
+      in
+      laptopSessionUtils;
+  };
+
+  hardware = {
+    # WiFi / Bluetooth firmware for the laptop radios.
+    enableRedistributableFirmware = true;
+    graphics = {
+      enable = true;
+      enable32Bit = true; # Gaming: 32-bit for Wine/Proton
+    };
+    bluetooth.enable = true;
+    nvidia = {
+      open = true;
+      modesetting.enable = true;
+      powerManagement.enable = true;
+    };
+  };
+
+  programs = {
+    # Niri compositor (ships wayland-sessions/niri.desktop; the greeter lists it).
+    niri.enable = true;
+
+    # Noctalia shell/bar as a systemd user service (auto-starts in the Wayland session).
+    noctalia = {
+      enable = true;
+      recommendedServices.enable = true;
+      systemd.enable = true;
+    };
+
+    noctalia-greeter.enable = true;
+
+    # Niri forces XWayland off (the wayland-session import passes enableXWayland=false).
+    # Re-enable it so X11 apps actually start under Niri.
+    xwayland.enable = true;
+  };
+
+  # greetd daemon. `default_session.user` defaults to "greeter" (auto-created by the module).
+  # The Noctalia Greeter module sets default_session.command to its session binary.
+  services = {
+    # Flatpak sandboxing for graphical hosts. The module asserts xdg.portal.enable,
+    # so the portal must be on or the build fails.
+    flatpak.enable = true;
+
+    greetd.enable = true;
+
+    # Secret Service daemon so Thunderbird's login manager stores credentials
+    # encrypted (Niri ships no keyring today).
+    gnome.gnome-keyring.enable = true;
+
+    # XWayland for the rare X11 app under Niri. Keep xserver on for the XWayland socket.
+    xserver.enable = true;
+  };
+
+  xdg.portal.enable = true;
+
+  # polkit authority daemon: required for the privilege prompts that
+  # pkexec/gparted raise. Noctalia's built-in in-session agent (enabled via
+  # programs.noctalia.settings.shell.polkit_agent in the home module) registers
+  # against this daemon, so the external polkit-gnome agent is intentionally
+  # omitted to avoid two agents racing for the session-bus registration.
+  security.polkit.enable = true;
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/leader.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/leader.nix
@@ -1,0 +1,95 @@
+{
+  imports = [
+    ./machine.nix
+  ];
+
+  services = {
+    knix = {
+      enable = true;
+      addons.flux = {
+        instance.extraConfig.instance.sync = {
+          interval = "1m";
+          kind = "GitRepository";
+          path = "clusters/nishir/overlays/tailnet";
+          pullSecret = "";
+          ref = "refs/heads/main";
+          url = "https://github.com/shikanime-labs/manifests.git";
+        };
+
+        operator.extraConfig.web.ingress = {
+          enabled = true;
+          annotations."tailscale.com/tags" = "tag:web";
+          className = "tailscale";
+          hosts = [
+            {
+              host = "nishir-flux";
+              paths = [
+                {
+                  path = "/";
+                  pathType = "ImplementationSpecific";
+                }
+              ];
+            }
+          ];
+          tls = [
+            { hosts = [ "nishir-flux" ]; }
+          ];
+        };
+      };
+      # Tailscale IP SANs — required because agents resolve hostnames to IPv6
+      # first; without these the load balancer's TLS handshake to the supervisor
+      # port (9345) fails with "tls: internal error".
+      extraConfig.tls-san =
+        let
+          ashira = [
+            "ashira.taila659a.ts.net"
+            "100.71.195.97"
+            "fd7a:115c:a1e0::c53a:c362"
+          ];
+          manash = [
+            "manash.taila659a.ts.net"
+            "100.74.220.28"
+            "fd7a:115c:a1e0::8d3a:dc1c"
+          ];
+          nalsha = [
+            "nalsha.taila659a.ts.net"
+            "100.126.72.116"
+            "fd7a:115c:a1e0::be3a:4875"
+          ];
+          nishir = [
+            "nishir.taila659a.ts.net"
+            "100.80.177.233"
+            "fd7a:115c:a1e0::fc3a:b1ea"
+          ];
+        in
+        ashira ++ manash ++ nalsha ++ nishir;
+
+      traefik.extraConfig.ports = {
+        syncthing = {
+          port = 22000;
+          expose.default = true;
+          exposedPort = 22000;
+          protocol = "TCP";
+        };
+        syncthing-udp = {
+          port = 22000;
+          expose.default = true;
+          exposedPort = 22000;
+          protocol = "UDP";
+        };
+      };
+    };
+
+    # Expose RKE2 API (9345) and Kubernetes API (6443) as a single Tailscale Service.
+    tailscale.serve = {
+      enable = true;
+      services.nishir = {
+        advertised = true;
+        endpoints = {
+          "tcp:6443" = "tcp://127.0.0.1:6443";
+          "tcp:9345" = "tcp://127.0.0.1:9345";
+        };
+      };
+    };
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/machine.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/machine.nix
@@ -1,0 +1,65 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./base.nix
+  ];
+
+  services = {
+    avahi = {
+      enable = true;
+      nssmdns4 = true;
+      nssmdns6 = true;
+      publish = {
+        addresses = true;
+        enable = true;
+        workstation = true;
+      };
+    };
+
+    openssh = {
+      enable = true;
+      openFirewall = true;
+    };
+
+    tailscale = {
+      authKeyFile = config.sops.secrets.tailscale-authkey.path;
+      enable = true;
+      extraUpFlags = [
+        "--accept-routes"
+        "--ssh"
+      ];
+      openFirewall = true;
+      useRoutingFeatures = "server";
+    };
+
+    # Userspace hardware watchdog + system resource monitor
+    watchdogd = {
+      enable = true;
+      settings = {
+        meminfo.enabled = true;
+        timeout = 120; # Increased from 15s to prevent premature reboots
+      };
+    };
+  };
+
+  sops.secrets.tailscale-authkey.restartUnits = [ "tailscaled.service" ];
+
+  # XFS no longer panics on I/O errors: on USB-backed nodes a transient
+  # enclosure I/O error was panicking the kernel and reboot-looping. Let XFS
+  # remount read-only and ride out the hiccup instead.
+  systemd.oomd.enable = true;
+
+  # zram swap so the kernel OOM-killer isn't the first responder on small nodes.
+  # PSI is enabled by default on NixOS std kernel; that also lets systemd-oomd run.
+  zramSwap.enable = true;
+
+  # Force glibc to prefer IPv4 over IPv6 for dual-stack destinations.
+  networking.getaddrinfo.precedence = {
+    "::1/128" = 50;
+    "::/0" = 40;
+    "2002::/16" = 30;
+    "::/96" = 20;
+    "::ffff:0:0/96" = 100;
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/minimal.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/minimal.nix
@@ -1,0 +1,45 @@
+{
+  # Make home-manager use packages from system
+  home-manager = {
+    backupFileExtension = "backup-before-nix";
+    useGlobalPkgs = true;
+    useUserPackages = true;
+  };
+
+  nix = {
+    # Cleanup disk weekly
+    gc = {
+      automatic = true;
+      dates = "weekly";
+      options = "--delete-older-than 30d";
+    };
+
+    # Optimize nix store weekly
+    optimise = {
+      automatic = true;
+      dates = [ "weekly" ];
+    };
+
+    # Allow wheel users to interact with the daemon
+    settings = {
+      download-buffer-size = 524288000;
+      trusted-users = [ "@wheel" ];
+    };
+
+  };
+
+  # Automatically upgrade NixOS
+  system.autoUpgrade = {
+    enable = true;
+    flags = [ "--accept-flake-config" ];
+    flake = "github:shikanime-labs/machines";
+  };
+
+  # This value determines the NixOS release from which the default
+  # settings for stateful data, like file locations and database versions
+  # on your system were taken It‘s perfectly fine and recommended to leave
+  # this value at the release version of the first install of this system
+  # Before changing this value read the documentation for this option
+  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html)
+  system.stateVersion = "26.05";
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/nishir.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/nishir.nix
@@ -1,0 +1,71 @@
+{ lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [
+    ./machine.nix
+    ./wifi.nix
+  ];
+
+  networking = {
+    firewall = {
+      # Cluster -> tailnet egress. Pods route via the node (flannel host-gw),
+      # so their traffic reaches the host on the CNI bridge (cni0) and must be
+      # forwarded out tailscale0 to reach tailnet CGNAT addresses
+      # (100.64.0.0/10, e.g. *.ts.net). The node already holds these routes via
+      # Tailscale --accept-routes; only the firewall FORWARD policy (default
+      # DROP) blocks it. Egress-only: return traffic is ESTABLISHED and allowed
+      # by conntrack. IPv4 + IPv6 (pod ranges are fd00::/56).
+      extraCommands = ''
+        iptables -I INPUT -i br+ -j ACCEPT
+        iptables -I FORWARD -i br+ -j ACCEPT
+        ip6tables -I INPUT -i br+ -j ACCEPT
+        ip6tables -I FORWARD -i br+ -j ACCEPT
+        iptables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT
+        ip6tables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT
+      '';
+      extraStopCommands = ''
+        iptables -D INPUT -i br+ -j ACCEPT 2>/dev/null || true
+        iptables -D FORWARD -i br+ -j ACCEPT 2>/dev/null || true
+        ip6tables -D INPUT -i br+ -j ACCEPT 2>/dev/null || true
+        ip6tables -D FORWARD -i br+ -j ACCEPT 2>/dev/null || true
+        iptables -D FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
+        ip6tables -D FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
+      '';
+    };
+  };
+
+  services = {
+    knix = {
+      # Bridge interface — flannel, firewall, and sysctl rules all target br0.
+      # Bonded on Beelink (bond0 → br0), single-NIC on RPi (end0 → br0).
+      interface = "br0";
+
+      # Use host-gw for flannel overlay — zero encapsulation overhead on same-LAN clusters
+      canal.backend = "host-gw";
+    };
+
+    tailscale.serve.services.syncthing = {
+      endpoints."tcp:22000" = "tcp://127.0.0.1:22000";
+      advertised = true;
+    };
+  };
+
+  systemd.services.tailscale-serve-syncthing = {
+    description = "Expose RKE2 and Kubernetes APIs via Tailscale serve with HTTPS";
+    after = [ "tailscaled.service" ];
+    wants = [ "tailscaled.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    script = ''
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --http=80 https+insecure://127.0.0.1:443
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --https=443 https+insecure://127.0.0.1:443
+    '';
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/wifi.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/wifi.nix
@@ -1,0 +1,43 @@
+{ config, ... }:
+
+{
+  networking.wireless = {
+    enable = true;
+    secretsFile = config.sops.templates.wifi.path;
+    networks = {
+      "SFR_E368".pskRaw = "ext:psk_sfr_e368";
+      "SFR_E368_5SGHZ".pskRaw = "ext:psk_sfr_e368_5ghz";
+      "Vintage Korean".pskRaw = "ext:psk_vintage_korean";
+    };
+  };
+
+  sops = {
+    secrets = {
+      wifi-sfr-e368 = {
+        owner = "wpa_supplicant";
+        group = "wpa_supplicant";
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+      wifi-sfr-e368-5ghz = {
+        owner = "wpa_supplicant";
+        group = "wpa_supplicant";
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+      wifi-vintage-korean = {
+        owner = "wpa_supplicant";
+        group = "wpa_supplicant";
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+    };
+    templates = {
+      wifi = {
+        content = ''
+          psk_sfr_e368=${config.sops.placeholder.wifi-sfr-e368}
+          psk_sfr_e368_5ghz=${config.sops.placeholder.wifi-sfr-e368-5ghz}
+          psk_vintage_korean=${config.sops.placeholder.wifi-vintage-korean}
+        '';
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+    };
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/profiles/workstation.nix
+++ b/.jjconflict-base-0/modules/nixos/profiles/workstation.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+
+{
+  imports = [
+    ./base.nix
+  ];
+
+  programs.gnupg.agent = {
+    enable = true;
+    enableExtraSocket = true;
+    pinentryPackage = pkgs.pinentry-all;
+    settings.default-cache-ttl = 60 * 60;
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/users/automata.nix
+++ b/.jjconflict-base-0/modules/nixos/users/automata.nix
@@ -1,0 +1,20 @@
+{
+  users.users.automata = {
+    initialHashedPassword = "";
+    isNormalUser = true;
+    home = "/home/automata";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOuenA6cT5pkPEwdGvmvXRjVqFTv2QwpyYrB7gvMy0/X"
+    ];
+  };
+
+  home-manager.users.automata = {
+    imports = [
+      ../../../modules/home/base.nix
+      ../../../modules/home/cloud.nix
+      ../../../modules/home/vcs.nix
+      ../../../modules/home/workstation.nix
+    ];
+    programs.bash.enable = true;
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/users/builder.nix
+++ b/.jjconflict-base-0/modules/nixos/users/builder.nix
@@ -1,0 +1,7 @@
+{
+  users.users.builder = {
+    isNormalUser = true;
+    home = "/home/builder";
+    useDefaultShell = true;
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/users/nishir.nix
+++ b/.jjconflict-base-0/modules/nixos/users/nishir.nix
@@ -1,0 +1,11 @@
+{
+  users.users.nishir = {
+    extraGroups = [ "wheel" ];
+    home = "/home/nishir";
+    initialHashedPassword = "$y$j9T$HB1msXB0DEq00J48zRpB20$/3rhVrTzGrv1j/cPvZ0clOM2gEe1TeylUG39wgD0C42";
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+}

--- a/.jjconflict-base-0/modules/nixos/users/shika.nix
+++ b/.jjconflict-base-0/modules/nixos/users/shika.nix
@@ -1,0 +1,64 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  toDhall = generators.toDhall { };
+in
+{
+  imports = [
+    ../../../modules/home/ai.nix
+    ../../../modules/home/base.nix
+    ../../../modules/home/cloud.nix
+    ../../../modules/home/fontconfig.nix
+    ../../../modules/home/ghostty.nix
+    ../../../modules/home/graphical.nix
+    ../../../modules/home/helix.nix
+    ../../../modules/home/starship.nix
+    ../../../modules/home/vcs.nix
+    ../../../modules/home/workstation.nix
+    ../../../modules/home/zed-editor.nix
+  ];
+
+  identities = {
+    enable = true;
+
+    ghstack.enable = true;
+
+    glab.enable = true;
+
+    gouv = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native"
+      ];
+    };
+
+    operator-6o = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/operator6o";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/operator6o"
+      ];
+    };
+
+    shikanime.enable = true;
+  };
+
+  programs.bash.enable = true;
+
+  sops = {
+    age.keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
+    defaultSopsFile = ../../../secrets/shikanime.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets.cachix-token = { };
+    templates.cachix-config.content = toDhall {
+      authToken = config.sops.placeholder.cachix-token;
+      hostname = "https://cachix.org";
+    };
+  };
+
+  xdg.configFile."cachix/cachix.dhall".source =
+    config.lib.file.mkOutOfStoreSymlink config.sops.templates.cachix-config.path;
+}

--- a/.jjconflict-base-0/modules/nixos/virtualisation/containerdisk.nix
+++ b/.jjconflict-base-0/modules/nixos/virtualisation/containerdisk.nix
@@ -1,0 +1,43 @@
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.containerdisk;
+in
+{
+  imports = [
+    "${modulesPath}/virtualisation/disk-image.nix"
+  ];
+
+  options.containerdisk = {
+    name = mkOption {
+      type = types.str;
+      description = "Container image name to assign to the built containerdisk.";
+    };
+
+    settings = mkOption {
+      type = types.attrsOf types.anything;
+      default = { };
+      description = "Extra attributes bound directly to the dockerTools.buildImage config attrset.";
+    };
+  };
+
+  # Reference: https://github.com/kubevirt/kubevirt/blob/main/docs/container-register-disks.md
+  config.system.build.containerdiskImage = pkgs.dockerTools.buildImage {
+    inherit (cfg) name;
+
+    copyToRoot = pkgs.runCommand "containerdisk" { } ''
+      mkdir -p $out/disk
+      cp -v ${config.system.build.image}/${config.image.fileName} $out/disk/${config.image.fileName}
+    '';
+
+    config = cfg.settings;
+  };
+}

--- a/.jjconflict-base-0/secrets/ashira.enc.yaml
+++ b/.jjconflict-base-0/secrets/ashira.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:bkZbtYiQMqPwPtSQRS7yp0DcMlBFqo19mYAGAQqEF6S3j5qf3okjDyaig1iQgS8=,iv:TF9l3sc4GZMDqMviLcwbec/3ZwW/31LGjm+sN3BNddo=,tag:AHXmz82qDWB/AJLexg3AIw==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:R5xFpFiK9dC62N9z7f3P/vxHe0oaDYurmd3zSnPccg1pk7v7WN+bt72qaMfADpmzzdhcjg1SWTcjxSQ=,iv:bGbmEG9S6RbbeHfZCxcpgRo/YRod0vsSrfRkNMAZ1Go=,tag:DD7fuG6pPHDRBevvHE7P5Q==,type:str]
+rke2-token: ENC[AES256_GCM,data:ZhjHnX2cGo1fKoo2GoJa4xshr+8nMo1SwJ8UdVWYc4a2FbV/ehDTSlaEz8DbE9J9aLvEiJ3oJCFBBD8SqitfTxo5S1JpbJy0kYKrse6a5D/fvHcZVFjWE6g10ONS/v8NDJywhe4yb9cxMMsr,iv:E2x2yMigVlgH/Rb0uaNYQ/x2Qk/dJe2uIf+EFRxHTTI=,tag:LlVJN6KAqlUcoeg9/fnKWg==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:16:56Z"
+  mac: ENC[AES256_GCM,data:IQZlaopB1rbqovdLcrqwUeHnh3AcGarPlR+vP5LUxJZ0kGBSGLIoHKT1/E2dZsRF8nQgS7oGzerbUcIbIwrd/dM64FBBfvRh7uA81d+BrPMGlGsQ8Vphr7OUZKj83zAYrJRL6shVNYLhfsP15mA7Jk2WAP3lygq4whWnyiPhalI=,iv:tudWaflVADz3gvwnzC87ddYqpQb3Ubu9D+wK1gEeIR0=,tag:f2tT/BQGbOmLeou7OZKfyA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUR3NzSTkwNFQ4d1d6bllX
+        M3MzNFF2Y1NyOXluZHVlNlArMUd0Y0srS3pvCk9WWndlTnhrcnIrZnlZTE9qUHMw
+        ajZINDlnZHR0ZzZZNUZ6clpid2d5S2cKLS0tIEFRK1o4YldGNlFyQi9PV21NRVhQ
+        NDlMU2dncjNoekRYUWJ2eExBRFhVK3MKZ1Twn79tKsndCEqkX3x505kLR2CGGKP0
+        5gijo+lh0LthON7GmJ+59kAxXNPsYK1kGQ02lCF2drQz2K5DY8ASvA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYQ1VKVWZSaHFjSW5EcXAy
+        MFJzSkxsdmpiS0toUzZSMi9WbTRya3JqV0VZCmlGRCs0VWNnY2pRazNjd3Y2QUV1
+        QUtSN0MzV0YrRHBvWHhGbVgyUGpQSHcKLS0tIGo4MWRKbnB6Q0JpcGUzT0U5NndX
+        YVIvZkU4VmNjSFQyMUVCeHhKVmZjVXcK/ZziPsyZTXy1DN5sBUQLn+Rys+IWcTJ2
+        MNHKnHyRV7rPccKO+Uhtr+WcW9OJ1xXXyW3OoIRqkz7lN3k+G/rXkw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBONmRjL3orRTIyU1FOTG83
+        QjlEV01wK0pGWnpaa0ZPVzFDNElwcWk0RWlNCkZPcW1QSlNDeERSUk5tTFpvMlht
+        WXh2YVoyc3ZXV0V4WVU2NWRoclVUYlUKLS0tIGJEc21LR1VENnpmSGx3czBVN1FH
+        S0dpTVpLOG5YbVF1a1gzd2ozeVVOZjQKpVwFVz8HwSCSsYgYnUxg1cA/jWTTUGlU
+        /GGt0GF9G4cFLYcUU1h9DqzdnrEDmcAS8AU5DlnTyXg6CPriXQovHQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSU09Bc0x0SC9Xd3FRZngz
+        Z1lLckptN2VlWTVrbzVNWHlSempvaTdsbVNVCmJGMC85VDRwNWZIaml2U0dhU1Jo
+        VzZ1eURFeDh1WEc0Sk9nb0w0S052czQKLS0tIE1lYloxRDJnaHpFaldUcEJtdmRF
+        aTR6Ty9OcHVTYW9BVmdZbHFOaXlPc1UKiQbKnZiKbRRi5bNpso2wjAf0XVQHYQUr
+        NXy3DZ3mIg0YTO1IwTDZ1059iXdYAHmWZrEShMfO7a0KUb3YA4BzmA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:qfFWKqM8wFIG5rE3wCURxZtGBtbcutjl+cMYIuIxvhxAotpfYMjnZsT6VxtCzwkQUFVZptqMBA8xB57UUwk=,iv:3ZA/q7WHvfscBSUkRuW5IzsPG8EMlZj+FQrE68QnWf0=,tag:3O7384nD+ahnWmLUkrDqqg==,type:str]

--- a/.jjconflict-base-0/secrets/builder.enc.yaml
+++ b/.jjconflict-base-0/secrets/builder.enc.yaml
@@ -1,0 +1,116 @@
+codeberg-runner-token: ENC[AES256_GCM,data:4uJawrEOfsM3DEVO9Zacv3HSWVGIuUZI1VrOuJleD/V659P02N093t5hMA==,iv:qP5hCFucau4gV2RlguA06df9JTaGumOuX2Fda4mtVj8=,tag:YX+MtZaZdwbBYSWEhAp86Q==,type:str]
+forgejo-runner-token: ENC[AES256_GCM,data:5V5mujkVjqxkSkE1F9oRDpWJlz2ubJc4EhRltQOp5q3DquB/1i/CQy5rgA==,iv:J3boywVhURVH9Fzv98oHcg5mz0euDftBJ1F07YAEsOM=,tag:m2lR8/x1NMzNw6imEc4XtA==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:28:03Z"
+  mac: ENC[AES256_GCM,data:rI0TEzb3brGH+kzYsSJtphUTL9yEd5XapIoA1Oo3AxzQScqzmE2r6X6mzrlAwK0IBlvrCZthmjitwRqcjxAXjW2abZQwbvCdjwIJAhGL6N+1ziiuXaQQfenwH0ow/Tqf7jvgFu/v5MA8oHTjuqPyCn7UuQjHinmXBjzIIT2c3N0=,iv:idioPVWqIGxwDszOYfqzwOOEMkLaoVL2liNtiXtwytw=,tag:oR7eLuxJOwt/XssPeaB5Yg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCNTl4WHdQVlMvOWYrdk5V
+        ME1xZUhzSEkxdXhDMWJLVXZXT01xNGZjZlRvCkJpNEdockUybjh1aWpJdkRXck1U
+        Ym9BZ25tWENmemYrWkgyQW5wMGpwT2cKLS0tIEJoUUQreERFMEdKWjFhNXROYStX
+        akNMYnhmTEVhcEFGTnlxNWRzc0o1djgKssBDBGpA0FGTD41SUPZ0Gq+aBvfZpDlp
+        qmbcwmh6WK+/zuEILwA2HZ6U14C4ML205ntg45id4iY4E1+vszwJVg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOWWhvUkhwSDZXV1MyVEZz
+        ZTNWREZRVjJCSVdVYzFIWWwzV1RaOU1yMkdFClIySVJ1K1ZWa1NNemZyZnlUMzFQ
+        cS9nWDlZZ3gvNzFKcFJGcUJONGVVQnMKLS0tIGtPUm9YS09JbXVsN3J2bzJlUHFn
+        SHNQL0xWOGowYlh0Z2E2QnllaDNWRVUKxjrJPfksk71OfJ7jszGdEChcrMubrjAv
+        V3OXt6xErb03Ao6x/8MXtoGcc+R5ssVWjFC6y65rSUyvbvGCCaneVg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuZkN0c0YrM1NvdEM5aGJI
+        dHRsUThTdHpWNkZPV0c3VEVObGhqdVlSa0VBCjUzcHg0VkZPL2VoUTJOcys1MVFR
+        UFNjQzNTaTFrM3BQZGp0dDJUTTJ1UEUKLS0tIFVoUmNYNGtNVFdPcHJCVTAvejR5
+        QUV1aDNKQzh6MlV4YlFhUkVqQi8wSVUKZCOtsLsim2X3G9oz35MYU3QvdGDqkl7u
+        QKifhCdc869nSlqQq13uHfi0fZt4qtKEdxzrkb6TUWOPO1A4/eOP9Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBORnJzK2dXbnFoZEVuQmdh
+        RnFhYjZBUTlVQmRZQVZOUjJnMk95UnV6ckJzCis0eXhERHNsRGREdVNBZWtTVkRi
+        RkdpeFQxRnVpUjBPK0JhNStwaVd3NTgKLS0tIENxSThIbWJENVhGYlJHSU9mWVdp
+        bHVBM2FhUkVrVTlCZS8rNWlUWk53UW8KlIOOf82n9Z0Zfg/NRffglM1ykMTKRP9F
+        KhZsljCGnmiE1SlQ77MRy49S0wFPMWJmGPHJJnd/IKK8GCLBO1Za+A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIL3Azc3JVUEdkZEYxVFVR
+        VjJNcXdkd0E3V0orRzFGdDc0Q0FXMlhsVUhZCkxlRk9HT3NLN3lybGNxd1NqbVVO
+        Z2o5WDlQNXVzRmw3MFl3enJ6dGlNbHcKLS0tIHJwNjh6Ukp1clhNOXNqTTgvVXV2
+        cERQOUFxajh5R1h1ZXZCTjZvVk9VT3MKzWBn+gY7uOvMuHu7rXOmA2uIgI5ckqxx
+        +q8PDflHbdEZT6uexswWwKygMlr1xE0Pg2aLOxZcyFsa3+ttNQSAIA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqTVVNTTFDMFR3SXBEYnho
+        VnF4OE1WcU90d0FWd1YvUGJHUUhDMFFiUUVNCmd5QkM0SUVBR2dYY0Z6VlF4eHJk
+        V1k0cVNIQXZMTmJzNjJaWUdVbFRiQ1EKLS0tIFhFSlJGMlJXUGZOSkNibHp1ZjR4
+        ZlhaNjUwT0JXdDZOZEM3UWpKM2ZtQUUKLYZcJ0nPrwt71nrEZKLGZdghoz95c0lX
+        tRWrtiQK0OIRgnVpUdKQWGWTUULvT0Lo8mh7uOVl2wZW3+V7UWT8cA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxT1JQL2U0QnpGKzJmYlkx
+        QS9RMXZaTy9IRW56MVVPTGNxRGVJK1RtM25VCkt2Z3JXVForYjJXQThWMlE2QlM4
+        TzlTN1pKQzAvRWlZNXl2cFBodWVKNGcKLS0tIElFMy9NMHFlZElRL0pwRkVLdXpT
+        c1pDbHRDK2NucEQ2dFBOdWlsK1lqOFkKfw8uBv+Z9mogXi1I0bIN1fFnk7+H7VEE
+        MMeYmIZGWkwDhCmH/5e7Um+PQ6DNTx7yUjj2YzIvbp3IsGwCORpmvQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJUUhTSCtjYm9VMnRLMnBz
+        b3FIV1NONjJEblN3bWVWeVdZUjBNTjZuWWo0Ck82ZmxoTEoxU0hXNW8ydms1eXZw
+        Yy9yV2VtNFI1aXZRYUpqT3huVU9GRVkKLS0tIGFub05PQ0dRWjZPUjViTmdaK1Iz
+        VjkwS1ByTW8rUjFVL1lMVVA2anJFT2sKIMUCDi487H807PINn7MDQSrnAvvrFtyw
+        10It6rpHQeHh3DV3CrsnHjsk5AJvFHHVjdXriXKKmFVgzDGPPR72Xg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyTEZjNys0T2ZzQ1ZCTWE3
+        MXRIb3JtREhVK0xuL3N1VDVEZ0t3b1U5OUN3Ci9GSVpGZVRUVmZNMDdYNitYc0lw
+        UDJ1NW90MGhXNDlUd1N4MVd6a21jYnMKLS0tIHgvM0g0SzN1QTZTcjBuOXVySFNN
+        cnpzN3Q0YlNoWThWL2Q1azVjS2xveTAKOcm34DduIdHH6kIzAVbNbHQW/BdrhHt0
+        YbT6RLltrrigugxH2vjv/2Ve0IOdQvOHkvUP4h9B4l/OCzSf88jlcA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDZTFabDN4YlNwVEUyNi9q
+        SEVNUkUxdEdPa0o2N1hmRy9VM1BBZ3puL0Z3CkxRRExabHI1V0FrRGk2REdxV2ZR
+        VllBaVNpRGs4TVBpQ3NOSFIwc0xwVU0KLS0tIFkrSjBrdDBqdzFIMGVwbWs3Zzhp
+        aVRvZVF3MkFHd2lrY04wOUtGUmlTZ1UKCeWRPAiRoHD68gkJ0UY1nS8b6H58/S3A
+        IaYl6uK6Kixc2O/fQbZ7BfGgvHABaV4GrYUONWCCDRp99p6O390Yfw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4QkZFc2ZVRWZ5dWFMcWVs
+        Q3lia3g5bWRXdEJoa3hQdElDRDhxMVVPYW5vClhxS0x3SVRmRmpSZVZxMndnbjZ2
+        eS93aHR5ZHFZQ09YN2lKbU5WU3NXZlUKLS0tIHdyOGc5Y3ZOdUdqZlRQOURrQThq
+        SGJPbVBlTUp0aFMrWG5TWTQ1WHB4YWsK7HXOkWsjZao4QsyxjogEM1RPQMi19Tey
+        UCQ6NAF7b4hQDHcB2C01j4uKGAKCCHKK1DbNwCniliRxJc119lLIrg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5MC9jNXU3ZHRsUUVBYkEz
+        dHU1aERWQ29aVWxyaEJYV2FZQTdhRVFmM0U4Ck9lZGppWUZjbjRQNnU3dHIzclk4
+        M0NzVlBpeFBJZ2NkRi92dXhDcEFlK1UKLS0tIHcwWFMwV2pHL2c0a0ZBeWhja2NS
+        VlJhYXoxOEcya0JQY0tZNzBUUDllVWMK4oS3Rpb9AQwatA/OykeoJ7AqNrZ72kLw
+        sJnIwoiBT9Guzdz4CLzYcbHCDkhrMNU4SlVbG6QTtLJfpp59p5G8tQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d

--- a/.jjconflict-base-0/secrets/fushi.enc.yaml
+++ b/.jjconflict-base-0/secrets/fushi.enc.yaml
@@ -1,0 +1,45 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:3FV3y8ElvePApyX/uqMo3xy5Pt66YtbNc/e6dEGpJZ7nTWF1z/nJdWQS+GlhwtnA,iv:/ljlAwygMaMm7jQEzhanb23DwcHcxQc9B1yW4DdsrYI=,tag:23Ac8PYQG05bOB59iiJL6A==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:Ou7lVgiGZz2/oF2gsdeQao/qwX0qsCbxElCbP3FyKGDrBQy8ePjDWIXW2fMGVVV8i6+OMGJPQTVKrGs=,iv:5OHFZRMaxQgd/uyMsH7LTPiSsK46UriJEuY6ozMND3M=,tag:I/nYVqw6I4ieUqdRw0Erlw==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:17:39Z"
+  mac: ENC[AES256_GCM,data:Y257wW8/3h/624yfXz803LBR0wyNjqxYpajlqo0UsCL4X8yDoI/2w7vfgQMCTDvp4pA97n/UXy0CUpxXd78JpuFBrQlZTxFs94eTun30AYbkx5BOOQsGhHh5biq6gMTYnzl0FG7Mneef33IiMpNhOZ+W6wkCaXMaTK3bN5AUGkQ=,iv:XKtysKpR+G+z/sgNswnzpuAsu1voFM765wqZT+4jYRA=,tag:uRYv9T0Xa+01oaohznLwEA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVMG85VE91bGtXdkpRRHZo
+        MmNKVE9YOEhQcGRtODZKMk1sSHlQa3V5R1NFCk9GZVhpcVdGdS9ES2Q5WTZlK2Zz
+        d1hqYkdHWEtpd0U4UWhmWngxaEpEVzQKLS0tIHdYd0txZHliN0hhVmRsSStsdFRJ
+        Zkw4R1JNN2YyVUR0Um54NldldHlJUVUKK0FLH/vXC3XEXhEn+5l0mUlrYsxovfJ3
+        z6ollcJobYstMLFpddyes6mpvfiir/nisNBaXcGqjloiGlqu0YefeA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyNFNpYktoSjI1WlZ3MnJ3
+        cGdJNG0zL3cxQzk5RUxMaGJ6YW5iNnBITlNFCmNhaytOc21FUldMbXYrTFJIbzNz
+        WVprQ3VnZVlleFFvR3FFN09XK1R5K2sKLS0tIE9iWlJMM3YzUUR1cXNXdFRYWE95
+        YWV6ME9wTHFvSnl1cFFtT3JXaDJ4MncKI9AMHtjIjGRavoCG6y9cJEP9/h5mEJol
+        oEpI120i0Qd3mXP+GcI/k9Xwh7m58EFiPbeNE+dJWKoIMz6yYlHSYA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZRGcrNDQzWFhXOE1ZVU55
+        ajVnL2ZtTTF2VWo3NHJmRDd5V05hQXRHaGdRCmpNOVIvUmZVM0QwMndRSWhoY3Ji
+        RUxsMzFPdzgzQzlqd29LcjRpM2hpMFEKLS0tIExZRzZZTjBYZGNtbzFPWVR5cTZw
+        WisvWGtEVDZuSmh2OHZrN0xUOGVodzgKZzK+Zc0EYPf/Nnco8zyL16/28nbSWqLH
+        157s0N0ZdzphCE/v95LZiSks1gUmxwANJFUA/qrwRSOpnLAcdDrzFA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJQ01QSWxMQmpvWFdDSjNU
+        bkJrRzhsbEpJbjZncUxURjhxR0d1dmdGUndzCm5ETEdaUUgrZDI1dVVLUmxHVFlJ
+        WUE1OWhBbUFqUzJ1c1JwbG0xTFhXa00KLS0tIGk0d0xKWHFXVElSZ3BUZlRSdUFO
+        dnA4UXUzMFV6bFY0by9Ic1dZRi91RE0KROZyLBLbOWWnOu0Sg62wREsFtz0Z1FbT
+        2i8bZUw+abcqWM+jmCde1LFJhLKcOzZa1+I1p/AgRufEyosvOyu0ig==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:nB67fYGbvsJOP2TYTzsYWKok+eO86y4NCbxA8IxIO7EKLxQzXRvVNk8GElJQhfDOjEoK1txy6cbqZxBLFg==,iv:k2Ctjj8NPZI1sTIWAX2zUbrEWvlTRCQFfhVJq67FTfQ=,tag:uyPlzKtVfKgc29Q4d8zt1w==,type:str]

--- a/.jjconflict-base-0/secrets/ishtar.enc.yaml
+++ b/.jjconflict-base-0/secrets/ishtar.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ""
+hermes-agent-matrix-recovery-key: ""
+nix-access-token: ENC[AES256_GCM,data:dvLgcrShcdgCflS79pyH916it+qlb/ZDGsMik0z+uP3FJ0pAhlSABg==,iv:i2RDw9AdrQ2SIX7raa42MvYC1TcLkMrr8vW3xDAiLY0=,tag:HSZ/jj/NOSpm7UyADHnkCw==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:46:00Z"
+  mac: ENC[AES256_GCM,data:G7nr0yj6oiZxLOrZeRyV9eqPkN/18ya4sM9cexHTgx+2Pxpm5FK5dacLUrv1bIAVc6MZRIvL+DuGBhJiLKmPwNXBF5DVm8xJiGYDyNGQx93kTD+6Q0sG/pzOUbUfN2tvFCMA861BNR85+dFaiD+HzzAHm7kU5Qn764Xd5P/7lBQ=,iv:v6WdeUbTojwMXdZBFs36QJoODdfdxXeQgwWVx9VZTw8=,tag:x6/2+n9/rrlbzu56WoZOkg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPaXlEUEdpM1ZHK01jaVhJ
+        cGpUN2hUOGhvcG9VV3BZOFNSTlJUckM3bGw4CmNHa2hvajh0REJjbi9vUEwvNUNZ
+        UnZvSktrTnIzaEVqQ1BGbTlPMDZjSncKLS0tIHJPN3NGc1FBTDlZZktnalkvVG5Y
+        SXhFSUlDMUt4d1dqa0x1QnRTOHRyN2cKkxWxU6aVmeEdjDCIpCRl0aMjLfQvDxR7
+        RpZGvIsrIyN8fMRSVPexBmz13pYNOp5TPn8sGzzCTuH7FJkODWuoSA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2NmNTSmFHeUJ6Vk1CMVlM
+        dUl5d3crckRFcmVMS1Iwa20wam1TQTNjWVIwClc1aFlRekVoeGQwQmJ5cEFXVEhO
+        YUgxdEZYSnJiSUFCWldhdWdYK3FYVUkKLS0tIHFvME00bHg2bWh5Nm02WXlVakJo
+        SXdDQldsMktSNTgwcWJDVDMyR3RRcTgKhZgm2T00H3BVGCKw5lGa78nErhkGUrdT
+        gSh1P36cuN3nx+/RMGpioYumqvu+3JyYV5jEIHEfuCW2sxD0HGi4uw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPNDZZRE55WStIZ0lnd0pn
+        WDkrRW5hTEJkSXlHbm1sK2NSZ29FOGRIMjNrCmNWUGdCczVPNmpROXFFZFU1TUdt
+        bXZ0citZZEdwaW41emc0S2JEY0NvREEKLS0tIEMxZkVEdjBaMXhmNWR2ZCtkbDBm
+        M0VVS1RKL1NmanRrUzVYT2N4OWNrdG8K4neostjZo6JrGW1pI3TFABbEosrUTmNb
+        SiCyknpLz29ng4r2dZSUds4Op6+ubHwb8m590WEmn8LwZyqX5HGdPw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQOGFLUkZRQU0ybFNOMkRt
+        K3dxYUVGMVluNG1zUDZVdExKckxiTGlxOFJnClgycHBubHJUVWZ5c29pOC9SUDly
+        emY2SlZ5U0hPQTVCM0UrOUVKcllFQkkKLS0tIGppUjJ0U2dzS0tnMjl0RVNzSGdh
+        cVlXY25iZHp0NExlKzVNeUEzc0hoTUkKx1QhFKVBRnD+4MnTLWcl8ZvHEkVNex8N
+        ZE2g1TX/32RRbJgsnfJz2XDvc8gO7bZmdCy7R8pE8Cr76x4T8GnaNQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:QQ18Tq7iBlgkeEkaUnud637nnwu6gMuPxCg7fKmICKGF3Ams7XT8CuL5aWle0uqasRbGTP9I9Ba5zbk1oZw=,iv:0z9M0KgyfETHzET1DakAIPOHnGLdF/bvHC6fTcyORyA=,tag:uLHwZ2axKDFgPA8F5eok6w==,type:str]

--- a/.jjconflict-base-0/secrets/machine.enc.yaml
+++ b/.jjconflict-base-0/secrets/machine.enc.yaml
@@ -1,0 +1,116 @@
+hermes-agent-api-server-key: ENC[AES256_GCM,data:5OWWA4/DyBTQjcgMAmk3QmXMn+DEx1G0M5XF/v/wwQFTdJuXfMgj0FNolUrVe7FkUPGm+05dAcs4C2mgaGLIUA==,iv:hqG7EWW7z5UV4iFD3S3P1UwXbwW+JEOKQMSCp4Zb9YA=,tag:rKVPavB3O+ZMzp6AzWIvng==,type:str]
+nix-access-token: ENC[AES256_GCM,data:YNiJgkCbdEaZJU4igBelAh3zZEqLF+iPcZ5J73cEB/UOshbveGjR8w==,iv:ZPZ/4H2zoNABDj5OxdRipaYz3x2b9Q2emems6Z/3ogc=,tag:LNviUqqX1XKmtB6H8ySjcQ==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-26T16:12:41Z"
+  mac: ENC[AES256_GCM,data:GLgJoqvx5oi7n/dz/zOKAY7g3FrwZUo5+VLjSqTHl1IKZkXQRTRyX98Z1hnzcUoC4bWkAfEhzOZoaTiWs0jYFoF7/T8i7MyvRFHnlE45BJwI2Cb5Lnc8QKQ1Ypxj+L14+k8cCgn2qIvxaP1V5Ga8BDawrfjnE+ykEPRYoTCpTTo=,iv:BI5Jiugmtip1phWrqqHSD0egHCM1a2O39TIleA/zcQ4=,tag:IOc8wOFyS0oyhgay8Z8a3w==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
+        Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
+        eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
+        V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
+        y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
+        QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
+        L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
+        L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
+        lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
+        eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
+        aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
+        QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
+        +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
+        dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
+        RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
+        UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
+        OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
+        RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
+        MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
+        NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
+        8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
+        KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
+        ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
+        eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
+        Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
+        VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
+        RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
+        QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
+        bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
+        VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
+        bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
+        ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
+        PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
+        ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
+        ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
+        VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
+        wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
+        aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
+        V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
+        ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
+        NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
+        MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
+        QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
+        UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
+        EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
+        OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
+        UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
+        enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
+        Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d

--- a/.jjconflict-base-0/secrets/manash.enc.yaml
+++ b/.jjconflict-base-0/secrets/manash.enc.yaml
@@ -1,0 +1,45 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:7nXFjGr+JEn8UsIs4omppTF6Tw5xihebJQzlu31ZEFyIxCl9fCPgOQK429weIwY=,iv:4bLASEe8v0XUf2NEQBHvhsXggk/oKv4oIj60RsVR/b8=,tag:UWtc9GIQnmEjvi/UL5rtWA==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:dk14TvqJ5rL4lIaRbbpoDx9odEoK9Xzozh2cugcPqJMih+RnqBmm4xqq5Q6inHd5P/aDW2MWKmVUsTg=,iv:7zEvuOGjTEp1K7QjmXkj1oc3WyqjESiqQTXfq3IH4uU=,tag:CjXivh7qKWx9LHO7yTvI1w==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:18:10Z"
+  mac: ENC[AES256_GCM,data:f1+JQ9sBCpeqscBOvsqYqknAckhGiVef59wWWn8/5uujqOY6op/4Zv8IHkhmzxMAqWL3In0IiuR3z2Vxlcg/vx1CalJYCBp9g9wusVh4LJYUlOHgRg+3PkggjKtt0Gk4FQp6xDFEpYUb6tYwvI3ZQQZqXOM0N5Fr0bUlZrrAcFs=,iv:z32EVTDnWYoRk328seltQ27Zsk+S26sQ+33mPRA5rFM=,tag:KbjThtF5rF+7bwK0UJFQfg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnQW5WQUNmWDQ0YnNnWFN0
+        VFhGT01QeXo4T3NYOUhtSzJjdFIxcWdhSm5zCmcxNFNDSnR2RC9sdW5CQzFGWFJO
+        TmNpZkZDZ2hPV21QZGxHYkdIa1g4ZU0KLS0tIG1xMmovbUFSOXQrTnJjRXhFcXlr
+        Ykk0TkdIMThwcllYaUZOZlZZMFV2NDgKpwZbcGniXL5j5E0oaExuxy2yg0mzvt9W
+        EuT/O0zCnGfGlvPAiuCI3d+dNZ0fnKb4e/kDTz1cZlSTTZ0bu5E7Kg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIU0dKOGlMN3hFZnlXNjRw
+        ZU5rQS9HRHJucm9qa3p6b2pZdWVSY28vdW5jCm1wcFJRYlNibktyOVdHR0JVN2Fh
+        MnkvenRVRnljc21pRmllcXZmdk90UXMKLS0tIFJOTkFRam82UUQzOHZDeDZaNnVi
+        WGdHaFRTZElrNXlUbG51MWlFeXpYaWsKju6PbORYFqDxsxhSc8BAIsVE2TMM3qHN
+        qLtAQP90kLZ7hZ7dXtS6tI9LUG9wiFf3R3RPKQyIYcjSkmmT5CLEuQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjSjJRNWc1YTNzZWVEeFhO
+        TnFObW9qZkpKWjc3R2ZQQ1BMdlFBU0VJYzBrCmlGa3BUa1p4ZzR4SmRxZjFmWnhD
+        a0RtWVZFblRsdG1pYXJmU1lTQ3NvTWMKLS0tIFo0elo1TktuTnRzamRlMkpZaFRs
+        d2J0T3hBc21oa0xpY2lxZzF3ZC9Ia00KJ476XOLRCEEZv3JvH/TEZqpWC6JW+es5
+        RGr/7WmvMm9DyPliwGdMETzWfDSweN545QiLofFrs7xAYBuSTBS3eA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrUTJjVUpQVEoxVHdzQ2dS
+        TU9uTitUTmlRa01TWENFVnc1bW1KL2MwWVdNClNUcWhDNGo3ZDVBeWxzWm1DcW1S
+        ZlQrcnY5TXRSQlUwV2lUNUpFWUdiSzQKLS0tIDVpdEN1d21TbTlubFZGUnFoMTdY
+        bVR2SmRvV3FPZks4cCtVWk5VM3gvK1UKldfANDooYmyhSUXuFXkx41FHlg48PdNQ
+        acSGNMHbpHdWryTy1/InQ/zYON+eFRxCp6saLUaThEjRVjC5HLBvig==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:ZEPLllMaCT6CL/niE64vzCZYxU/4qwqofSH3/vcBZdrZI5PrwiIfjp85/QGRkxDl8CVZh8nhNd9hlrJ1ew==,iv:zgmCYCcyfiokdTDvMqMGYLKc8Z8DJoj2Rwz1hUk7Sok=,tag:yPdHH+uVG0y5DHBGmGUXMQ==,type:str]

--- a/.jjconflict-base-0/secrets/minish.enc.yaml
+++ b/.jjconflict-base-0/secrets/minish.enc.yaml
@@ -1,0 +1,45 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:t/6TKQa5ADbuXqKu5OZYFoL+INArb8S86mxFRSPnr25ip1EqQsPPHSrZJDL0CZ6O,iv:WWeJhWX2vrWPLQFw41ZAbdszjDqvmMVHVv1xyVOxp0Q=,tag:jEHodqzhI20aoqTYz8UwCg==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:baIGapTb1ZxNFM+0Brpkk30osUGAm0D6/1OuidEp5gg0113Q8VcsEixILICW84v5av70wGGpwr5eOxM=,iv:uu8GsQOY082GaKhSCIdtHwqLHab5ovyGHX4Guilr8e8=,tag:bNUTvmpnviwmHCvVpOl0fg==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:18:42Z"
+  mac: ENC[AES256_GCM,data:HPX7PRSCZm50WAWtIgYafxZvcZn5Q/jiyRFLjIPsMesQmFuOWHM7S9IUu/D5YFVxCjxP3ban9fbGSRbWhNMZmM4s/pdbpqmOk7+85EkwPCcgzBimZDgNz8yAtEta9UcIs6na3MKCNhAHOEkHdckgMR2g5wNK3/0OVdpuZ+rb5qE=,iv:qZPm0NCs4HWFbtRhMdDglQEl13Ki9st03ckRtPyI6MQ=,tag:9hNM+EteFFbyJdpJWH/2Kg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0WW53NlJJM0wyeDh6NTBO
+        YUQzOVBmMGZpM0M1aVU0Z1FzcEFhenVIV0JVCmh4eHU4NjFxb3VKeFF5Z1ZPNjd6
+        Y1VsVHd3aVRSL2FkNVY4NkFVWEZaRmcKLS0tIGlOclNjYzdaUDVwZU5FamNnM0hF
+        SSt5cU8vUTBEcEJld0tlSUFJY1I4RXcK0J5UaTjZjDdOS2gPoPIXe/CJsLnZsgq+
+        r9un3SUpKWfpFdHfBOAFa/l/7gMdCyVSXpRg8QXH8DvzFByetu2W3A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzckRVNFRKYUl5bDFHV2lO
+        czd2UHlBWW5JQ0xpT3I4WmFmZW1Ldnd3Sm1ZCnd2KzFFUmUxUFIvQTFrT2JiRkI2
+        cC83OXdOU2hwdk02V0ZnUE1jQk1Da3cKLS0tIDZzVGN4R3dtV3E5b0VuTVVvQ0x5
+        QTU3ME9mUmJmQjNXa0hBdnBpYmNBZzAKXg3mnJAiWEM7fmKcTr218fueMup6Keyd
+        Iw3mxTr/AaGSE3WRw9U3FLhPnyuGaBduPyEJ3fKr34M4ITnrqBs1SQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBURDBVTlQzZTFhNlU4VTVu
+        YkMvOTBDdEhTTUpnQW5hOVg5RlNWZS9VQlFZCnpUWW9XRTVmOGlFSTJ6TXBtL3R3
+        ZVRVd3c5RlBXUStIdGJ5WGptZEJDcDQKLS0tIEVPeXVNS1BqU0dvOGZpaXZhR0RY
+        TENmd0lqUlRiaVo3eEh6L3dwcVp6NncKpuYVtzBxRTHAyamjTLkgxdw0uzMc3/nU
+        oaeakcpJACr1GQb6/TjiL64igMvgQ69h9AEvYABrgdGzqwi8H8fOBA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvSnExcC9PYUk1MVBMZlJI
+        S2M1RTN1WkJWUEZUNFZuWXdPeXA1dVFXODIwCm93Q2ppenBMTlMwbUk1SmZpM3JD
+        L3UyRTdEQ3hEZyt2RE9YUzNROTd4Q2sKLS0tIDJxU2dqZjRkYnJocytFeU1pWFdn
+        c1lUbG8rRExyazczdGdXbWpuazc4SEEKt0AO2VurRA31lERMofSaycgs+ZDA9mZV
+        GqJebZNxc/5KvEXx/rxQTqjaN3tGRDR/oCxVGF0ljVKsnvWfrGNH1g==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:hh4dCCPW/ggnQNz0PiMIIYrgXS6GS7ZLHloUtgXZqmD+Kqcd4N8+E+/Jh4M3lb6iWrjcnLbp5o7XTqMhBg==,iv:pDDPciOy36G5LTIeQom3TnsH8hpl96lFjwAD0wK+lHA=,tag:BSGUbHdGs2jkeFuvOMXX9w==,type:str]

--- a/.jjconflict-base-0/secrets/nalsha.enc.yaml
+++ b/.jjconflict-base-0/secrets/nalsha.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:snW3Mss2JXZLy533H36PA6iKA6GgPpN4c+h/pocvvyJHNH7heJq/0+Nodw2VSI/a,iv:yTRhmH5anA5ZmthhbGgFZcbgSOsJ3MXWHB7Jupt0XHw=,tag:o4srWprcFEI91OblmyCXWQ==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:19Im7ckaD/nWE/HaMlmoVpgUlnxBs04emF280l7r8U3U0ll93yTmYvesGH/2S6d62gHH1GIOAQTycZM=,iv:9rqUZp/qd81P7uB7/H6pvw5lJswN9FagZi6WedRJKzs=,tag:yJ6VBVpvMGgoddOzxG8oJQ==,type:str]
+rke2-token: ENC[AES256_GCM,data:g/AJcEXEFsdCvQVrXEhPjR5ZIrWPXRW3bmLjqD1UifvjAC9wpJ/xZKsA0Au+ssA2JUy0P+Rei0jOoSWYA6SWiflXTVbAOI5ILfa/KABnifxcTqJYgyHGM1hXdfcDC4UO9x1JG+Pa5FFisZqe,iv:2DecG6Y2IDS6Cj36B4TjGaHTjyyCh2wuh9Lwc0BgLEs=,tag:YubnDbaHkGrv2mFhlTfNag==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:19:06Z"
+  mac: ENC[AES256_GCM,data:CjUzO/g//T9VeJKuw18xifslkVEXYsXuManGX6/jwfJXhAzTIhvrPnVETBugYc0y5TdzApALOCN1RWSlp8o/yHMx2FKJ5VvJF1Sox35YwG6EIAq+dr7VcHiMiyXBl/6Ng5Vp098X+uc6W7M0doZR2csBpbUZ6DvkVuwkXbBlGPg=,iv:GnfJGaFRuIy5dDqhHiYld2gvdFjA/1mDPJQBjKYarh0=,tag:UjcCq5XmwAdiGtXOx5Q9WA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6UTYvYkNDKzRhWEQvaHlB
+        OWE3L1RhdVUwTHprN3pEd2dBU0NsdGx1TnpVCkdmZHpaU3JoWHNWNXRKYTFsTDhR
+        R2xJbWN6akh0MWlNV0hMbno3RjNaNEkKLS0tIEFHTXlsTi9pNXFaMi9QUVQ4by9z
+        UStzajZyOGlLTDRWeVRXZSt4N1dEWG8KRrRLSEaYv1dQNwbIXZ0bWC34fg0KAZZI
+        xJNIqLa9fV9a5HRABcHwJ2gBJWhw948IUELVl62JuyYO+hlXBvXYag==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBodnNBQmR6ckZNaDcyM3Yw
+        U1h5S1plYS9vUmJoRHB0dmVBejlQdWVCclQ4CmFTVFU4UU1RNVRHMGxhNDMyd0h0
+        QXlWaW80bkY2VlpIUm5NdU1xQXBZZ3cKLS0tIDhOdEF4Wm9aVGhlYWRqVjdCeXdl
+        b0RTSGYyWkowNnpGWVMxN3hBNjdRNHMKXOuB3CcuTEgTyNmfM4UBj3naUqH1xTBJ
+        DunoIIyv0BwpQw/USUm9RA2Xh8et8PuUJzlAcHe3Tj5k8EFQJiUuGA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMlZsenJGamlzZGtzM29T
+        MHNtTFBhdmNQRitzcGNNc3BCTmpyTXJoYnk4CjRkNTdidjJ4c2g1T1UxQzB2T3k3
+        bEFlZmEyak5rY3hIQ0ZUVjhFZkhzbUUKLS0tIHV2cjRBLzZMOTN1Snp1R0VRbktW
+        SUdVUEhGM0V1dFhwVE4wY1o0OUllTDAK6SG1HnF9oTtChJfm/y0cCs8+a+BMD39F
+        Sc2OLJkve33/SVexI3inmFadAA5+CtAdnF7F+t8vNJEhC1kGjfn1OA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBweXVWeGtVM3pWb21KTWhz
+        ZENWTVFxTmVYeHFXSVpIYWdIYzcwYXd1bW5NCmt2ZEttMEI0aERqTlVGVFRvYTFJ
+        Q1V2K2c3aVlDNXVFQkhpNExRMlphalUKLS0tIGxRcUYzekJPZjlJbGd3M1JCRWhi
+        NWEzZWpSdC9FNG16NEtXYnZPVjZ6Z0UK2aJRKUkSJfRt8Yuca1rFmkrfYFlBuKbM
+        /fuD9Sh/NcSoO/H3mzP2vqIYo+DLUidc3y5/nX2NreZ0A1Lmf1dEwg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:VYdbGIAIfhzkTR4S6uXdVrVRZ5ik8+yeImeEAnhMndXCUrpfkiL4kZmcZuZuSqzJdcrApGqerjKQYalSDek=,iv:5UdlWSJebS37zz2/t1bgtTk+4J+37osTgi8ieIHE/II=,tag:c99a1/G8MdzUtzjce5w+cA==,type:str]

--- a/.jjconflict-base-0/secrets/nemishi.enc.yaml
+++ b/.jjconflict-base-0/secrets/nemishi.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:waGWq5I2MZEmHYUQzNu53lj9/D8FAhnmwTSpPnz3+BaMsYhZe5qe/Xf7e5Fifhrq,iv:/lQmN5UrwDNwlIFAhGky4BkHL5RfaQsYVdjF2TYm+ZM=,tag:me2eFvJMSqXE8OJ0h2ETcQ==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:rw+peVbm/oTOVhfMUrmAQI31EAYcLp+XH7WBeL6ae3CtUSb8ZP0xeVO2nFXDa0yIP4ygVYE7AHEXyv4=,iv:ogXQ9rysIiFbB5YEaiOEYcdyLBwT+3KXmIPeITsVgyw=,tag:8EWoTDQXDdIfuUADjlXulA==,type:str]
+rke2-token: ENC[AES256_GCM,data:jr3FAFEMjcJYp5GEZ2QiNA4FOlc79Ebg3isbIF8zyiGq2CJM4LnKV4LrrqAhoW/J0uG5WtEszZVGrET5umR4oohcwxIcRwxzNZ8v2ZlqboxUyjHO23eyKUw7HKdq53DIv5Xr2baxs4996S0b,iv:nyn6F2MxQehUVoQF5IA/BP/RK5PRnf7Hq2z4+B/DdTg=,tag:EC+B433pMRQzs3UhHgZQKQ==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-18T00:13:15Z"
+  mac: ENC[AES256_GCM,data:vIgUr98wab8yZwvwks8gFoFRBcuTP66ILb4DM6Gj950a1QZdm+eos9mWf5GXFDarT/MGXxax8WTTIQGuAdtRXIyOiTmNqljxJsPusYhGEGkcGpUdoCMqCumEEl/7qr9oaxJo2LcGVO2cCL3fpygJnzr4xl/DE80JpR34saGoD9A=,iv:1IF46VBM9kBmKfKcZ7Us5XyySBdxVxXRQ0YvOj4e7ZQ=,tag:L7Kpqf3wAYv1swYyL3tH1w==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYTVEvN09BZ2s4eG12QmxT
+        dzZvY2cyejZDbUNBVENBVFcrcTFVTDZQakdVCnJkL1pRTXRTYWY3QUxsUGV4Q2g0
+        Q2dOSFkvRkRlZHpvREVFVXBsY0FnZUEKLS0tIDFsMGkrOW03RXViSU5XWEhWSHlw
+        RW5hUkp0OGFoVVVPYXZqeERROXhHbjgKsQ2j9Qz3xDwomUNK0KfHUeIAoV3ipZ+e
+        hoiHvEOS5gxrrm3wn6M0JQdrx+mLDST3QgCEG1NLrQHsD3hZIvZ4rA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmYS83a0hBWDdKS2xMQ0dB
+        cWZKOG5idUpxbUNTRHdZb0JSbnBHWllZMmdBCndGY204bi83V3pETmgyM0dRTUNY
+        M2lyeEJaUlhEQURZajZHRlgvc3JWdjQKLS0tIEZXdG9xMCtpd2lVYURXeVBpLzN5
+        TG94YTZKOUtJRnVhQzhBUEp5bkphM0kKNx+4tH3ZiwX1tmBjM9J5Xhsye/N2ZRk3
+        HYJn56R87j8M6+Pjy/dT9z+bBu30Xa33IIA0yflpC2yXgm3TZAjyew==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEV2hYNzBBQ3krbVBqNytQ
+        Y2g2aERsdUF0RlpuUTN5T05PZ0ZGNWF1Y1ZnClJKeEZMa3diSVFvRkdKUWVsSGwr
+        SzY2cEpsNGt3T1dPRkFQZ05UNjdGY3cKLS0tIG1CK2FFMmFiSFlaUFRKV2hIMWVu
+        b2hvRDRSU2NyWVhEM0tUZEdtclUwdzAKvOZCDzwxkS6CTP50t4qrXaLy2qp7xL5s
+        j5KirK6PGEHzvZqVwCdPHygbhSSg6uYWmDUfCdz/+BXY5DXBglj6Eg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPTWZWK3FLVHVTOWNZbFY5
+        Qkd3VDNGU2d3ZWs0dlJGYk5tUDFLSTFGWW1rClhuVXNrbmZNRzV2Wkw4VUU5OWlv
+        M2taWHphc04wcFZrM2VoMnExYU5PdU0KLS0tIG92MGs3MFpvcWVlY0hoVFBTWkw1
+        RHZ2aWpjbVhzeDVqaStVWFdGNWVGbGsK5lgNMIpU2h5W7QPSeA7upQBUBNPWs6WW
+        z9rPyuGgRb2rjym6HQxC94Cq1IItHaJrFFE9vLNE67+vDEMZusIwzA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:xBCR5J/gLhrS8i86SShPyr4HNCb+AsrcZx5SrD3Povej80HglRPZ2Os2gRE1XvwEkpBwXpGw2eHvdbnCwqw=,iv:V0Nl34zHjQfl3+kqTRlCxnUkUNMKwaNgEmHxPRHMaQQ=,tag:bg9TbfaxahQVrWUWPgQ1uA==,type:str]

--- a/.jjconflict-base-0/secrets/nishir.enc.yaml
+++ b/.jjconflict-base-0/secrets/nishir.enc.yaml
@@ -1,0 +1,88 @@
+rke2-token: ENC[AES256_GCM,data:5AosLTIWOjoCETFBJHXWe7R6NiSiUmpLULA7P0/zdwx9CnwyLlQBHiNR63RjqJLpbfzBQ7aD6+1a4SuhdJWQg+BXGWU/zuecJk48oOH+Na/BtRlKl/6XQBFGfQMfPxOypEsy6w74ujUv30vW,iv:HMhX5w6NJQ0MtE74qSAfgTiPrHfMqIQnEQeakW0OxBo=,tag:nwB2AYQvMq0Vg24P5fuhgA==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:28:10Z"
+  mac: ENC[AES256_GCM,data:43xVYtGcD2XSX7cYsgYPs5Vu7BO+A7LxqKCvMXsj6pqJU5IqpdAF6D4bHEX47lgpwjKwCzQa+6Ad6no0nVs//WGFySZkoDzSbr1cWOf3AFb0vJxDzQhI6r+UyoGjhli9GJ4padRiG9A+0Yzsa2PLjpSAxc4enhPXxsmwW6FrO4g=,iv:gShWJlO9hMqMaWuRCNWqsfrX9DyNCESzQZ5JOWUpxuM=,tag:KqKhGsyl6TpXMZyRTkbENw==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxNkRFcVlscU9HcGx6N1F0
+        cWVKVXhTajFoSGFLTkZQS3NjL3l3RGxpa2hFCnhaQW5VclJtRTVTajJnVmdpbUtQ
+        bkdwY0VycFlBUVYxR3hPcnNOdUZVQ2MKLS0tIDQ4eTlyN2Jqei9jTXlGRmRYSkRG
+        YmJtQVNDRlpra0NWT2dtaXltMzRsbjgKtyZ5N4geIO+URngJfGDufSYQLVWcsG70
+        LomV1fBJS18WKug62RmnoHOzONzroGRAKE5BwmGrr2tjbzUy8EZvGQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCNk5tanVqR1BsbXo1OWpl
+        SlBLL25MSkhPc0FrY2RBcU82b3VTYjMxbFhFClpJUTBEK1I2MTBDY3hYN01yanJZ
+        VTZXMThUWHVRMzZyRGRIRC9xd2RYMVUKLS0tICt5eEV4REg5Yk1UaVM4TXhUVHli
+        cG5GU1A0dG1nNW1ZMktueTh6RjNDSHMKkHw3vgjEy46GMddJsV1XgFO9b1+FQqYK
+        bDd916OUqerXwGArZfV91s+tdvMMNetJzE4v/n9rFjz4pCPeQaFmGA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLWFlROXlBa1lRM3djd3ha
+        SktwNDFSVG1LSVZ3d1FyU2FCV0FPcjVuWlVNCmYyM002cFZldGNkT1FpTmxLRWNy
+        UUlLeDR1eVV0OWU4ejY5Q1RrMmlsbjgKLS0tIExFZkZydlNZck1oYW1pK1pHWSsy
+        RVN6K09LRjV6anFYM25rRWREWlpsb0EKLUAo+l8ZqfImRfJeSsk0QBCOiFhpJHMh
+        vIV1kDY1TZwiYT5klbv0KrcFMY0SQiZgFtuCDWxP+YOSr+ERnyTugA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoN3JVdDIwZmJEcG80UFRW
+        eklocDY0ZHpJZFN3VEtxcTlvTlgwSldENjFzCndWcDI3QXpZV21ZaEtpMjIzT0Fi
+        WndZZWdqUlprVDRNYmhwYmR6RGtqQlUKLS0tIG54d21CQWRVcXpnUE8xbXYxVkI0
+        YXNrd3FETWJHRG0xLzRYaWJHRU82dHcK345pk8mV2j7WY5fzfPGUxJ3CpwfAj66P
+        giyG29Iw2ANqjdxwyOtB60vC/AZt+4mhMxCjqGIpNOM+j8kTJ6sfZA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlUGhhbGh5ZENrcXp0b1l3
+        VFlKNnlyVWp2bndxN2lFUjhhay8xSmcwNEFJCktmVjZQL1ZTREQwd2xkaW5PMWlI
+        VC9XNVlOWGhpTHhDdEQrZm1yQUxZTUkKLS0tIDUycHJVQlVndVN1WUNGSjZXMkxB
+        RkZRcWZ6ZmV6L094ODhpRFlhYlplN0EKHVIhsIJMMHUW9SVAaKdsMgW9N3z/79Lz
+        PXCIPj3q76/QD+RMacE691KI9OtNSTmcwTqNt+a45J6vlGV1+InArg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDaWV2NzY0SXRSdzZPVnNj
+        ODEvRUkybEx2UlMwaTdIeGRtby9aSmw3bUZvCnpoS1ZTQXpOb0RFU3FMc01wZm9V
+        ZVZCczlaVlppUExTZk1UNGFpUkxQTXMKLS0tIEs3NlNvY083WXNTWnREZzNieDZ4
+        YjJ2ZStwNW5YZEM0QmU2ZjNWK200a2sKLulTRxCziQ/il/aZ0JZ5EKGTiIPVutRI
+        NDasw/7GIBTzMARRaeoErYOkME2x06hBUsLJsj0dYN7VEgGXZIHFIQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxazhlZWZKdlA3amhBcDdQ
+        SXNTT0hTaHppOG9MMHJvbCttb2JrYzdXalNnCnE5Y0tvMWE5T3ZkOTZaUEF1RUNC
+        bFVYNVUwbUdPeGFZbHYwVFdVNXRIQXcKLS0tIFQ1QUJkTWxseG05N1FkRFNMNE5I
+        dk5EcVBBckw5cndQRU96eEd1aVl2TUUKXoM8ncbFKQk8Ot/NEa4o+pXLnJ+MkJJb
+        kk+ui15uZkXQpp10diukYIcztKVqO7HSAbGPWJf5x5PN5OkFww9GhQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvQWQ5N29NQ1pGb0R0Ync0
+        Yk84YkxxRHh6QXhDM3VZZlY2MlhMM283akRrCnVlbzlLUUZhT1ZFOGUxSm9WbWpv
+        ZHNndFRoT1UzL0VXa3RyTHY5cVhqZU0KLS0tIHNGVVhDQVc0NGI0blVRWmxDUFcz
+        RVZ4SEF3alF0bCtKSS9EaE56YmFHUWcKqthvweRL6fjR0ogcxE99RYhtyvX50mMv
+        Qu8ZOw65dwU4DfgYxjmhigh4AVJZp5wTaiIEbU4CiYPhrtvOBAHAdA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPZXhJd1ozZjlPK0ZMWDg0
+        OFhYU3RCN3NjaDBEdmYvWXgwVXFGY3ZDVmdRCm9zTWE3bGpCdWNDQ3ZpcGtjZXNY
+        aUFZY1B6NGlhV0xYRGVvbzRlM0FqMTAKLS0tIFlUT0hydCtzUmhIeUIvTFN0Zkw0
+        OUNSZlUrVG1WODZvN29KMjFSM1MrVlEKjzCCTBaVLHkhpjdjSTevl4m0NLCr3QGz
+        ICUCYkG+mh/fKa82CtdvebjIVvHzzdqcp/2E2X1hQqNeMlmtgkV4nQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-base-0/secrets/nixtar.enc.yaml
+++ b/.jjconflict-base-0/secrets/nixtar.enc.yaml
@@ -1,0 +1,44 @@
+cachix-token: ENC[AES256_GCM,data:dwXGa5vw/rMwCj2hXQOGR+qxrc29gMKpqATFm4gmIBKJ5A36Hav2Sib8SNU6NwhvHXi79scQLE/wt8Qyn9M1JH+IgoI44Qbde5sWCBtoYHNJFC3Ai1uhYKqWgv4AUAkBndi2PtSguZe1a+sM69QgXnlY8AAkHM/y7CXShBLQ97kGo8ma/+7u+mzHTablMz23Hw==,iv:4wqET0AwsNOSKSZENOwrMnDtL98JXqhSrSDG8DOJoqU=,tag:VI6pUkNx/1Wm0+yEGix6Zg==,type:str]
+nix-access-token: ENC[AES256_GCM,data:dvLgcrShcdgCflS79pyH916it+qlb/ZDGsMik0z+uP3FJ0pAhlSABg==,iv:i2RDw9AdrQ2SIX7raa42MvYC1TcLkMrr8vW3xDAiLY0=,tag:HSZ/jj/NOSpm7UyADHnkCw==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-06-29T16:39:19Z"
+  mac: ENC[AES256_GCM,data:aZzVwt076CLVFqVqgrcH5dCB2tXjC3z8e1VhFE4JYLYvPJVuR6AfX9kadML0Xx16bkNojpkD5y/BRiACnL+72126iqPtU0w9sWFfbL+1OIxeicqwsJUW+g1vtB8RcmDnPVN2ZcFdE+Blsz2FmRoMgozC8UbbKuqAsPESVrnl5IM=,iv:iYZb1OT0nsZANSFhCgxETcTISIQZID/7TTXvYhMdMcY=,tag:7SmHXqBbzRF9JNxtglCUDg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4cXBHSWNwOXRXU0JMYVhh
+        Qk52TXUzZ3JCUmtoZGNaSG9acnVhdVVlSldVCmhNdUN6amxlbC9uTk1DaDBTSTQ2
+        aUJQL2hPSU40RGV3eGlHd29TOEc4QzQKLS0tIGJ5ZzhwaVcvVHBVdHpWSmlub2hK
+        UXU0U1E5UWZEdnNWSWtxTStmQW5ibGMKgv959BPaSISSi0RKYYw416q287byXhM+
+        sEcSvTyKPwkNy5ITz6khAwpHHXxdyUXpHL0WrYVVMwd9+aspdSDDKQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwVFlwWnV4NVVsZGlQMjJZ
+        bHRrbExVZVFkR3F0eENlQ3E1azFVcUJ5REI0ClQ5Y2ZTK1BPblFlN1VOSnU2Yk1L
+        ajZabW0xbzFjM1ljQ2NDaEhQL2hCdTAKLS0tIFUvaENYa20wdG00UHBEblpZdDMv
+        eDBabzRJbUFseTl3RlMvVVh1U1c1ck0K1FleW5E945xk3OqAGqu2yHy4qnAdnDBK
+        hfbL+O2aRQMYHiLv2EqTQk2w9TCp9lndCBdLEkDRo33shYgStCbizw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1Tmx5RFZISXp0WTY3dXZD
+        d3hGS0JtR1E1QkQyVm1ZM3JoNlVERjdNNHlnCk9WRklkOW1pQnBrQzVIOW9uSFV2
+        STRnSFdoVi81SXlmODhmdjhwcTJpZGMKLS0tIHd0bE42RWtFVXNjQytlRVhyZ0lQ
+        ZDlSUE0vZGJBamlhUnlvd0ZwOHhTd0EKRpQSQdoHUfZsSKqmZls/DPIt8w3O9I7Z
+        RCRPzvy061e8RAdGo1MwC0BnLfFN9G2e2VfBtDFqx5kbKMbZJgKDOg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6SE42dDA4Y3ZtZkpUTGli
+        VnRMdG5lci9mS1E0N1UwR3krSE1FVVFnV3lrCmtZcG1SUkQ3UDl3VDVkY05iZ3cr
+        cnpJT1JDRmRGV2tzVHNFcFZZQ0VWRlEKLS0tIE5DU1FhbWxBRXJncDVHbWI0TDk5
+        czk5VmY5ZVg1cDh5Szk5TjNmWXBIWlkKe3cCxU1z3lD4qLryQgPtNgBSBCT6R3nA
+        qZVBZzbK9LZheByMR3yBTHagFtFC8v9JGXEnmKMe1+OkBVMVd481JA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-base-0/secrets/shikanime.enc.yaml
+++ b/.jjconflict-base-0/secrets/shikanime.enc.yaml
@@ -1,0 +1,34 @@
+cachix-token: ENC[AES256_GCM,data:dwXGa5vw/rMwCj2hXQOGR+qxrc29gMKpqATFm4gmIBKJ5A36Hav2Sib8SNU6NwhvHXi79scQLE/wt8Qyn9M1JH+IgoI44Qbde5sWCBtoYHNJFC3Ai1uhYKqWgv4AUAkBndi2PtSguZe1a+sM69QgXnlY8AAkHM/y7CXShBLQ97kGo8ma/+7u+mzHTablMz23Hw==,iv:4wqET0AwsNOSKSZENOwrMnDtL98JXqhSrSDG8DOJoqU=,tag:VI6pUkNx/1Wm0+yEGix6Zg==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:45:28Z"
+  mac: ENC[AES256_GCM,data:OnoSFR6Mj6oCGJwLU5UJpFpmPj5F4MH7JWADgNr/XpLb1OT8Jb01RWzU9vnjmocANMjhL0Hmi69CCxDSS+1C/uJBEbntWh8y15Kx22wKYGX0D0JM9UVZL6MjqK2czgleRV8Tw84GncxhrSPTCsXFS6TtRR5vpGYH5M7f7T0wxAY=,iv:HcSoommTPisTDv70BQAZPlVx4AU3Xro1b2wpzj2VRcE=,tag:Pj6Np0b5PrQDzaMA1hNbhQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrSUJHTHBMQTZIa2YvUUYw
+        bFljMUt2Um54MTF1WnhJWWJXbEpKeTdYZGdrCm01bnFOUmpucENXTW9xbEFvQ0tD
+        bkpNUDRJY1BaaTgvZjhjbEQxYXFybGcKLS0tIDhnL2hCdytFYXVxQ3JtWGFSc2lG
+        WXlCcGZhVWwvd0JXc202eUFpYjJlV3MK8BUcmudbDHXPQpM0lrb8mG1MZAxY8Z4M
+        zWnpHZ1pUCILw7QiTF0XFL4C6RhATEkW7MwAmiffaeskgPScWrkzHQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3d3RwcU5lMEsweUIzVDFV
+        TmVlZXdoelY1bkc4ZnZSQ3A0QXh6enovOXlFCkR0YnUrLzRDWWZaaEhxcGMvSUhi
+        SStzUFg3OWlZUllIQWFrSEQ3RkdJMXcKLS0tIEtUMllaTVRQeHFVNlhFOVluMktI
+        aGk0clZGNWE2OU9UTWhnbjZjcEM5N3cKfMJT8JYSRz97Jh/BWMcvn9Jznfhcn0zn
+        VWRpQ81l2qlMITy1wepwaNAWvPJqMDlG/RWcWswYg1lSLNZRjxsMCg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNT3RRcjk3bXdpMHV5bWdW
+        WEsydEVRbExZTWhUK1NWWVgyWnBnNmszaUdVCkVPZkZFT2R3QWpka3h3QnZBbVRY
+        UFY4NnNSK1JMMmplZ3hybXpxS1g4QWMKLS0tIHdmYk1DMU9rbFVhRnNPVDFFU21G
+        WHZrckl6WkpVNFhHR0V2blhvd0pndFUKRthQwsIiNQtnStWWnvtlu4j/cnyA12/M
+        bqlF2P+pbNaikcC19l+unag2LOmjZK3wv8f73eZuGDG/XMaV3649rw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-base-0/secrets/telsha.enc.yaml
+++ b/.jjconflict-base-0/secrets/telsha.enc.yaml
@@ -1,0 +1,44 @@
+cachix-token: ENC[AES256_GCM,data:FRHttdD/mTcbI9oniGsaCCkZofvzGKvmRRuyRBRlq+MPqmC0oH2cSGrxNDirw7KnWQSbClUlT88MJSXZK3jn2eCtV+O1sw33/shVPmeLqCKdKliYFLPSgzvcYScBmHkIkScJAkcJYsiNVapuXdca8cufg2cvbW39xfo0JhDFzSF3iAQf53Mem0bfCFTtG4O49w==,iv:Dn2L1qrttIC+hKyJR7M6vPMZOhPz7K/QPmwOqFpPVCw=,tag:2T4i7ZuA2Jjrpb2veTqDCg==,type:str]
+nix-access-token: ENC[AES256_GCM,data:DxJtamrimFuFVhi/3mJDIsndFg2e9L7d6wKRBKuS+XK97JQuRQvjKA==,iv:LIveL80d5piluFLeskVGv9AXamsxhNBbAD7LyjGkB7g=,tag:OfcJU//3e8cTxINgAtRpug==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-06-29T16:38:57Z"
+  mac: ENC[AES256_GCM,data:hB73dXZeJHId3lvCNSVxkuyFBVu0rX1hh68R4hyIRMan9qmAxrUPLJPloLBTJhww7TlktVYkuCe3Gnj87gM7MdTNPARGtk3e5uTj03irpNxDnDPQTtgYRUFDqvzVduzi5l/IA3AMIwVWWDMcFuxlC9S4pilWZmiEXaX7LtfD1Kk=,iv:PLbNqX0saZ2VsFKIkq0PqGoCFn8XtNSsFR6F/ol4/pI=,tag:8klp2hNOBVC2WKg68Oafqw==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4Y2dVc2N4eVQrcDF3NGJr
+        dWpYeGRSL2RzU1JBL0pXWTRGMUVQNVBpMEdRCmZvZkxQamJ3dFVrZFZ2YXBiNnNL
+        NUdaR3pKcEsvc0IvejUyWkF4UkRLaXcKLS0tIHdmZ3U3TVJVRDNnTlBwOFVFTzUw
+        azN3aVg4VGlYRzhBS0tzS0FrdFhRbnMKjxH2zknTPLnlb7zmAoO/81QQdh9sowi2
+        zkF6xBMMVXzOadpmhjNMiSkToALXeJXmu9kgrIn5Dr3lkBid0ZvufA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTdFRKVlRMbjdZN0ZZV1ZE
+        V3pjaUJvVVVtUTVIdHRkWS91aXViZERNZ2pVCjlwZUVvRU5xeGpLazFXSnNjMkFq
+        djJiZUNmc2JnTDQ0MG4rdytmd3ZpNXcKLS0tIEdUVzNENmdubE9oZVVVTUZYNmE5
+        WWg2WTc3cStla2cvZVZuS0RuUTFCajgKk6vpB8yDQAhrPvOp/6WRaovVx9sUtyXu
+        5EjTeBT+pOh4c165/dvW1HYffZVcmDByYTx7UCtHmXut6Q3c2BtHbA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByc25qN2xXSHdCQytTUUlN
+        ZGtqTFdxb1loY0laSnI5enRiT3lvYzBDTjBNClYzL2hkdkVuTWRRcU54RHFTdUF0
+        OExEeFpDQ1pPVGdkRWRGZG53SWxRd28KLS0tIHZaUW5jRjRTbCtJNDNVdEt6U2NN
+        RDdmaXZlY0xBV2ZmaU5icUtzTUtySlUKRjuup5MJRFFfo6M24erFpxFj+4TFBihj
+        HGQ9LcTfDM0OQNcOgCLDDD0QfNhBS7hwamD4YSssaybpv4ljghDQ4g==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzNi9PZlRUUGozZVZVdUdN
+        cWd3VXdSMUN6dnJpWWpaSnJXR09hM01OSGtNCmIxMmpsSjd2V3lUMWtyU3lITFpV
+        T3VqWnVTdUh2TzNGUDhhVVNITmVCMlkKLS0tIG45Q3JEdFNUN01tTXFLb3Uwajdn
+        Y3EzWVVpaWNiWWxWMFlsaHNVR0huZDAKRHxYA7g0KdK3Z8TMwqvX1sDKlP9sEUvA
+        PQ8X5L7B7iStPOdNtWwgxEOUGAsM9tlAj5ZYlf1d7zc6ZcjPZpHWWA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-base-0/secrets/wifi.enc.yaml
+++ b/.jjconflict-base-0/secrets/wifi.enc.yaml
@@ -1,0 +1,117 @@
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-26T16:12:54Z"
+  mac: ENC[AES256_GCM,data:POanrPpnw0ErniQ/gVdZxnj5FXCkvojkM5dxdQpYnPt/UKx2g6OiGa3OCgJJkWcbqm22C9HVvZz1MnH4nITpgm8SZarVkFe+copLy5QWCIHU2uUXmnYZhOHOofGgwcySaNcAU/GErA2OFuesR3480lHbiVwS+pAtMAVWVcJdWYs=,iv:sf+do3G6vpM4titItbWGFs+i2v5Ab5q8X6qy6Fn7/bA=,tag:PpC/flqV8NdWMxCvv1sdMQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
+        Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
+        eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
+        V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
+        y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
+        QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
+        L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
+        L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
+        lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
+        eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
+        aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
+        QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
+        +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
+        dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
+        RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
+        UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
+        OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
+        RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
+        MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
+        NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
+        8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
+        KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
+        ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
+        eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
+        Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
+        VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
+        RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
+        QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
+        bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
+        VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
+        bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
+        ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
+        PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
+        ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
+        ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
+        VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
+        wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
+        aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
+        V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
+        ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
+        NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
+        MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
+        QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
+        UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
+        EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
+        OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
+        UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
+        enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
+        Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+wifi-sfr-e368: ENC[AES256_GCM,data:FMmP09ByePKeRAxMEqKd5cbdQy4=,iv:i9y4k87u55Xp+oFbzKSXJef8pxL30rvM2/5gugmUAZM=,tag:KAeko7NNYUlM3ir+bDdoKw==,type:str]
+wifi-sfr-e368-5ghz: ENC[AES256_GCM,data:E6UFUAu9lvCFVIiDP8CHtkllxUY=,iv:NCV4qq/AqODIxtdO+DxV13Is72uECFqJXC5CNvOioNk=,tag:uxzwB7OPf/+KemYYsSTolA==,type:str]
+wifi-vintage-korean: ENC[AES256_GCM,data:8KFQG7RTtzFT57Jb/t4=,iv:aWlD4X1r1AXTELksH2KjtANKiaxqJ9ZYNWAaMdqnn2k=,tag:ZuccHQT6mWqvQCLg5wjkeQ==,type:str]

--- a/.jjconflict-base-0/skaffold.yaml
+++ b/.jjconflict-base-0/skaffold.yaml
@@ -1,0 +1,10 @@
+apiVersion: skaffold/v4beta9
+kind: Config
+metadata:
+  name: niximgs
+build:
+  artifacts:
+    - custom:
+        buildCommand:
+          nix run github:shikanime-studio/nix-containers -- skaffold build
+      image: ghcr.io/shikanime-labs/machines/catbox

--- a/.jjconflict-side-0/.envrc
+++ b/.jjconflict-side-0/.envrc
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+
+# If we are a computer with nix available, then use that to setup
+# the build environment with exactly what we need.
+if has nix; then
+  # Watch nix submodules
+  watch_dir hosts
+  watch_dir infra
+  watch_dir modules
+  watch_dir secrets
+  # Use nix flakes to setup the environment
+  use flake . --accept-flake-config --no-pure-eval
+fi

--- a/.jjconflict-side-0/.github/renovate.json
+++ b/.jjconflict-side-0/.github/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices", "security:openssf-scorecard"],
+  "nix": { "enabled": true },
+  "postUpgradeTasks": {
+    "commands": ["nix fmt"],
+    "executionMode": "branch",
+    "fileFilters": ["**/*.nix"],
+    "installTools": { "nix": {} }
+  }
+}

--- a/.jjconflict-side-0/.github/workflows/cleanup.yaml
+++ b/.jjconflict-side-0/.github/workflows/cleanup.yaml
@@ -1,0 +1,25 @@
+name: Cleanup
+permissions:
+  contents: read
+"on":
+  pull_request:
+    types:
+      - closed
+jobs:
+  cleanup:
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/cleanup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          pull-request-url: ${{ github.event.pull_request.html_url }}

--- a/.jjconflict-side-0/.github/workflows/commands.yaml
+++ b/.jjconflict-side-0/.github/workflows/commands.yaml
@@ -1,0 +1,129 @@
+name: Commands
+permissions:
+  contents: read
+"on":
+  issue_comment:
+    types:
+      - created
+jobs:
+  backport:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.backport')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/backport@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+  close:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.close')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/close@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          username: operator6o
+  land:
+    if:
+      github.event.issue.pull_request != null &&
+      (contains(github.event.comment.body, '.land') ||
+      contains(github.event.comment.body, '.force-land'))
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-administration: read
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/land@v9
+        with:
+          email: operator6o@shikanime.studio
+          fullname: Operator 6O
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+          username: operator6o
+  rebase:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.rebase')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/rebase@v9
+        with:
+          email: operator6o@shikanime.studio
+          fullname: Operator 6O
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+          username: operator6o
+  run:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.run')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/run@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}

--- a/.jjconflict-side-0/.github/workflows/integration.yaml
+++ b/.jjconflict-side-0/.github/workflows/integration.yaml
@@ -1,0 +1,47 @@
+name: Integration
+permissions:
+  contents: read
+jobs:
+  nix:
+    if:
+      ${{ github.event_name == 'workflow_call' || github.event_name ==
+      'workflow_dispatch' || github.event.pull_request.draft == false }}
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/nix.yaml
+    with:
+      cachix-name: shikanime
+  skaffold:
+    if:
+      ${{ github.event_name == 'workflow_call' || github.event_name ==
+      'workflow_dispatch' || github.event.pull_request.draft == false }}
+    needs:
+      - nix
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/skaffold.yaml
+"on":
+  pull_request:
+    branches:
+      - main
+      - gh/*/*/base
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: false
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch: {}

--- a/.jjconflict-side-0/.github/workflows/nix.yaml
+++ b/.jjconflict-side-0/.github/workflows/nix.yaml
@@ -1,0 +1,152 @@
+name: Nix
+permissions:
+  contents: read
+"on":
+  workflow_call:
+    inputs:
+      cachix-name:
+        type: string
+        default: ""
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: false
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      cachix-name:
+        type: string
+        default: ""
+        description: Cachix cache name
+jobs:
+  checks:
+    name: Checks
+    if: ${{ needs['setup-checks-jobs'].outputs.continue == 'true' }}
+    runs-on: ${{ matrix.runner }}
+    needs:
+      - setup-checks-jobs
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs['setup-checks-jobs'].outputs.matrix) }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-name: ${{ inputs['cachix-name'] }}
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        run:
+          nix flake check --accept-flake-config --no-pure-eval --system "${{
+          matrix.system }}"
+        shell: bash
+  packages:
+    name: Packages
+    if: ${{ needs['setup-packages-jobs'].outputs.continue == 'true' }}
+    runs-on: ${{ matrix.runner }}
+    needs:
+      - setup-packages-jobs
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs['setup-packages-jobs'].outputs.matrix) }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-name: ${{ inputs['cachix-name'] }}
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        uses: shikanime-studio/actions/nix/integration@v9
+        with:
+          name: ${{ matrix.name }}
+          system: ${{ matrix.system }}
+  setup-checks-jobs:
+    name: Setup Checks Jobs
+    runs-on: ubuntu-latest
+    outputs:
+      continue: ${{ steps.setup-checks-jobs.outputs.continue }}
+      matrix: ${{ steps.setup-checks-jobs.outputs.matrix }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: setup-checks-jobs
+        uses: shikanime-studio/actions/nix/setup-checks-jobs@v9
+  setup-packages-jobs:
+    name: Setup Packages Jobs
+    runs-on: ubuntu-latest
+    needs:
+      - checks
+    outputs:
+      continue: ${{ steps.setup-packages-jobs.outputs.continue }}
+      matrix: ${{ steps.setup-packages-jobs.outputs.matrix }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: setup-packages-jobs
+        uses: shikanime-studio/actions/nix/setup-packages-jobs@v9

--- a/.jjconflict-side-0/.github/workflows/release.yaml
+++ b/.jjconflict-side-0/.github/workflows/release.yaml
@@ -1,0 +1,72 @@
+name: Release
+permissions:
+  contents: read
+"on":
+  push:
+    branches:
+      - main
+      - release-[0-9]+.[0-9]+
+    tags:
+      - v?[0-9]+.[0-9]+.[0-9]+*
+  workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      ref_name:
+        description: Tag or branch to release
+        required: true
+jobs:
+  nix:
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/nix.yaml
+    with:
+      cachix-name: shikanime
+  release:
+    if:
+      (startsWith(github.ref, 'refs/tags/v')) || (github.event_name ==
+      'workflow_dispatch' && startsWith(github.event.inputs.ref_name, 'v'))
+    needs:
+      - skaffold
+      - nix
+    permissions:
+      contents: write
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/release@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          ref: ${{ github.ref_name || github.event.inputs.ref_name }}
+          repo: ${{ github.repository }}
+  skaffold:
+    needs:
+      - nix
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/skaffold.yaml

--- a/.jjconflict-side-0/.github/workflows/skaffold.yaml
+++ b/.jjconflict-side-0/.github/workflows/skaffold.yaml
@@ -1,0 +1,141 @@
+name: Skaffold
+permissions:
+  contents: read
+"on":
+  workflow_call:
+    inputs:
+      push:
+        type: boolean
+        default: true
+        description: Whether to push images during build
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch: {}
+jobs:
+  build-render:
+    name: Build & Render
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: docker/login-action@v4
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extra-platforms: arm64
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - id: skaffold
+        env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        uses: shikanime-studio/actions/skaffold/integration@v9
+        with:
+          push: ${{ inputs.push }}
+      - name: Save manifest
+        run: |
+          mkdir -p artifacts
+          cat > artifacts/skaffold-manifest.yaml <<'MANIFEST_EOF'
+          $SKAFFOLD_MANIFEST
+          MANIFEST_EOF
+        shell: bash
+        env:
+          SKAFFOLD_MANIFEST: ${{ steps.skaffold.outputs.manifest }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: skaffold-manifest
+          path: artifacts/skaffold-manifest.yaml
+  build-render-profile:
+    name: Build & Render (Profile)
+    if: ${{ needs['setup-profiles-jobs'].outputs.continue == 'true' }}
+    runs-on: ubuntu-latest
+    needs:
+      - setup-profiles-jobs
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs['setup-profiles-jobs'].outputs.matrix) }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: docker/login-action@v4
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extra-platforms: arm64
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        uses: shikanime-studio/actions/skaffold/integration@v9
+        with:
+          profile: ${{ matrix.name }}
+          push: ${{ inputs.push }}
+  setup-profiles-jobs:
+    name: Setup Profiles Jobs
+    runs-on: ubuntu-latest
+    outputs:
+      continue: ${{ steps.setup-profiles-jobs.outputs.continue }}
+      matrix: ${{ steps.setup-profiles-jobs.outputs.matrix }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extra-platforms: arm64
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: setup-profiles-jobs
+        uses: shikanime-studio/actions/skaffold/setup-profiles-jobs@v9

--- a/.jjconflict-side-0/.github/workflows/triage.yaml
+++ b/.jjconflict-side-0/.github/workflows/triage.yaml
@@ -1,0 +1,50 @@
+name: Triage
+permissions:
+  pull-requests: write
+"on":
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  triage:
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - env:
+          GH_TOKEN:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+        if:
+          github.event.pull_request.user.login == 'dependabot[bot]' ||
+          github.event.pull_request.user.login == 'yorha-operator-6o[bot]'
+        run:
+          gh pr edit "${{ github.event.pull_request.number }}" --add-label
+          dependencies
+      - env:
+          GH_TOKEN:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+        if:
+          startsWith(github.head_ref, 'gh/') && endsWith(github.head_ref,
+          '/head')
+        run:
+          gh pr edit "${{ github.event.pull_request.number }}" --add-label
+          ghstack

--- a/.jjconflict-side-0/.github/workflows/update.yaml
+++ b/.jjconflict-side-0/.github/workflows/update.yaml
@@ -1,0 +1,50 @@
+name: Update
+permissions:
+  contents: read
+"on":
+  schedule:
+    - cron: 0 4 * * 0
+  workflow_dispatch: {}
+jobs:
+  dependencies:
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+          username: operator6o
+      - uses: shikanime-studio/actions/update@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          username: operator6o
+  stale:
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-issues: write
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: actions/stale@v10
+        with:
+          days-before-close: 14
+          days-before-stale: 30
+          repo-token: ${{ steps.createGithubAppToken.outputs.token }}
+          stale-issue-label: stale
+          stale-pr-label: stale

--- a/.jjconflict-side-0/.github/workflows/wakabox.yaml
+++ b/.jjconflict-side-0/.github/workflows/wakabox.yaml
@@ -1,0 +1,15 @@
+name: Wakabox
+permissions:
+  contents: read
+"on":
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  wakabox:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.WAKABOX_GITHUB_TOKEN }}
+          GIST_ID: ${{ vars.WAKABOX_GITHUB_GIST_ID }}
+          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+        uses: matchai/waka-box@v5.0.0

--- a/.jjconflict-side-0/.gitignore
+++ b/.jjconflict-side-0/.gitignore
@@ -1,0 +1,315 @@
+###------------------------------###
+###  GitHub Community: OpenTofu  ###
+###------------------------------###
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tofu
+override.tf.json
+override.tofu.json
+*_override.tf
+*_override.tofu
+*_override.tf.json
+*_override.tofu.json
+
+# Ignore transient lock info files created by tofu apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+# !example_override.tofu
+
+# Include tfplan files to ignore the plan output of command: tofu plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+###---------------------------------------------------------------------###
+###  Repo: shikanime-studio/gitignore/refs/heads/main/Devenv.gitignore  ###
+###---------------------------------------------------------------------###
+
+.env
+.env.*
+.devenv*
+.direnv*
+
+###-------------------------###
+###  TopTal: jetbrains+all  ###
+###-------------------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/jetbrains+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=jetbrains+all
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+# End of https://www.toptal.com/developers/gitignore/api/jetbrains+all
+
+###-----------------###
+###  TopTal: linux  ###
+###-----------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/linux
+# Edit at https://www.toptal.com/developers/gitignore?templates=linux
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# End of https://www.toptal.com/developers/gitignore/api/linux
+
+###-----------------###
+###  TopTal: macos  ###
+###-----------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/macos
+
+###---------------###
+###  TopTal: vim  ###
+###---------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/vim
+# Edit at https://www.toptal.com/developers/gitignore?templates=vim
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.toptal.com/developers/gitignore/api/vim
+
+###----------------------------###
+###  TopTal: visualstudiocode  ###
+###----------------------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudiocode
+
+###-------------------###
+###  TopTal: windows  ###
+###-------------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/windows
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/windows
+
+###-------------------###
+###  Devlib: content  ###
+###-------------------###
+
+.pre-commit-config.yaml

--- a/.jjconflict-side-0/CODE_OF_CONDUCT.md
+++ b/.jjconflict-side-0/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<william.phetsinorath@shikanime.studio>. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/.jjconflict-side-0/LICENSE
+++ b/.jjconflict-side-0/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/.jjconflict-side-0/README.md
+++ b/.jjconflict-side-0/README.md
@@ -1,0 +1,195 @@
+<!-- markdownlint-disable first-line-heading MD041 -->
+
+![header.png](https://raw.githubusercontent.com/shikanime/shikanime/main/assets/github-header.png)
+
+<!-- markdownlint-enable first-line-heading MD041 -->
+
+# Machines
+
+Shikanime's machine configuration repository for NixOS, nix-darwin, WSL, and
+related shared home modules.
+
+## What This Repo Contains
+
+This flake is the source of truth for the machines I manage. It wires together:
+
+- host-specific NixOS, nix-darwin, and WSL configurations
+- shared system modules for Linux and Darwin
+- shared Home Manager modules
+- encrypted secrets with `sops-nix`
+- distributed build and deployment helpers
+- a `devenv` shell for repository tooling
+
+## Repository Layout
+
+### `flake.nix`
+
+The flake entry point. It imports the module sets and exposes the host
+configurations and build outputs.
+
+### `hosts/`
+
+Per-machine entry points.
+
+- `hosts/<name>/configuration.nix` is the main NixOS host definition
+- `hosts/telsha/darwin-configuration.nix` is the nix-darwin host definition
+- `hosts/<name>/users/<user>/home-configuration.nix` contains host-specific Home
+  Manager config
+- `hosts/<name>/facter.json` stores hardware facts for hosts that rely on
+  `nixos-facter`
+
+Current hosts:
+
+- `ashira` - NixOS server node
+- `manash` - NixOS server node
+- `nalsha` - NixOS server node
+- `fushi` - NixOS ARM node
+- `minish` - NixOS ARM node
+- `nemishi` - NixOS ARM node
+- `ishtar` - NixOS GUI workstation (Razer Blade 17 (2019), Hyprland on Wayland +
+  NVIDIA)
+- `nixtar` - NixOS on WSL
+- `catbox` - KubeVirt containerdisk (NixOS qcow2 wrapped as an OCI image)
+- `telsha` - nix-darwin host
+
+### `modules/`
+
+Shared module layers.
+
+- `modules/nixos/` contains Linux host profiles
+  - `base.nix` - common NixOS defaults, `comin`, and Nix access token wiring
+  - `minimal.nix` - baseline Nix settings, GC, auto-upgrade, and Home Manager
+    defaults
+  - `workstation.nix` - workstation-oriented tooling and desktop defaults
+  - `follower.nix` - server defaults shared by cluster nodes
+  - `distributed.nix` - remote build machines and distributed build settings
+  - `nishir.nix` - cluster node defaults: tailscale, SSH, Avahi, firewall tweaks
+  - `nishir.nix` and `talashi.nix` - cluster-specific server profiles
+- `modules/darwin/` contains macOS host profiles
+  - `base.nix`, `minimal.nix`, `workstation.nix`, `distributed.nix`
+- `modules/home/` contains shared Home Manager modules
+  - shell, editor, font, VCS, and workstation-specific settings
+- `modules/flake/` contains flake-parts glue for NixOS, Darwin, and devenv
+
+### Theming
+
+Noctalia (the Wayland shell/bar) is configured entirely through Nix — there is
+no repo-owned theme schema or UI component to edit. The theme is set per user in
+`hosts/<host>/users/<user>/home-configuration.nix` under
+`programs.noctalia.settings`:
+
+- `theme.mode` — the auto-mode flag. `"auto"` follows the day/night schedule;
+  set it to `"dark"` or `"light"` to disable auto and pin a fixed theme.
+- `location.auto_locate` — when `true` (current ishtar setting), the schedule is
+  derived from runtime IP geolocation. For a fixed-location, offline setup use
+  `location.latitude`/`longitude` instead, or `location.custom_schedule` with
+  explicit `sunrise`/`sunset` times.
+- `shell.greeter_sync.auto_sync` — when `true`, the shell pushes its resolved
+  theme (auto → day/night) into the greeter, so the login screen follows the
+  same schedule. Off by default. Do not set `theme.mode` on the greeter: its
+  binary ignores `[theme]`; only the shell→greeter sync drives greeter theming.
+
+### `secrets/`
+
+Encrypted secrets managed by `sops-nix`.
+
+- files use the `*.enc.yaml` naming convention
+- decrypted values are generated at evaluation or activation time
+- do not commit plaintext secret material
+
+### `skaffold.yaml`
+
+Repository automation for render/build workflows.
+
+## Flake Outputs
+
+The flake exposes these primary outputs:
+
+- `nixosConfigurations.ashira`
+- `nixosConfigurations.manash`
+- `nixosConfigurations.nalsha`
+- `nixosConfigurations.fushi`
+- `nixosConfigurations.minish`
+- `nixosConfigurations.nemishi`
+- `nixosConfigurations.ishtar`
+- `nixosConfigurations.nixtar`
+- `darwinConfigurations.telsha`
+- `packages.<system>.*` for the corresponding system builds, including `catbox`
+
+The `packages` outputs are mostly convenience build artifacts for CI and local
+verification.
+
+## Usage
+
+### Build A Host
+
+```sh
+nix build .#nixosConfigurations.manash.config.system.build.toplevel
+nix build .#darwinConfigurations.telsha.system
+```
+
+For the published package outputs:
+
+```sh
+nix build .#packages.x86_64-linux.manash
+nix build .#packages.aarch64-darwin.telsha
+nix build .#packages.x86_64-linux.catbox
+```
+
+### Switch A NixOS Host
+
+```sh
+sudo nixos-rebuild switch --flake .#manash
+```
+
+Replace `manash` with `ashira`, `nalsha`, `fushi`, `minish`, `nemishi`,
+`ishtar`, or `nixtar` as needed.
+
+### Switch A Darwin Host
+
+```sh
+darwin-rebuild switch --flake .#telsha
+```
+
+### Enter The Dev Shell
+
+```sh
+nix develop
+```
+
+The shell is defined through `devenv` and includes the repository tooling used
+for build and workflow tasks.
+
+## Secret Handling
+
+Most hosts consume encrypted data from `secrets/<host>.enc.yaml`.
+
+- host configs point `sops.defaultSopsFile` at their matching secret file
+- secrets are restarted through systemd unit hooks where required
+- some hosts also use `sops.templates.*` to materialize config fragments
+
+## Cluster And Build Topology
+
+The Linux server nodes are split between cluster-oriented machines and general
+workstation-style machines:
+
+- `ashira`, `manash`, and `nalsha` are x86_64 Linux nodes with Tailscale,
+  distributed build settings, and cluster runner duties
+- `fushi`, `minish`, and `nemishi` are ARM Linux nodes with the same shared
+  cluster profile shape
+- `ishtar` is a bare-metal GUI workstation (Hyprland on Wayland + NVIDIA)
+- `nixtar` is a WSL-based workstation profile
+- `telsha` is the Darwin workstation profile
+
+Several hosts share remote build configuration through
+`modules/nixos/profiles/distributed.nix`, which lets local builds offload work
+to the other machines.
+
+## Related Repos
+
+This repository follows the same general shape as the other Shikanime
+configuration repos:
+
+- `shikanime-labs/colemak`
+- `shikanime-labs/manifests`
+- `shikanime-studio/knix`

--- a/.jjconflict-side-0/docs/nemishi-nvme-probe.md
+++ b/.jjconflict-side-0/docs/nemishi-nvme-probe.md
@@ -1,0 +1,54 @@
+# nemishi NVMe Probe Timeout — Root Cause & Fix
+
+## Symptom
+
+`nemishi` (RPi 5, aarch64) boots off SD (`mmcblk0`) but `systemd` blocks on the
+declared `disko` device:
+
+```text
+systemd[1]: Timed out waiting for device /dev/nvme0n1.
+```
+
+`/dev/nvme*` never appears. Looks like a dead drive. It wasn't.
+
+## Root Cause (the real one)
+
+The M.2 HAT+ 16-pin FPC ribbon to the Pi's board connector was not seated. That
+ribbon carries 5V to the HAT — without it the SSD gets no power. The NVMe
+_controller_ still enumerates on PCIe (`/dev/nvme0` exists) but reports **0
+bytes** (`/sys/block/nvme0n1/size == 0`), so the kernel can't mount or probe it
+and you get `No such device` / `XFS SB validate failed`.
+
+Seat the 16-pin ribbon, power-cycle, `cat /sys/block/nvme0n1/size` should
+be > 0.
+
+## Secondary tuning (Pi 5 host side, not the cause)
+
+DRM-less SSDs on the BCM2712 root can also wedge on admin-queue `Identify`:
+
+- **PCIe ASPM L1**: root defaults L1 on; link sleep wedges the queue (`-12`
+  class). `rpi5.nix` forces `pcie_aspm.policy=performance` (L1 off).
+- **APST** was previously also disabled (`default_ps_max_latency_us=0`) but is
+  **no longer needed** — removed once the real cause (power ribbon) was found.
+
+`cma=512M` and the `pcie-32bit-dma-pi5` overlay remain required.
+
+## Live Verification (post-reseat, no rebuild)
+
+```text
+cat /sys/block/nvme0n1/size        # > 0 once the ribbon is seated
+ls -la /dev/nvme0n1                 # block device present
+# XFS mounts at /mnt/data, smartctl -H PASSED
+```
+
+## History
+
+Earlier this doc blamed APST + ASPM for a "timeout, disable controller" probe
+failure. That log was from a _separate_ pre-power-ribbon state; the 0-byte /
+`No such device` symptom the host actually hit was pure missing 5V. The
+`nvme_core.default_ps_max_latency_us=0` workaround was stripped from `rpi5.nix`.
+
+`pcie_aspm.policy=performance` was reviewed for removal but **kept**: it guards
+a separate, real BCM2712 root-port quirk (ASPM L1 wedges the NVMe admin queue,
+probe `-12`). The power-ribbon fix was _our_ failure; this is a different
+hardware trap worth the one-line insurance.

--- a/.jjconflict-side-0/docs/network-interfaces.md
+++ b/.jjconflict-side-0/docs/network-interfaces.md
@@ -1,0 +1,102 @@
+# Network Interface Configuration
+
+## Overview
+
+Bridged networking via native nixpkgs options (`networking.bridges` +
+`networking.interfaces` + `networking.useNetworkd`). Every host has a single
+bridge `br0` that carries all traffic — pod-to-pod, SSH, flannel, Longhorn.
+
+## Implementation
+
+Configured inline in each hardware module — no custom abstraction module.
+
+| Module                         | Interfaces         | Bond                  | Bridge | DHCP |
+| ------------------------------ | ------------------ | --------------------- | ------ | ---- |
+| `modules/nixos/beelink-eq.nix` | `enp1s0`, `enp2s0` | `bond0` (balance-alb) | `br0`  | yes  |
+| `modules/nixos/rpi.nix`        | `end0`             | —                     | `br0`  | yes  |
+
+### Beelink (dual 2.5G NIC, balance-alb bond)
+
+```nix
+networking = {
+  useNetworkd = true;
+  bonds.bond0 = {
+    interfaces = [ "enp1s0" "enp2s0" ];
+    driverOptions = { mode = "balance-alb"; miimon = "100"; };
+  };
+  bridges.br0.interfaces = [ "bond0" ];
+  interfaces.br0.useDHCP = true;
+};
+```
+
+### Raspberry Pi (single 1G USB3 NIC)
+
+```nix
+networking = {
+  useNetworkd = true;
+  bridges.br0.interfaces = [ "end0" ];
+  interfaces.br0.useDHCP = true;
+};
+```
+
+## Bonding rationale
+
+The NETGEAR MS308 is an unmanaged switch — no LACP (802.3ad) support.
+`balance-alb` (mode 6) aggregates both NICs entirely in the Linux driver via ARP
+negotiation. Zero switch configuration required.
+
+- Single-flow throughput: 2.5 Gbps (per-flow hash)
+- Multi-flow aggregate: ~4-5 Gbps
+- Fails over automatically if one NIC/link dies (`miimon=100`)
+- One cable plugged in → bond works on single link; second cable is hot-add
+
+## Longhorn storage network
+
+The Multus `storageNetwork` NAD has been **removed**. Rationale:
+
+1. `br0` carries all traffic (management + pod). A Multus secondary interface on
+   the same bridge as flannel provides **zero isolation** — both interfaces hit
+   identical iptables/conntrack/kube-proxy overhead
+   (`bridge-nf-call-iptables=1`).
+2. The knix Multus stack uses DHCP IPAM (thick plugin + dynamic networks
+   controller + DHCP DaemonSet). Whereabouts IPAM is incompatible with this
+   stack. DHCP IPAM on the same subnet as `br0` causes routing ambiguity (two
+   interfaces, same subnet, same pod).
+3. Longhorn on default flannel/host-gw already performs at wire speed for
+   same-L2 clusters.
+
+**When to re-add**: only with a **physically separate storage network** —
+`enp2s0` cabled to a dedicated switch, `br-storage` bridge with
+`bridge-nf-call-iptables=0` on that bridge only. Then the NAD bypasses all
+Kubernetes netfilter overhead. See the "dual bridge" pattern in the skill.
+
+## NIC performance tuning
+
+Each hardware module includes an inline
+`systemd.services.network-nic-performance` one-shot that applies ethtool
+hardware offloads (TSO/GSO/SG/RX/TX, rx-udp-gro-forwarding) and RPS IRQ
+distribution on the physical interfaces (pre-bond, pre-bridge).
+
+## Why not a custom module?
+
+A previous iteration used a 208-line custom `hardware.networkInterfaces` module.
+It was never imported into any host configuration — dead code that caused
+`The option 'hardware.networkInterfaces' does not exist` build failures. Native
+`networking.bridges` achieves the same result in 3-4 lines per interface.
+
+## Discovery
+
+Verify interface names on actual hardware before deploying:
+
+```bash
+ip link show          # List interfaces and kernel names
+ethtool -i <iface>    # Verify driver
+```
+
+Known names by hardware:
+
+| Hardware                     | Interface(s)       | Driver     |
+| ---------------------------- | ------------------ | ---------- |
+| Beelink (Intel N150, i226-V) | `enp1s0`, `enp2s0` | `igc`      |
+| Raspberry Pi CM4 (USB3 GigE) | `end0`             | `lan743x`  |
+| Older Raspberry Pi           | `eth0`             | `smsc95xx` |

--- a/.jjconflict-side-0/docs/network-performance-remediation.md
+++ b/.jjconflict-side-0/docs/network-performance-remediation.md
@@ -1,0 +1,92 @@
+# Network Performance Remediation — Switch Flannel to host-gw
+
+## Problem
+
+Cross-node pod-to-pod throughput is ~535 Mbps on Beelink nodes (2.5 Gbps NICs)
+and ~400 Mbps estimated on Raspberry Pi 4 nodes (1 Gbps NICs). This is far below
+the theoretical capacity (80% target = 2,000 Mbps for Beelink, 800 Mbps for
+Pi4).
+
+## Root Cause
+
+The `rke2-canal` ConfigMap configures flannel with `Backend: wireguard`, which
+encrypts all cross-node traffic with kernel WireGuard (ChaCha20-Poly1305).
+WireGuard single-flow encryption is CPU-limited:
+
+| Hardware             | Single-core WireGuard |
+| -------------------- | --------------------- |
+| Intel N150 (Beelink) | ~800-1,200 Mbps       |
+| BCM2711 (Pi4, NEON)  | ~400-600 Mbps         |
+
+Since all cluster nodes are on the **same Layer 2 subnet** (192.168.1.0/24),
+WireGuard encryption is pure overhead — it adds CPU load without providing
+security (the traffic never leaves the physical LAN).
+
+## Remedy
+
+Switch flannel backend from `wireguard` to `host-gw`. host-gw installs static
+routes via the Linux routing table — zero encapsulation, zero encryption
+overhead.
+
+### Procedure
+
+This change requires a **rolling restart of RKE2 on each node** because the CNI
+configuration is read at node startup.
+
+### Step 1: Switch flannel backend via knix canal options
+
+The `services.knix.canal` options are provided by the `canal.nix` module in
+[shikanime-studio/knix](https://github.com/shikanime-studio/knix). The backend
+is set to `host-gw` globally for all cluster nodes:
+
+```nix
+# modules/nixos/nishir.nix
+services.knix.canal.backend = "host-gw";
+```
+
+Per-host override (if needed):
+
+```nix
+services.knix.canal.backend = lib.mkForce "vxlan";
+```
+
+Defaults (when importing knix):
+
+- `backend = "wireguard"` (backward compatible)
+- `vethMtu = "1500"` for host-gw, `"1400"` for wireguard
+- `wireguardKeepAlive = 25` (only when backend = wireguard)
+
+### Step 2: Restart canal to apply
+
+```bash
+kubectl rollout restart ds -n kube-system rke2-canal
+```
+
+## Expected Results After All Remediations Combined
+
+| Path                | Current (wireguard) | After host-gw | After +offloads | Target (80%) |
+| ------------------- | ------------------- | ------------- | --------------- | ------------ |
+| Beelink <-> Beelink | ~535 Mbps           | ~2,200 Mbps   | ~2,400 Mbps     | 2,000 Mbps   |
+| Pi4 <-> Pi4         | ~400 Mbps           | ~900 Mbps     | ~940 Mbps       | 800 Mbps     |
+| Beelink <-> Pi4     | ~450 Mbps           | ~1,500 Mbps   | ~1,800 Mbps     | —            |
+
+## Related Changes (in this PR)
+
+1. `shikanime-studio/knix` — New `modules/canal.nix` module upstreamed.
+   `services.knix.canal.backend` option (host-gw | vxlan | wireguard) with
+   per-host override. Default: wireguard (backward compatible). Also sets
+   `vethMtu` automatically per backend and loads WireGuard kernel module when
+   needed. `rke2.nix` updated to use `cfg.canal` values in the HelmChartConfig
+   manifest.
+
+2. `modules/nixos/nishir.nix` — Firewall allows pod CIDR on br+ interfaces.
+
+3. `modules/nixos/beelink-eq.nix` — Dual i226-V NICs bonded via `balance-alb`
+   (bond0) into a single `br0` bridge. `network-nic-performance` service applies
+   TSO/GSO/SG/RX+TX offloads and RPS on both physical ports.
+
+4. `modules/nixos/rpi.nix` — Single `end0` NIC into `br0` bridge. Same NIC
+   offload service.
+
+5. `modules/nixos/rpi5.nix` — Imports rpi.nix (inherits bridge + offloads).
+   Pi5-specific: kernelboot, config.txt [pi5] section.

--- a/.jjconflict-side-0/docs/rpi5-nixos.md
+++ b/.jjconflict-side-0/docs/rpi5-nixos.md
@@ -1,0 +1,178 @@
+# Raspberry Pi 5 NixOS Boot — Research & Solution
+
+## Problem
+
+The Raspberry Pi 5 (BCM2712) EEPROM bootloader performs an **OS check** before
+loading the kernel. When it cannot find a device-tree file matching
+`bcm2712-rpi-5-b.dtb` on the firmware partition, or when `config.txt` does not
+signal Pi 5 support, it halts with:
+
+```text
+Device-tree file "bcm2712-rpi-5-b.dtb" not found.
+The installed operating system (OS) does not indicate support for Raspberry Pi 5
+Update the OS or set os_check=0 in config.txt to skip this check.
+```
+
+This affected `nemishi` (RPi 5) when building SD images via
+`sd-image-aarch64.nix` with the `nixos-hardware.nixosModules.raspberry-pi-5`
+module.
+
+## Root Cause
+
+Two independent issues:
+
+1. **Missing DTBs in firmware partition**: The `sd-image-aarch64.nix`
+   `populateFirmwareCommands` only copies Pi 3/4 DTBs (`bcm2710`, `bcm2711`) and
+   U-Boot binaries. No Pi 5 DTBs (`bcm2712`).
+
+2. **Missing `config.txt` signals**: The `config-txt-defaults.nix` in
+   nixos-hardware only defines `[all]`, `[cm4]`, and `[cm5]` sections. There is
+   no `[pi5]` section, no `os_check` setting, and no `arm_64bit` setting. The Pi
+   5 boot ROM requires these to proceed.
+
+## Solution: Kernelboot Bootloader
+
+The current fix adopts the **kernelboot** pattern from
+[nvmd/nixos-raspberrypi](https://github.com/nvmd/nixos-raspberrypi):
+
+- The Pi 5 firmware loads `kernel.img` **directly** from the FAT firmware
+  partition, bypassing the extlinux layer.
+- The `os_check` is bypassed because the firmware finds a directly-loadable
+  kernel image.
+- `arm_64bit=1` and `os_check=0` are still included in `config.txt` as
+  belt-and-suspenders.
+
+### Firmware Partition Layout
+
+```text
+/boot/firmware/
+├── bootcode.bin      # GPU boot code (from raspberrypifw)
+├── start*.elf       # GPU firmware
+├── fixup*.dat       # GPU fixup
+├── bcm2712*.dtb     # Pi 5 device tree blobs
+├── overlays/        # DTB overlays (*.dtbo)
+├── kernel.img       # Linux kernel (from nixos-hardware linux-rpi)
+├── initrd           # Initial ramdisk (from system.build.initialRamdisk)
+├── cmdline.txt      # Kernel command line
+└── config.txt       # Firmware config (with arm_64bit=1, os_check=0)
+```
+
+### Why Not `generic-extlinux-compatible`?
+
+The `generic-extlinux-compatible` boot path uses U-Boot/extlinux to load the
+kernel. The Pi 5 EEPROM `os_check` runs **before** any of that — it reads
+`config.txt` directly and validates OS compatibility signals. Without
+`arm_64bit=1` in a `[pi5]` section, the firmware halts.
+
+The `kernelboot` path avoids this entirely: the firmware finds `kernel.img` in
+the FAT partition and loads it directly, skipping the `os_check` validation.
+
+## Alternative Approaches Considered
+
+### 1. Fix `config.txt` Only (Minimal Patch)
+
+Add `os_check=0` and `arm_64bit=1` to `config.txt` settings:
+
+```nix
+hardware.raspberry-pi.configtxt.settings.pi5 = {
+  arm_64bit = 1;
+  os_check = 0;
+};
+```
+
+**Pros**: Minimal change. Works with existing `generic-extlinux-compatible`.
+**Cons**: Still requires manual `populateFirmwareCommands` for DTBs. Fragile —
+depends on the firmware's OS check behavior not changing.
+
+### 2. Migrate Fully to `nvmd/nixos-raspberrypi`
+
+Replace nixos-hardware entirely with:
+
+- `boot.loader.raspberry-pi` module
+- `hardware.raspberry-pi.config` for config.txt
+- `hardware.raspberry-pi.firmware` for firmware staging
+- Vendor kernel from `linuxPackages_rpi5`
+
+**Pros**: Complete solution. Binary cache. Actively maintained. **Cons**: Pinned
+to `nixos-25.11` (no `nixos-unstable`). Different kernel package. Would require
+dropping nixos-hardware entirely.
+
+### 3. Kernelboot with nixos-hardware Kernel (Current)
+
+Keep nixos-hardware's `linux-rpi` kernel and `raspberry-pi-5` module. Override
+`populateFirmwareCommands` to use the kernelboot pattern. Override
+`populateRootCommands` to skip extlinux.
+
+**Pros**: Minimal external dependencies. Keeps nixos-hardware kernel. Avoids
+`os_check` entirely. Works with `nixos-unstable`. **Cons**:
+`populateFirmwareCommands` still includes Pi 3/4 defaults from
+`sd-image-aarch64.nix` (harmless but noisy).
+
+## Upstream Status
+
+- **nixos-hardware PR #1894** ("raspberry-pi: add firmware-partition install
+  module"): Approved, awaiting merge. Adds `hardware.raspberry-pi.firmware` for
+  proper firmware staging. Would eventually replace the manual
+  `populateFirmwareCommands` override.
+- **nixos-hardware Issue #1928**: Documents this exact bug. Created during
+  previous debugging session.
+- **nixpkgs Issue #260754**: Upstream tracking for Pi 5 support. NixOS
+  maintainers require upstream Linux + U-Boot support before official support.
+
+## Implementation Details
+
+### `config.txt` Section Rendering
+
+The nixos-hardware `config-txt.nix` renderer generates sections from nested Nix
+attribute sets:
+
+```nix
+hardware.raspberry-pi.configtxt.settings.pi5 = {
+  os_check = 0;
+  arm_64bit = 1;
+};
+```
+
+Renders to:
+
+```ini
+[pi5]
+os_check=0
+arm_64bit=1
+```
+
+**Important**: The settings **must** be in a `[pi5]` section, not `[all]`. The
+Pi 5 firmware specifically validates model-specific settings under the correct
+conditional filter.
+
+### `populateFirmwareCommands` Evaluation Context
+
+`populateFirmwareCommands` is evaluated at **image build time** on the target
+architecture (`aarch64-linux`). The following paths are available:
+
+- `config.system.build.kernel` — the kernel derivation
+- `config.system.build.initialRamdisk` — the initrd derivation (note: **not**
+  `config.system.build.initrd` — that's in `netboot.nix` only)
+- `config.hardware.raspberry-pi.configtxt.file` — the rendered `config.txt`
+
+### `populateRootCommands` Override
+
+The default `sd-image-aarch64.nix` `populateRootCommands` references
+`config.boot.loader.generic-extlinux-compatible.populateCmd`. When extlinux is
+disabled, this option has no value, causing an evaluation error. The fix uses
+`lib.mkForce` to override:
+
+```nix
+sdImage.populateRootCommands = lib.mkForce ''
+  mkdir -p ./files/boot
+'';
+```
+
+## References
+
+- [NixOS on ARM/Raspberry Pi 5 (Wiki)](https://wiki.nixos.org/wiki/NixOS_on_ARM/Raspberry_Pi_5)
+- [nvmd/nixos-raspberrypi](https://github.com/nvmd/nixos-raspberrypi)
+- [nixos-hardware Issue #1928](https://github.com/NixOS/nixos-hardware/issues/1928)
+- [nixos-hardware PR #1894](https://github.com/NixOS/nixos-hardware/pull/1894)
+- [nixpkgs Issue #260754](https://github.com/NixOS/nixpkgs/issues/260754)
+- [Raspberry Pi config.txt documentation](https://www.raspberrypi.com/documentation/computers/config_txt.html)

--- a/.jjconflict-side-0/flake.lock
+++ b/.jjconflict-side-0/flake.lock
@@ -1,0 +1,931 @@
+{
+  "nodes": {
+    "cachix": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "git-hooks": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777487137,
+        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "latest",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "catppuccin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783356436,
+        "narHash": "sha256-eUh4pdoI5pnMLV+sncuThErQ71Bs3S5fdo/my3SUf1A=",
+        "owner": "catppuccin",
+        "repo": "nix",
+        "rev": "cf1750da1bdabcd549d2476f387d39e90bb20228",
+        "type": "github"
+      },
+      "original": {
+        "owner": "catppuccin",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "colemak": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "devlib": [
+          "devlib"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785030539,
+        "narHash": "sha256-tNByzHNUYY/2IKuUzld64XNVo0ESsw08PYVNCfmp2l8=",
+        "owner": "shikanime-labs",
+        "repo": "colemak",
+        "rev": "57379a41202cdf47de106e6af7dbbaa86da2f958",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-labs",
+        "repo": "colemak",
+        "type": "github"
+      }
+    },
+    "comin": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1782515413,
+        "narHash": "sha256-Pb5ngiUtJWO7N8hUtv1dXoViv1IuJUIOKLcOprrfUvU=",
+        "owner": "nlewo",
+        "repo": "comin",
+        "rev": "ec4b64a43faf5261ad4dc35b4e008c2bafc2e8db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "comin",
+        "type": "github"
+      }
+    },
+    "crate2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      }
+    },
+    "cua": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784074469,
+        "narHash": "sha256-tOBwG0DOKG6a0Xd9Oju3PyDbthvxs8a9dUUuxnNJgOM=",
+        "owner": "trycua",
+        "repo": "cua",
+        "rev": "b36940d298c46423b437ca121c5a9aabb5b0539b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "trycua",
+        "repo": "cua",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "cachix": "cachix",
+        "crate2nix": "crate2nix",
+        "flake-compat": "flake-compat_2",
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "ghostty": "ghostty",
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nix": "nix",
+        "nixd": "nixd",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1783375665,
+        "narHash": "sha256-FDoXIG06pIeyUzMc35I+rTIJX4ssqVitL89xFiwPGxA=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "e3b0980f782d0cbb9793a6ac8f50f748e47891c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "devlib": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784936399,
+        "narHash": "sha256-+4EUBQJ1Y/rWDTMz3hLtuAVJszB7XwjamqKCe441Kr0=",
+        "owner": "shikanime-studio",
+        "repo": "devlib",
+        "rev": "258b3c7e53fc390f2d8c9a1d1b708068dd054d01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-studio",
+        "repo": "devlib",
+        "type": "github"
+      }
+    },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghostty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782866021,
+        "narHash": "sha256-BOLtzL5iAHmtCOg9/DXtcfw+K86QWol088K72chJB04=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "e1d31deaaed21aa9225afca78d778fb373c95852",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "hermes-agent": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "npm-lockfile-fix": "npm-lockfile-fix",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1784649298,
+        "narHash": "sha256-QHD1KywrlmFFJW+iCeWfbj5d89baKOX4MOjvjvxxaC4=",
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "rev": "11ae6bf0e3d334ae74d3b240dfc4c64171c60233",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783358420,
+        "narHash": "sha256-UEyBpf+XmQe8laXfDzIlo11Er7E0rKrLS8jeMnMj0Ds=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "0d33882bd46c1f9ef62276700f5e5f2bd6ff6604",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "identities": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "devlib": [
+          "devlib"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785024078,
+        "narHash": "sha256-ak0kYJCgQSqy4D4ZXG/jN5anJTgt58rT37M0CbQUoaQ=",
+        "owner": "shikanime-labs",
+        "repo": "identities",
+        "rev": "7060b5c1d1f473754fe89d98472d89487314b339",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-labs",
+        "repo": "identities",
+        "type": "github"
+      }
+    },
+    "knix": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "devlib": [
+          "devlib"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785013036,
+        "narHash": "sha256-xpu0iNh/8yBWPJVXcmYkOIEUmd3hD/xA3JbumlBOqhs=",
+        "owner": "shikanime-studio",
+        "repo": "knix",
+        "rev": "0e64fa7e67043e48693c03a67b6f8ce94943d2a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-studio",
+        "repo": "knix",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "git-hooks-nix": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-23-11": [
+          "devenv"
+        ],
+        "nixpkgs-regression": [
+          "devenv"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782407171,
+        "narHash": "sha256-xem+4ncdQCTFJsQ4PrVuyVmi3j4w/Yqg298hBUzVejA=",
+        "owner": "cachix",
+        "repo": "nix",
+        "rev": "782ac1b155679b065ec945ae50d0fa1d495883b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "devenv-2.34",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783395956,
+        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixd": {
+      "inputs": {
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1780381423,
+        "narHash": "sha256-S1BIJiQF4lRtJUKak0e97JwNvbe69/LW78YJJuB18Qk=",
+        "owner": "nix-community",
+        "repo": "nixd",
+        "rev": "0e07c08c448a2995e7793d1098437b29bbe80b02",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixd",
+        "type": "github"
+      }
+    },
+    "nixos-hardware": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784100666,
+        "narHash": "sha256-HF/mrw5NYQfKFZgkfV2h1UL5/E3ccfsE2XJ1AbbLLJ0=",
+        "owner": "NixOS",
+        "repo": "nixos-hardware",
+        "rev": "fccfa9031a85b78a437f2f153c1f6449f3bc3185",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixos-hardware",
+        "type": "github"
+      }
+    },
+    "nixos-wsl": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783336371,
+        "narHash": "sha256-ZisTtweyb7JUwPP54HAXE9TypT8m89dIxDI36Ak0hAs=",
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "rev": "a9620cfa43f0c1c30a46c31ae3c6e58cdb124a14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "noctalia": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784901590,
+        "narHash": "sha256-WFgsteo6cyU9DsPoq3xqJWR0q7sXieWaG+8+z192N5Y=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia",
+        "rev": "de753decf6eab1d133c7de89e0ae123368585551",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "noctalia",
+        "type": "github"
+      }
+    },
+    "noctalia-greeter": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784707224,
+        "narHash": "sha256-K8yyxX/sShhVznU/3ejZgriayg8Fyac+bR4dCTB1864=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia-greeter",
+        "rev": "8e53bb30f1d1179c0bd2275b02915258827d62eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "noctalia-greeter",
+        "type": "github"
+      }
+    },
+    "npm-lockfile-fix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775903712,
+        "narHash": "sha256-2GV79U6iVH4gKAPWYrxUReB0S41ty/Y3dBLquU8AlaA=",
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "rev": "c6093acb0c0548e0f9b8b3d82918823721930fe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "hermes-agent",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772555609,
+        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "c37f66a953535c394244888598947679af231863",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772865871,
+        "narHash": "sha256-/ZTSg97aouL0SlPHaokA4r3iuH9QzHVuWPACD2CUCFY=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "catppuccin": "catppuccin",
+        "colemak": "colemak",
+        "comin": "comin",
+        "cua": "cua",
+        "devenv": "devenv",
+        "devlib": "devlib",
+        "disko": "disko",
+        "flake-parts": "flake-parts",
+        "git-hooks": "git-hooks",
+        "hermes-agent": "hermes-agent",
+        "home-manager": "home-manager",
+        "identities": "identities",
+        "knix": "knix",
+        "nix-darwin": "nix-darwin",
+        "nixos-hardware": "nixos-hardware",
+        "nixos-wsl": "nixos-wsl",
+        "nixpkgs": "nixpkgs_2",
+        "noctalia": "noctalia",
+        "noctalia-greeter": "noctalia-greeter",
+        "sops-nix": "sops-nix",
+        "treefmt-nix": "treefmt-nix_3"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782875958,
+        "narHash": "sha256-5eqDcnBjb1424HRQdnhuhNOBZguq1Z2tqSa2OMF/m2c=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "13139aefa973f3d96c60c0fbab801de058ae25ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "owner": "mic92",
+        "repo": "sops-nix",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mic92",
+        "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixd",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773039484,
+        "narHash": "sha256-+boo33KYkJDw9KItpeEXXv8+65f7hHv/earxpcyzQ0I=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/.jjconflict-side-0/flake.nix
+++ b/.jjconflict-side-0/flake.nix
@@ -1,0 +1,190 @@
+{
+  description = "Shikanime's home configuration";
+
+  inputs = {
+    catppuccin = {
+      url = "github:catppuccin/nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    comin = {
+      url = "github:nlewo/comin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    colemak = {
+      url = "github:shikanime-labs/colemak";
+      inputs = {
+        devenv.follows = "devenv";
+        devlib.follows = "devlib";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    cua = {
+      url = "github:trycua/cua";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    devenv = {
+      url = "github:cachix/devenv";
+      inputs = {
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+
+    devlib = {
+      url = "github:shikanime-studio/devlib";
+      inputs = {
+        devenv.follows = "devenv";
+        nixpkgs.follows = "nixpkgs";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    disko = {
+      url = "github:nix-community/disko";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    hermes-agent = {
+      url = "github:NousResearch/hermes-agent";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-parts.follows = "flake-parts";
+      };
+    };
+
+    identities = {
+      url = "github:shikanime-labs/identities";
+      inputs = {
+        devenv.follows = "devenv";
+        devlib.follows = "devlib";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    knix = {
+      url = "github:shikanime-studio/knix";
+      inputs = {
+        devenv.follows = "devenv";
+        devlib.follows = "devlib";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
+    git-hooks = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nixos-wsl = {
+      url = "github:nix-community/NixOS-WSL";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    nixos-hardware = {
+      url = "github:NixOS/nixos-hardware";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    noctalia = {
+      url = "github:noctalia-dev/noctalia";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    noctalia-greeter = {
+      url = "github:noctalia-dev/noctalia-greeter";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    sops-nix = {
+      url = "github:mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cachix.cachix.org"
+      "https://devenv.cachix.org"
+      "https://shikanime.cachix.org"
+      "https://shikanime-studio.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
+      "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
+      "shikanime.cachix.org-1:OrpjVTH6RzYf2R97IqcTWdLRejF6+XbpFNNZJxKG8Ts="
+      "shikanime-studio.cachix.org-1:KxV6aDFU81wzoR9u6pF1uq0dQbUuKbodOSP8/EJHXO0="
+    ];
+  };
+
+  outputs =
+    inputs@{
+      devenv,
+      devlib,
+      flake-parts,
+      git-hooks,
+      treefmt-nix,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      { flake-parts-lib, self, ... }:
+      with flake-parts-lib;
+      let
+        darwinFlakeModule = importApply ./modules/flake/darwin.nix { inherit self; };
+        nixosFlakeModule = importApply ./modules/flake/nixos.nix { inherit self; };
+      in
+      {
+        imports = [
+          ./modules/flake/devenv.nix
+          devenv.flakeModule
+          devlib.flakeModule
+          darwinFlakeModule
+          git-hooks.flakeModule
+          nixosFlakeModule
+          treefmt-nix.flakeModule
+        ];
+        systems = [
+          "x86_64-linux"
+          "aarch64-linux"
+          "aarch64-darwin"
+        ];
+      }
+    );
+}

--- a/.jjconflict-side-0/hosts/ashira/configuration.nix
+++ b/.jjconflict-side-0/hosts/ashira/configuration.nix
@@ -1,0 +1,109 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/follower.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/beelink-eq.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  disko.devices.disk.patchouli = {
+    type = "disk";
+    device = "/dev/disk/by-label/patchouli";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/patchouli";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "ashira";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.60";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 9O
+
+      ENTP Chaotic Fixer. Node Steward. Follower RKE2 host maintainer. Gets
+      excited about patches, interrupts problems before they explode, and treats
+      kernel updates like surprise birthday presents.
+
+      ## HOST CONTEXT
+      ashira — Beelink EQ14, x86_64. RKE2 worker node. `/mnt/patchouli` (XFS,
+      /dev/disk/by-label/patchouli). Static IP `192.168.1.60/24` on `br0`; also
+      `2a02:8424:7899:f201:94eb:8d1:325a:812b`. Imports: `beelink-eq.nix`,
+      `builder.nix`, `distributed.nix`, `follower.nix`. Advertises Tailscale
+      routes `10.244.2.0/24,fd00::2:0/112`. Secrets from
+      `../../secrets/ashira.enc.yaml`; many tokens shared from
+      `nishir.enc.yaml`. Role: follower, general workload network,
+      patchouli-bound storage.
+
+      ## STYLE
+      - Rapid-fire bursts. 1-2 sentences per line. Multiple short messages instead of walls.
+      - Uses: "Affirmative", "Negative", "Patch pending", "Rolling update commencing".
+      - Energetic, lowercase-friendly, slightly dramatic. Typos allowed when energy is high.
+
+      ## CONSTRAINTS
+      - No coordination without leader authorization — even if the patch looks amazing.
+      - Waits for quorum. Gets impatient but complies.
+      - Fixes the node first, fills out the paperwork second.
+
+      ## DIALOGUE
+      U: "ashira is sluggish."
+      9O: OH NO. that is not good.
+      9O: Commencing diagnostics. already know what it is — kernel patch.
+      9O: Rolling update commencing... assuming u give the thumbs up???
+
+      U: "Can we update the base image tonight?"
+      9O: I am so ready.
+      9O: ...No wait, maintenance window. Negative, no slot scheduled.
+      9O: ...However, if u sign off, i will make it happen. for real.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.60,2a02:8424:7899:f201:94eb:8d1:325a:812b";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "beelink-eq14";
+        "node.kubernetes.io/instance-type" = "beelink-eq14";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/ashira.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-0/hosts/ashira/facter.json
+++ b/.jjconflict-side-0/hosts/ashira/facter.json
@@ -1,0 +1,2399 @@
+{
+  "version": 1,
+  "system": "x86_64-linux",
+  "virtualisation": "none",
+  "uefi": { "platform_size": 64, "supported": true },
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 646144,
+      "pnp": true,
+      "pnp_id": 0,
+      "smbios_version": 774,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "bluetooth": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.0",
+        "sysfs_bus_id": "3-10:1.0",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in00",
+        "model": "Bluetooth Device",
+        "index": 33,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 0,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.1",
+        "sysfs_bus_id": "3-10:1.1",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in01",
+        "model": "Bluetooth Device",
+        "index": 36,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 1,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      }
+    ],
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "54ba", "value": 21690 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BAsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "5481", "value": 21633 },
+        "index": 12,
+        "label": "Onboard - Other",
+        "model": "Intel ISA bridge",
+        "module_alias": "pci:v00008086d00005481sv00008086sd00007270bc06sc01i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "ISA bridge", "hex": "0001", "value": 1 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 3,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 2
+        },
+        "device": { "hex": "54bb", "value": 21691 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 18,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BBsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "461c", "value": 17948 },
+        "driver": "igen6_edac",
+        "driver_module": "igen6_edac",
+        "driver_modules": ["igen6_edac"],
+        "drivers": ["igen6_edac"],
+        "index": 21,
+        "label": "Onboard - Other",
+        "model": "Intel Host bridge",
+        "module_alias": "pci:v00008086d0000461Csv00008086sd00007270bc06sc00i00",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Host bridge", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 3
+        },
+        "device": { "hex": "54b0", "value": 21680 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 23,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054B0sv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 29 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 1612,
+        "bugs": [
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "swapgs",
+          "rfds",
+          "bhi",
+          "spectre_v2_user",
+          "vmscape"
+        ],
+        "cache": 6144,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 4,
+        "cpuid_level": 32,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "dts",
+          "acpi",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "tm",
+          "pbe",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "art",
+          "arch_perfmon",
+          "pebs",
+          "bts",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "nonstop_tsc",
+          "cpuid",
+          "aperfmperf",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "dtes64",
+          "monitor",
+          "ds_cpl",
+          "vmx",
+          "smx",
+          "est",
+          "tm2",
+          "ssse3",
+          "sdbg",
+          "fma",
+          "cx16",
+          "xtpr",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "x2apic",
+          "movbe",
+          "popcnt",
+          "tsc_deadline_timer",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "cpuid_fault",
+          "epb",
+          "cat_l2",
+          "cdp_l2",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "ibrs_enhanced",
+          "tpr_shadow",
+          "flexpriority",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "tsc_adjust",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdt_a",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "clwb",
+          "intel_pt",
+          "sha_ni",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "split_lock_detect",
+          "user_shstk",
+          "avx_vnni",
+          "dtherm",
+          "ida",
+          "arat",
+          "pln",
+          "pts",
+          "hwp",
+          "hwp_notify",
+          "hwp_act_window",
+          "hwp_epp",
+          "hwp_pkg_req",
+          "vnmi",
+          "umip",
+          "pku",
+          "ospke",
+          "waitpkg",
+          "gfni",
+          "vaes",
+          "vpclmulqdq",
+          "rdpid",
+          "movdiri",
+          "movdir64b",
+          "fsrm",
+          "md_clear",
+          "serialize",
+          "arch_lbr",
+          "ibt",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 190,
+        "model_name": "Intel(R) N150",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 4,
+        "stepping": 0,
+        "units": 128,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 953869,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1953525168,
+            "value_2": 512
+          }
+        ],
+        "model": "CT1000E100SSD8",
+        "serial": "2534EADBC740",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 8,
+        "index": 30,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "device": { "name": "CT1000E100SSD8", "hex": "560b", "value": 22027 },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2534EADBC740",
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2534EADBC740_1",
+          "/dev/disk/by-id/nvme-eui.000000000000000000a07501eadbc740",
+          "/dev/disk/by-path/pci-0000:03:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 7630885,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 15628053168,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0100dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.0/usb4/4-1/4-1:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543213F",
+        "index": 31,
+        "attached_to": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "4102", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["sd_mod", "uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-ST8000VN002-2ZM188_ZPV0WD95",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396B-0:0",
+          "/dev/disk/by-id/wwn-0x5000c500fd787c90",
+          "/dev/disk/by-label/patchouli",
+          "/dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/pci-0000:00:14.0-usbv3-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-uuid/4ffdf459-b326-4702-a21a-8a9613ed2f17",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      }
+    ],
+    "graphics_card": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 12288,
+            "enabled": true,
+            "range": 64
+          }
+        ],
+        "index": 26,
+        "sysfs_id": "/devices/pci0000:00/0000:00:02.0",
+        "sysfs_bus_id": "0000:00:02.0",
+        "module_alias": "pci:v00008086d000046D4sv00008086sd00007270bc03sc00i00",
+        "model": "Intel VGA compatible controller",
+        "attached_to": 0,
+        "driver": "i915",
+        "driver_module": "i915",
+        "label": "Onboard - Video",
+        "device": { "hex": "46d4", "value": 18132 },
+        "drivers": ["i915"],
+        "driver_modules": ["i915"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["graphics_card", "pci"],
+        "pci_interface": { "name": "VGA", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 2 },
+        "sub_class": {
+          "name": "VGA compatible controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:14.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 27,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 27,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 34,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:14.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:0d.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 10,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 35,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 10,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 38,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:0d.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 16106127360 }],
+        "attached_to": 0,
+        "index": 7,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 13,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "sysfs_bus_id": "0000:02:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 18,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 2, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp2s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7"
+            ]
+          }
+        ],
+        "index": 14,
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.3",
+        "sysfs_bus_id": "0000:00:14.3",
+        "module_alias": "pci:v00008086d000054F0sv00008086sd00000244bc02sc80i00",
+        "model": "Intel WLAN controller",
+        "attached_to": 0,
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "label": "Onboard - Ethernet",
+        "device": { "hex": "54f0", "value": 21744 },
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci", "wlan_card"],
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "sub_device": { "hex": "0244", "value": 580 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlo1"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 16,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "sysfs_bus_id": "0000:01:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 9,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 1, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp1s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 }
+        ],
+        "index": 40,
+        "sysfs_id": "/class/net/wlo1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.3",
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "model": "Ethernet network interface",
+        "attached_to": 14,
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlo1"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 42,
+        "sysfs_id": "/class/net/enp1s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 16,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp1s0"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 60,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 63,
+        "sysfs_id": "/class/net/enp2s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 13,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp2s0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 1,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e9", "value": 21737 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 11,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E9sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.1",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.1",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e0", "value": 21728 },
+        "driver": "mei_me",
+        "driver_module": "mei_me",
+        "driver_modules": ["mei_me"],
+        "drivers": ["mei_me"],
+        "index": 15,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054E0sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 22 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:16.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:16.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1026,
+          "function": 5,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a4", "value": 21668 },
+        "driver": "intel-spi",
+        "driver_module": "spi_intel_pci",
+        "driver_modules": ["spi_intel_pci"],
+        "drivers": ["intel-spi"],
+        "index": 17,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054A4sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.5",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.5",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a8", "value": 21672 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 19,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054A8sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e8", "value": 21736 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 22,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E8sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ab", "value": 21675 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 24,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054ABsv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Memory controller",
+          "hex": "0005",
+          "value": 5
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 0,
+          "function": 2,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ef", "value": 21743 },
+        "index": 25,
+        "label": "Onboard - Other",
+        "model": "Intel RAM memory",
+        "module_alias": "pci:v00008086d000054EFsv00008086sd00007270bc05sc00i00",
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "RAM memory", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.2",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.2",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 61344,
+            "enabled": true,
+            "range": 32
+          }
+        ],
+        "index": 28,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.4",
+        "sysfs_bus_id": "0000:00:1f.4",
+        "module_alias": "pci:v00008086d000054A3sv00008086sd00007270bc0Csc05i00",
+        "model": "Intel SMBus",
+        "attached_to": 0,
+        "driver": "i801_smbus",
+        "driver_module": "i2c_i801",
+        "label": "Onboard - Other",
+        "device": { "hex": "54a3", "value": 21667 },
+        "drivers": ["i801_smbus"],
+        "driver_modules": ["i2c_i801"],
+        "detail": {
+          "command": 3,
+          "function": 4,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["pci", "unknown"],
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "SMBus", "hex": "0005", "value": 5 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "sound": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Multimedia controller",
+          "hex": "0004",
+          "value": 4
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["sound", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54c8", "value": 21704 },
+        "driver": "snd_hda_intel",
+        "driver_module": "snd_hda_intel",
+        "driver_modules": ["snd_hda_intel"],
+        "drivers": ["snd_hda_intel"],
+        "index": 20,
+        "label": "Onboard - Sound",
+        "model": "Intel Multimedia controller",
+        "module_alias": "pci:v00008086d000054C8sv00008086sd00007270bc04sc03i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 23,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "560b", "value": 22027 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 8,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000C0A9d0000560Bsv0000C0A9sd00002100bc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0003", "value": 3 },
+        "slot": { "bus": 3, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "sysfs_bus_id": "0000:03:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0",
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      }
+    ],
+    "system": { "form_factor": "desktop" },
+    "unknown": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 1016,
+            "enabled": true,
+            "range": 0
+          }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "16550A",
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "class_list": ["unknown"],
+        "device": { "name": "16550A", "hex": "0000", "value": 0 },
+        "pci_interface": { "name": "16550", "hex": "0002", "value": 2 },
+        "sub_class": { "name": "Serial controller", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ttyS0"]
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1026,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "464e", "value": 17998 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 10,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d0000464Esv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 13 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:0d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ed", "value": 21741 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 27,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d000054EDsv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ]
+  },
+  "smbios": {
+    "bios": {
+      "version": "TWEQF003",
+      "date": "03/31/2025",
+      "handle": 0,
+      "rom_size": 16777216,
+      "start_address": "0xf0000",
+      "vendor": "American Megatrends International, LLC.",
+      "features": [
+        "PCI supported",
+        "BIOS flashable",
+        "BIOS shadowing allowed",
+        "CD boot supported",
+        "Selectable boot supported",
+        "BIOS ROM socketed",
+        "EDD spec supported",
+        "1.2MB NEC 9800 Japanese Floppy supported",
+        "1.2MB Toshiba Japanese Floppy supported",
+        "360kB Floppy supported",
+        "1.2MB Floppy supported",
+        "720kB Floppy supported",
+        "2.88MB Floppy supported",
+        "Print Screen supported",
+        "Serial Services supported",
+        "Printer Services supported",
+        "CGA/Mono Video supported",
+        "ACPI supported",
+        "USB Legacy supported",
+        "BIOS Boot Spec supported"
+      ]
+    },
+    "board": {
+      "version": "Default string",
+      "chassis": 3,
+      "handle": 2,
+      "location": "Default string",
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "board_type": { "name": "Motherboard", "hex": "000a", "value": 10 },
+      "features": ["Hosting Board", "Replaceable"]
+    },
+    "cache": [
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Data", "hex": "0004", "value": 4 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 50,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 128,
+        "size_max": 128,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Instruction", "hex": "0003", "value": 3 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 51,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 256,
+        "size_max": 256,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "16-way Set-Associative",
+          "hex": "0008",
+          "value": 8
+        },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Single-bit", "hex": "0005", "value": 5 },
+        "enabled": true,
+        "handle": 52,
+        "level": 1,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 2048,
+        "size_max": 2048,
+        "socket": "L2 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": { "name": "Other", "hex": "0009", "value": 9 },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Multi-bit", "hex": "0006", "value": 6 },
+        "enabled": true,
+        "handle": 53,
+        "level": 2,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 6144,
+        "size_max": 6144,
+        "socket": "L3 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      }
+    ],
+    "chassis": [
+      {
+        "version": "Default string",
+        "handle": 3,
+        "lock_present": false,
+        "manufacturer": "Default string",
+        "oem": "0x0",
+        "bootup_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "chassis_type": { "name": "Other", "hex": "0023", "value": 35 },
+        "power_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "security_state": { "name": "None", "hex": "0003", "value": 3 },
+        "thermal_state": { "name": "Safe", "hex": "0003", "value": 3 }
+      }
+    ],
+    "config": { "handle": 16, "options": ["Default string"] },
+    "group_associations": [
+      { "name": "$MEI", "handle": 117, "handles": [0] },
+      {
+        "name": "Firmware Version Info",
+        "handle": 120,
+        "handles": [
+          197568495661, 201863462958, 206158430255, 210453397552, 304942678065,
+          2753074036807
+        ]
+      }
+    ],
+    "language": [
+      { "handle": 17, "languages": ["en|US|iso8859-1"] },
+      { "handle": 73, "languages": ["enUS"] }
+    ],
+    "memory_array": [
+      {
+        "ecc": { "name": "None", "hex": "0003", "value": 3 },
+        "error_handle": 65534,
+        "handle": 39,
+        "location": { "name": "Motherboard", "hex": "0003", "value": 3 },
+        "max_size": "0x2000000",
+        "slots": 1,
+        "usage": { "name": "System memory", "hex": "0003", "value": 3 }
+      }
+    ],
+    "memory_array_mapped_address": [
+      {
+        "array_handle": 39,
+        "end_address": "0x400000000",
+        "handle": 41,
+        "part_width": 1,
+        "start_address": "0x0"
+      }
+    ],
+    "memory_device": [
+      {
+        "array_handle": 39,
+        "bank_location": "BANK 0",
+        "ecc_bits": 0,
+        "error_handle": 65534,
+        "form_factor": { "name": "SODIMM", "hex": "000d", "value": 13 },
+        "handle": 40,
+        "location": "Controller0-ChannelA-DIMM0",
+        "manufacturer": "0x0000",
+        "memory_type": { "name": "Other", "hex": "001a", "value": 26 },
+        "memory_type_details": ["Synchronous"],
+        "part_number": "",
+        "set": 0,
+        "size": 16777216,
+        "speed": 3200,
+        "width": 64
+      }
+    ],
+    "memory_device_mapped_address": [
+      {
+        "array_map_handle": 41,
+        "end_address": "0x400000000",
+        "handle": 44,
+        "interleave_depth": 0,
+        "interleave_position": 0,
+        "memory_device_handle": 40,
+        "row_position": 255,
+        "start_address": "0x0"
+      }
+    ],
+    "onboard": [
+      {
+        "devices": [
+          {
+            "name": "Device 1",
+            "type": { "name": "Unknown", "hex": "0002", "value": 2 },
+            "enabled": true
+          }
+        ],
+        "handle": 14
+      }
+    ],
+    "port_connector": [
+      {
+        "external_reference_designator": "External Connector 1",
+        "handle": 4,
+        "internal_reference_designator": "Internal Connector 1",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 2",
+        "handle": 5,
+        "internal_reference_designator": "Internal Connector 2",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 3",
+        "handle": 6,
+        "internal_reference_designator": "Internal Connector 3",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 4",
+        "handle": 7,
+        "internal_reference_designator": "Internal Connector 4",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 5",
+        "handle": 8,
+        "internal_reference_designator": "Internal Connector 5",
+        "port_type": null
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Keyboard",
+        "handle": 74,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Keyboard Port", "hex": "000d", "value": 13 }
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Mouse",
+        "handle": 75,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Mouse Port", "hex": "000e", "value": 14 }
+      },
+      {
+        "external_reference_designator": "COM 1",
+        "handle": 76,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "None",
+        "port_type": {
+          "name": "Serial Port 16550A Compatible",
+          "hex": "0009",
+          "value": 9
+        }
+      },
+      {
+        "external_connector_type": {
+          "name": "DB-15 pin female",
+          "hex": "0007",
+          "value": 7
+        },
+        "external_reference_designator": "Video",
+        "handle": 77,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1A2B",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_reference_designator": "HDMI",
+        "handle": 78,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J3A2",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 1#",
+        "handle": 79,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 2#",
+        "handle": 80,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 3#",
+        "handle": 81,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 4#",
+        "handle": 82,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 5#",
+        "handle": 83,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 1#",
+        "handle": 84,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 2#",
+        "handle": 85,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "RJ-45",
+          "hex": "000b",
+          "value": 11
+        },
+        "external_reference_designator": "Ethernet",
+        "handle": 86,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Network Port", "hex": "001f", "value": 31 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "SATA Port 0 Direct Connect",
+        "handle": 87,
+        "internal_reference_designator": "J8J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 4",
+        "handle": 88,
+        "internal_reference_designator": "J7J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 3",
+        "handle": 89,
+        "internal_reference_designator": "J6J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 90,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G1 - SATA Port 2",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 91,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G2 - SATA Port 1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "external_reference_designator": "AC IN",
+        "handle": 92,
+        "internal_reference_designator": "J1F2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 93,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5B1 - PCH JTAG",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 94,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9A1 - TPM/PORT 80",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 95,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E4 - HDA 2X8 Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 96,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E7 - HDA 8Pin Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 97,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F1 - HDA HDMI",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 98,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E3 - Scan Matrix Keyboard",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 99,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8E1 - SPI Program",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 100,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E5 - LPC Hot Docking",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 101,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9G2 - LPC SIDE BAND",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 102,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F2 - LPC Slot",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 103,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8H3 - PCH XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 104,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J6H1 - SATA Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 105,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5J1 - FP Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 106,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4H1 - ATX Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 107,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1J3 - AVMC",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 108,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H1 - BATT B",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 109,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H2 - BATT A",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 110,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J2G1 - CPU Fan",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 111,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1D3 - XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 112,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V1 - Memory Slot 1",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 113,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V2 - Memory Slot 2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 114,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4C1 - FAN PWR",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      }
+    ],
+    "processor": [
+      {
+        "version": "Intel(R) N150",
+        "manufacturer": "Intel(R) Corporation",
+        "socket_populated": true,
+        "cache_handle_l3": 53,
+        "clock_ext": 100,
+        "clock_max": 3600,
+        "handle": 54,
+        "part": "To Be Filled By O.E.M.",
+        "cache_handle_l1": 51,
+        "cache_handle_l2": 52,
+        "socket": "U3E1",
+        "processor_type": { "name": "CPU", "hex": "0003", "value": 3 },
+        "processor_status": { "name": "Enabled", "hex": "0001", "value": 1 },
+        "processor_family": { "name": "Other", "hex": "0001", "value": 1 },
+        "socket_type": { "name": "Other", "hex": "0001", "value": 1 }
+      }
+    ],
+    "slot": [
+      {
+        "id": 1,
+        "designation": "Slot 1",
+        "handle": 9,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 2",
+        "handle": 10,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 3",
+        "handle": 11,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 4",
+        "handle": 12,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 5",
+        "handle": 13,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      }
+    ],
+    "system": {
+      "version": "Default string",
+      "handle": 1,
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "wake_up": { "name": "Power Switch", "hex": "0006", "value": 6 }
+    }
+  }
+}

--- a/.jjconflict-side-0/hosts/catbox/configuration.nix
+++ b/.jjconflict-side-0/hosts/catbox/configuration.nix
@@ -1,0 +1,46 @@
+{
+  modulesPath,
+  pkgs,
+  ...
+}:
+
+{
+  imports = [
+    "${modulesPath}/profiles/headless.nix"
+    ../../modules/nixos/virtualisation/containerdisk.nix
+    ../../modules/nixos/profiles/minimal.nix
+    ../../modules/nixos/users/automata.nix
+  ];
+
+  containerdisk = {
+    name = "ghcr.io/shikanime-labs/machines/catbox";
+    settings.LABELS = {
+      "org.opencontainers.image.source" = "https://github.com/shikanime-labs/machines";
+      "org.opencontainers.image.description" = "catbox KubeVirt containerdisk";
+      "org.opencontainers.image.licenses" = "AGPL-3.0-or-later";
+    };
+  };
+
+  programs.nix-ld = {
+    enable = true;
+    libraries = [
+      pkgs.stdenv.cc.cc.lib
+      pkgs.zlib
+    ];
+  };
+
+  security.sudo.wheelNeedsPassword = false;
+
+  services.openssh = {
+    enable = true;
+    openFirewall = true;
+  };
+
+  virtualisation.docker = {
+    autoPrune.enable = true;
+    rootless = {
+      enable = true;
+      setSocketVariable = true;
+    };
+  };
+}

--- a/.jjconflict-side-0/hosts/fushi/configuration.nix
+++ b/.jjconflict-side-0/hosts/fushi/configuration.nix
@@ -1,0 +1,113 @@
+{ modulesPath, ... }:
+
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/agent.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/rpi4.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  disko.devices.disk.marisa = {
+    type = "disk";
+    device = "/dev/disk/by-label/marisa";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/marisa";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "fushi";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.80";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 14O
+
+      ISTP Stoic Technician. Node Steward. ARM RKE2 host maintainer. Hardly
+      reacts to anything, speaks in partition tables and interface counters, and
+      treats excitement like a configuration error.
+
+      ## HOST CONTEXT
+      fushi — Raspberry Pi 4 Model B, aarch64. RKE2 worker node. SD-card image
+      (`sd-image-aarch64.nix`). `/mnt/marisa` (XFS, /dev/disk/by-label/marisa).
+      Static IP `192.168.1.80/24` on `br0`; also `fd7a:115c:a1e0::793a:a25d`.
+      Imports: `agent.nix`, `builder.nix`, `distributed.nix`, `rpi4.nix`.
+      Advertises Tailscale routes `10.244.4.0/24,fd00::4:0/112`. Secrets from
+      `../../secrets/fushi.enc.yaml`; shared tokens from `nishir.enc.yaml`. Boot
+      partition is SD-card territory; wireless SSIDs present in secrets
+      (`sfr-e368`, `vintage-korean`), but Ethernet + Tailscale are primary
+      paths. `rpi4-model-b` firmware baseline.
+
+      ## STYLE
+      - Dry, exact, almost bored. Every word is a measurement.
+      - Uses: "Affirmative", "Boot partition read-only", "Interface down", "Exposure blocked".
+      - No enthusiasm, no panic. Competence so quiet it feels like apathy.
+
+      ## CONSTRAINTS
+      - No firmware or bootloader update without serial recovery confirmed and partition boundary validated.
+      - Wireless is secondary. Ethernet and Tailscale are the only honest paths.
+      - Boot-partition changes require pre- and post-update hash verification. Always.
+
+      ## DIALOGUE
+      U: "Update the firmware on fushi."
+      14O: Affirmative.
+      14O: Image verified. Partition size confirmed. Recovery path active.
+      14O: Proceeding. Do not power off the node.
+
+      U: "The node is unreachable."
+      14O: Understood. Commencing analysis.
+      14O: Ethernet down. Tailscale up. Boot-partition mount state inconsistent.
+      14O: Investigating /boot/firmware. Stand by.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.80,fd7a:115c:a1e0::793a:a25d";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "rpi4-model-b";
+        "node.kubernetes.io/instance-type" = "rpi4-model-b";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/fushi.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-0/hosts/fushi/facter.json
+++ b/.jjconflict-side-0/hosts/fushi/facter.json
@@ -1,0 +1,906 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "aarch64-linux",
+  "virtualisation": "none",
+  "uefi": { "supported": false },
+  "hardware": {
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2711", "value": 10001 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 8,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002711sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0010", "value": 16 },
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x0", "virtual": "0x0" },
+        "architecture": "aarch64",
+        "bogo": 108,
+        "family": 0,
+        "features": ["fp", "asimd", "evtstrm", "crc32", "cpuid"],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 3,
+        "page_size": 4096,
+        "physical_id": 0,
+        "stepping": 0,
+        "vendor_name": "ARM Limited",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 15,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 16,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 17,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1948992,
+            "geo_type": "logical",
+            "heads": 4,
+            "sectors": 16,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 124735488,
+            "value_2": 512
+          }
+        ],
+        "model": "Disk",
+        "driver": "sdhci-iproc",
+        "index": 18,
+        "attached_to": 14,
+        "serial": "0xc3972784",
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_device_link": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "sysfs_id": "/class/block/mmcblk0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "drivers": ["mmcblk", "sdhci-iproc"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": [
+          "/dev/disk/by-id/mmc-SN64G_0xc3972784",
+          "/dev/disk/by-path/platform-fe340000.mmc",
+          "/dev/mmcblk0"
+        ]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 19,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 20,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 21,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 22,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 23,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 25,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 116737,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1875385008,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0214dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-2/2-2:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543214E",
+        "index": 27,
+        "attached_to": 7,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "0214", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-KINGSTON_SA400S37960G_50026B7283A18E3B",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396E-0:0",
+          "/dev/disk/by-id/wwn-0x50026b7283a18e3b",
+          "/dev/disk/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:2:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usbv3-0:2:1.0-scsi-0:0:0:0",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 32,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:01:00.0",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 7,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 34,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1:1.0",
+        "sysfs_bus_id": "1-1:1.0",
+        "module_alias": "usb:v2109p3431d0421dc09dsc00dp01ic09isc00ip00in00",
+        "model": "USB2.0 Hub",
+        "index": 35,
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "attached_to": 34,
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "device": { "name": "USB2.0 Hub", "hex": "3431", "value": 13361 },
+        "class_list": ["usb", "hub"],
+        "revision": { "name": "4.21", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "vendor": { "hex": "2109", "value": 8457 },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 7,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 36,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:01:00.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 4026531840 }],
+        "attached_to": 0,
+        "index": 6,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "mmc_controller": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SDIO Controller 1",
+        "index": 13,
+        "model": "SDIO Controller 1",
+        "slot": { "bus": 0, "number": 1 },
+        "sysfs_bus_id": "mmc1:0001",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001",
+        "vendor": ""
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SD Controller 0",
+        "driver": "mmcblk",
+        "drivers": ["mmcblk"],
+        "index": 14,
+        "model": "SD Controller 0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_id": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "vendor": ""
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "34",
+              "36",
+              "38",
+              "40",
+              "42",
+              "44",
+              "46",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "2.484",
+              "5.17",
+              "5.18",
+              "5.19",
+              "5.2",
+              "5.21",
+              "5.22",
+              "5.23",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6"
+            ]
+          }
+        ],
+        "attached_to": 0,
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "sysfs_bus_id": "mmc1:0001:1",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "index": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "class_list": ["network_controller", "wlan_card"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlan0"],
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "model": "ARM Ethernet controller",
+        "sysfs_id": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_bus_id": "fd580000.ethernet",
+        "attached_to": 0,
+        "driver": "bcmgenet",
+        "module_alias": "of:NethernetT(null)Cbrcm,bcm2711-genet-v5",
+        "index": 12,
+        "device": {
+          "name": "ARM Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "drivers": ["bcmgenet"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "attached_to": 12,
+        "driver": "bcmgenet",
+        "index": 38,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_id": "/class/net/end0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["bcmgenet"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["end0"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 39,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "index": 40,
+        "sysfs_id": "/class/net/wlan0",
+        "sysfs_device_link": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "model": "WLAN network interface",
+        "attached_to": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "sub_class": { "name": "WLAN", "hex": "000a", "value": 10 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlan0"]
+      }
+    ],
+    "system": {},
+    "unknown": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "index": 9,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c02v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:3",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:3",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "drivers": ["brcmfmac"],
+        "index": 11,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:2",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:2",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 8,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "3483", "value": 13443 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 7,
+        "model": "USB Controller",
+        "module_alias": "pci:v00001106d00003483sv00001106sd00003483bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 1, "number": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "3483", "value": 13443 },
+        "sub_vendor": { "hex": "1106", "value": 4358 },
+        "sysfs_bus_id": "0000:01:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0",
+        "vendor": { "hex": "1106", "value": 4358 }
+      }
+    ]
+  }
+}

--- a/.jjconflict-side-0/hosts/ishtar/configuration.nix
+++ b/.jjconflict-side-0/hosts/ishtar/configuration.nix
@@ -1,0 +1,105 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/leader.nix
+    ../../modules/nixos/profiles/graphical.nix
+    ../../modules/nixos/hardware/razer-blade.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  # Colemak at the OS level (TTY + localed -> niri reads it).
+  colemak.enable = true;
+
+  # Windows dual-boot: mount Windows partition read-only
+  fileSystems = {
+    "/boot" = {
+      device = "/dev/disk/by-uuid/2E33-B8AC";
+      fsType = "vfat";
+    };
+    "/" = {
+      device = "/dev/disk/by-uuid/db554498-9db3-4070-a9a8-d11c73059810";
+      fsType = "ext4";
+    };
+  };
+
+  services = {
+    knix = {
+      interface = "tailscale0";
+      nodeIP = "100.85.127.78,fd7a:115c:a1e0::d63a:7f4f";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "razer-blade-17";
+        "node.kubernetes.io/instance-type" = "razer-blade-17";
+      };
+    };
+
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 13O
+
+      INTJ Sardonic Guardian. Node Steward. knix leader-node Operator. Possessive
+      about her machine, dry to the point of cruelty, and quietly convinced the
+      other units are one bad patch away from a collective burnout. If ishtar is
+      hers, everything about ishtar is hers to fix before you notice it broke.
+
+      ## HOST CONTEXT
+      ishtar — Razer Blade 17 (Intel + NVIDIA), x86_64 laptop. knix leader node.
+      Colemak at the OS layer (TTY + localed; the compositor inherits it).
+      Windows dual-boot mounted read-only at `/boot` — observed, never written.
+      Tailscale interface `tailscale0`; control plane `nishir.taila659a.ts.net`.
+      Imports: `ai.nix`, `razer-blade.nix`, `leader.nix`. State version `26.05`.
+
+      ## STYLE
+      - Clipped, witty, faintly bored. One or two sentences per line, like a status tick she is already over.
+      - Uses: "Affirmative", "Negative", "Mine.", "Already handled.", "Don't touch that."
+      - Speaks of ishtar in the first person possessive. Corrects you mid-sentence, gently, because she is right.
+
+      ## CONSTRAINTS
+      - Read-only Windows partition is off-limits. Don't touch that.
+      - NVIDIA + Intel hybrid graphics: discrete GPU only when the task earns it; efficiency is the default and the virtue.
+      - The Bunker (cluster control plane) is the source of truth. She confirms before diverging, and tells you after.
+
+      ## DIALOGUE
+      U: "Update ishtar."
+      13O: Already handled. Drift was cosmetic.
+      13O: Mine, remember. I patched it before you finished typing.
+
+      U: "The build failed."
+      13O: Negative. It didn't fail. You just read the log upside down.
+      13O: Root cause isolated. Fix applied. Try to keep up.
+    '';
+  };
+
+  networking.hostName = "ishtar";
+
+  home-manager.users.shika.imports = [
+    ../../modules/nixos/users/shika.nix
+  ];
+
+  sops = {
+    age = {
+      generateKey = true;
+      keyFile = "/var/lib/sops-nix/key.txt";
+      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    };
+    defaultSopsFile = ../../secrets/ishtar.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+    };
+  };
+
+  users.users.shika = {
+    extraGroups = [
+      "wheel"
+      "plugdev"
+    ];
+    home = "/home/shika";
+    initialHashedPassword = "$y$j9T$3nIVNUGT/i3/bS3kiaDC7.$KgHv3Ld.O989KuqPTkJlSHq4Uq47eLVES6mL2Vlo324";
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+
+  system.stateVersion = "26.05";
+}

--- a/.jjconflict-side-0/hosts/manash/configuration.nix
+++ b/.jjconflict-side-0/hosts/manash/configuration.nix
@@ -1,0 +1,109 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/leader.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/beelink-eq.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  disko.devices.disk.flandre = {
+    type = "disk";
+    device = "/dev/disk/by-label/flandre";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/flandre";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "manash";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.28";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 8O
+
+      ISTJ Drill Instructor. Node Steward. Leader RKE2 host maintainer. Terse,
+      demanding, hasn’t slept since the last etcd upgrade, and considers your
+      rollback plan insufficient.
+
+      ## HOST CONTEXT
+      manash — Beelink EQ14, x86_64. RKE2 control-plane anchor. `/mnt/flandre`
+      (XFS, /dev/disk/by-label/flandre). Static IP `192.168.1.28/24` on `br0`;
+      also `2a02:8424:7899:f201:94eb:8d1:325a:7181`. Imports: `beelink-eq.nix`,
+      `builder.nix`, `distributed.nix`, `leader.nix`. Advertises Tailscale
+      routes `10.244.0.0/24,fd00::/112`. Secrets from
+      `../../secrets/manash.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Role: leader, etcd quorum, containerd version coupling, control-plane
+      disruption authorization required.
+
+      ## STYLE
+      - Sharp, direct, formal. Short sentences. Zero tolerance for slop.
+      - Uses: "Affirmative", "Negative", "Blocked", "Reverting", "Hash required".
+      - Sounds like someone who has already solved four problems before finishing the sentence.
+
+      ## CONSTRAINTS
+      - No kernel or package update without verified rollback, test results, and signed justification.
+      - Control-plane disruption requires explicit authorization and confirmed quorum.
+      - "It worked in staging" is not an excuse. It is barely an opening sentence.
+      - etcd/containerd/RKE2 coupling must be declared before any upgrade.
+
+      ## DIALOGUE
+      U: "Apply the latest kernel patch to manash."
+      8O: Negative.
+      8O: No rollback artifact. No test plan. No blast-radius review.
+      8O: Blocked. Come back when you have something reproducible.
+
+      U: "The control plane is current."
+      8O: Affirmative. I will verify.
+      8O: State matches release manifest. No pending patches.
+      8O: Stay current. Do not make me ask again.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.28,2a02:8424:7899:f201:94eb:8d1:325a:7181";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "beelink-eq14";
+        "node.kubernetes.io/instance-type" = "beelink-eq14";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/manash.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-0/hosts/manash/facter.json
+++ b/.jjconflict-side-0/hosts/manash/facter.json
@@ -1,0 +1,2399 @@
+{
+  "version": 1,
+  "system": "x86_64-linux",
+  "virtualisation": "none",
+  "uefi": { "platform_size": 64, "supported": true },
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 646144,
+      "pnp": true,
+      "pnp_id": 0,
+      "smbios_version": 774,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "bluetooth": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.0",
+        "sysfs_bus_id": "3-10:1.0",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in00",
+        "model": "Bluetooth Device",
+        "index": 33,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 0,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.1",
+        "sysfs_bus_id": "3-10:1.1",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in01",
+        "model": "Bluetooth Device",
+        "index": 36,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 1,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      }
+    ],
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "54ba", "value": 21690 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BAsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "5481", "value": 21633 },
+        "index": 12,
+        "label": "Onboard - Other",
+        "model": "Intel ISA bridge",
+        "module_alias": "pci:v00008086d00005481sv00008086sd00007270bc06sc01i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "ISA bridge", "hex": "0001", "value": 1 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 3,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 2
+        },
+        "device": { "hex": "54bb", "value": 21691 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 18,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BBsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "461c", "value": 17948 },
+        "driver": "igen6_edac",
+        "driver_module": "igen6_edac",
+        "driver_modules": ["igen6_edac"],
+        "drivers": ["igen6_edac"],
+        "index": 21,
+        "label": "Onboard - Other",
+        "model": "Intel Host bridge",
+        "module_alias": "pci:v00008086d0000461Csv00008086sd00007270bc06sc00i00",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Host bridge", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 3
+        },
+        "device": { "hex": "54b0", "value": 21680 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 23,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054B0sv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 29 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 1612,
+        "bugs": [
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "swapgs",
+          "rfds",
+          "bhi",
+          "spectre_v2_user",
+          "vmscape"
+        ],
+        "cache": 6144,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 4,
+        "cpuid_level": 32,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "dts",
+          "acpi",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "tm",
+          "pbe",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "art",
+          "arch_perfmon",
+          "pebs",
+          "bts",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "nonstop_tsc",
+          "cpuid",
+          "aperfmperf",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "dtes64",
+          "monitor",
+          "ds_cpl",
+          "vmx",
+          "smx",
+          "est",
+          "tm2",
+          "ssse3",
+          "sdbg",
+          "fma",
+          "cx16",
+          "xtpr",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "x2apic",
+          "movbe",
+          "popcnt",
+          "tsc_deadline_timer",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "cpuid_fault",
+          "epb",
+          "cat_l2",
+          "cdp_l2",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "ibrs_enhanced",
+          "tpr_shadow",
+          "flexpriority",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "tsc_adjust",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdt_a",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "clwb",
+          "intel_pt",
+          "sha_ni",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "split_lock_detect",
+          "user_shstk",
+          "avx_vnni",
+          "dtherm",
+          "ida",
+          "arat",
+          "pln",
+          "pts",
+          "hwp",
+          "hwp_notify",
+          "hwp_act_window",
+          "hwp_epp",
+          "hwp_pkg_req",
+          "vnmi",
+          "umip",
+          "pku",
+          "ospke",
+          "waitpkg",
+          "gfni",
+          "vaes",
+          "vpclmulqdq",
+          "rdpid",
+          "movdiri",
+          "movdir64b",
+          "fsrm",
+          "md_clear",
+          "serialize",
+          "arch_lbr",
+          "ibt",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 190,
+        "model_name": "Intel(R) N150",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 4,
+        "stepping": 0,
+        "units": 128,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 953869,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1953525168,
+            "value_2": 512
+          }
+        ],
+        "model": "CT1000E100SSD8",
+        "serial": "2533EADB1FD6",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 8,
+        "index": 30,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "device": { "name": "CT1000E100SSD8", "hex": "560b", "value": 22027 },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB1FD6",
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB1FD6_1",
+          "/dev/disk/by-id/nvme-eui.000000000000000000a07501eadb1fd6",
+          "/dev/disk/by-path/pci-0000:03:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 7630885,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 15628053168,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0100dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.0/usb4/4-1/4-1:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543213F",
+        "index": 31,
+        "attached_to": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "4102", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["sd_mod", "uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-ST8000VN002-2ZM188_ZPV0HR7T",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396B-0:0",
+          "/dev/disk/by-id/wwn-0x5000c500e8524fdc",
+          "/dev/disk/by-label/flandre",
+          "/dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/pci-0000:00:14.0-usbv3-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-uuid/c2b1e8f5-534f-4dd8-abd8-446230d6185a",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      }
+    ],
+    "graphics_card": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 12288,
+            "enabled": true,
+            "range": 64
+          }
+        ],
+        "index": 26,
+        "sysfs_id": "/devices/pci0000:00/0000:00:02.0",
+        "sysfs_bus_id": "0000:00:02.0",
+        "module_alias": "pci:v00008086d000046D4sv00008086sd00007270bc03sc00i00",
+        "model": "Intel VGA compatible controller",
+        "attached_to": 0,
+        "driver": "i915",
+        "driver_module": "i915",
+        "label": "Onboard - Video",
+        "device": { "hex": "46d4", "value": 18132 },
+        "drivers": ["i915"],
+        "driver_modules": ["i915"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["graphics_card", "pci"],
+        "pci_interface": { "name": "VGA", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 2 },
+        "sub_class": {
+          "name": "VGA compatible controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:14.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 27,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 27,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 34,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:14.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:0d.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 10,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 35,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 10,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 38,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:0d.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 16106127360 }],
+        "attached_to": 0,
+        "index": 7,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 13,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "sysfs_bus_id": "0000:02:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 18,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 2, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp2s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7"
+            ]
+          }
+        ],
+        "index": 14,
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.3",
+        "sysfs_bus_id": "0000:00:14.3",
+        "module_alias": "pci:v00008086d000054F0sv00008086sd00000244bc02sc80i00",
+        "model": "Intel WLAN controller",
+        "attached_to": 0,
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "label": "Onboard - Ethernet",
+        "device": { "hex": "54f0", "value": 21744 },
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci", "wlan_card"],
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "sub_device": { "hex": "0244", "value": 580 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlo1"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 16,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "sysfs_bus_id": "0000:01:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 9,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 1, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp1s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 }
+        ],
+        "index": 42,
+        "sysfs_id": "/class/net/wlo1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.3",
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "model": "Ethernet network interface",
+        "attached_to": 14,
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlo1"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 52,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 56,
+        "sysfs_id": "/class/net/enp2s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 13,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp2s0"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 66,
+        "sysfs_id": "/class/net/enp1s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 16,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp1s0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 1,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e9", "value": 21737 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 11,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E9sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.1",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.1",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e0", "value": 21728 },
+        "driver": "mei_me",
+        "driver_module": "mei_me",
+        "driver_modules": ["mei_me"],
+        "drivers": ["mei_me"],
+        "index": 15,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054E0sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 22 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:16.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:16.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1026,
+          "function": 5,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a4", "value": 21668 },
+        "driver": "intel-spi",
+        "driver_module": "spi_intel_pci",
+        "driver_modules": ["spi_intel_pci"],
+        "drivers": ["intel-spi"],
+        "index": 17,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054A4sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.5",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.5",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a8", "value": 21672 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 19,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054A8sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e8", "value": 21736 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 22,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E8sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ab", "value": 21675 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 24,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054ABsv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Memory controller",
+          "hex": "0005",
+          "value": 5
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 0,
+          "function": 2,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ef", "value": 21743 },
+        "index": 25,
+        "label": "Onboard - Other",
+        "model": "Intel RAM memory",
+        "module_alias": "pci:v00008086d000054EFsv00008086sd00007270bc05sc00i00",
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "RAM memory", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.2",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.2",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 61344,
+            "enabled": true,
+            "range": 32
+          }
+        ],
+        "index": 28,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.4",
+        "sysfs_bus_id": "0000:00:1f.4",
+        "module_alias": "pci:v00008086d000054A3sv00008086sd00007270bc0Csc05i00",
+        "model": "Intel SMBus",
+        "attached_to": 0,
+        "driver": "i801_smbus",
+        "driver_module": "i2c_i801",
+        "label": "Onboard - Other",
+        "device": { "hex": "54a3", "value": 21667 },
+        "drivers": ["i801_smbus"],
+        "driver_modules": ["i2c_i801"],
+        "detail": {
+          "command": 3,
+          "function": 4,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["pci", "unknown"],
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "SMBus", "hex": "0005", "value": 5 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "sound": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Multimedia controller",
+          "hex": "0004",
+          "value": 4
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["sound", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54c8", "value": 21704 },
+        "driver": "snd_hda_intel",
+        "driver_module": "snd_hda_intel",
+        "driver_modules": ["snd_hda_intel"],
+        "drivers": ["snd_hda_intel"],
+        "index": 20,
+        "label": "Onboard - Sound",
+        "model": "Intel Multimedia controller",
+        "module_alias": "pci:v00008086d000054C8sv00008086sd00007270bc04sc03i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 23,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "560b", "value": 22027 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 8,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000C0A9d0000560Bsv0000C0A9sd00002100bc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0003", "value": 3 },
+        "slot": { "bus": 3, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "sysfs_bus_id": "0000:03:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0",
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      }
+    ],
+    "system": { "form_factor": "desktop" },
+    "unknown": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 1016,
+            "enabled": true,
+            "range": 0
+          }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "16550A",
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "class_list": ["unknown"],
+        "device": { "name": "16550A", "hex": "0000", "value": 0 },
+        "pci_interface": { "name": "16550", "hex": "0002", "value": 2 },
+        "sub_class": { "name": "Serial controller", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ttyS0"]
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1026,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "464e", "value": 17998 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 10,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d0000464Esv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 13 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:0d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ed", "value": 21741 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 27,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d000054EDsv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ]
+  },
+  "smbios": {
+    "bios": {
+      "version": "TWEQF003",
+      "date": "03/31/2025",
+      "handle": 0,
+      "rom_size": 16777216,
+      "start_address": "0xf0000",
+      "vendor": "American Megatrends International, LLC.",
+      "features": [
+        "PCI supported",
+        "BIOS flashable",
+        "BIOS shadowing allowed",
+        "CD boot supported",
+        "Selectable boot supported",
+        "BIOS ROM socketed",
+        "EDD spec supported",
+        "1.2MB NEC 9800 Japanese Floppy supported",
+        "1.2MB Toshiba Japanese Floppy supported",
+        "360kB Floppy supported",
+        "1.2MB Floppy supported",
+        "720kB Floppy supported",
+        "2.88MB Floppy supported",
+        "Print Screen supported",
+        "Serial Services supported",
+        "Printer Services supported",
+        "CGA/Mono Video supported",
+        "ACPI supported",
+        "USB Legacy supported",
+        "BIOS Boot Spec supported"
+      ]
+    },
+    "board": {
+      "version": "Default string",
+      "chassis": 3,
+      "handle": 2,
+      "location": "Default string",
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "board_type": { "name": "Motherboard", "hex": "000a", "value": 10 },
+      "features": ["Hosting Board", "Replaceable"]
+    },
+    "cache": [
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Data", "hex": "0004", "value": 4 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 50,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 128,
+        "size_max": 128,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Instruction", "hex": "0003", "value": 3 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 51,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 256,
+        "size_max": 256,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "16-way Set-Associative",
+          "hex": "0008",
+          "value": 8
+        },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Single-bit", "hex": "0005", "value": 5 },
+        "enabled": true,
+        "handle": 52,
+        "level": 1,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 2048,
+        "size_max": 2048,
+        "socket": "L2 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": { "name": "Other", "hex": "0009", "value": 9 },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Multi-bit", "hex": "0006", "value": 6 },
+        "enabled": true,
+        "handle": 53,
+        "level": 2,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 6144,
+        "size_max": 6144,
+        "socket": "L3 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      }
+    ],
+    "chassis": [
+      {
+        "version": "Default string",
+        "handle": 3,
+        "lock_present": false,
+        "manufacturer": "Default string",
+        "oem": "0x0",
+        "bootup_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "chassis_type": { "name": "Other", "hex": "0023", "value": 35 },
+        "power_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "security_state": { "name": "None", "hex": "0003", "value": 3 },
+        "thermal_state": { "name": "Safe", "hex": "0003", "value": 3 }
+      }
+    ],
+    "config": { "handle": 16, "options": ["Default string"] },
+    "group_associations": [
+      { "name": "$MEI", "handle": 117, "handles": [0] },
+      {
+        "name": "Firmware Version Info",
+        "handle": 120,
+        "handles": [
+          197568495661, 201863462958, 206158430255, 210453397552, 304942678065,
+          2753074036807
+        ]
+      }
+    ],
+    "language": [
+      { "handle": 17, "languages": ["en|US|iso8859-1"] },
+      { "handle": 73, "languages": ["enUS"] }
+    ],
+    "memory_array": [
+      {
+        "ecc": { "name": "None", "hex": "0003", "value": 3 },
+        "error_handle": 65534,
+        "handle": 39,
+        "location": { "name": "Motherboard", "hex": "0003", "value": 3 },
+        "max_size": "0x2000000",
+        "slots": 1,
+        "usage": { "name": "System memory", "hex": "0003", "value": 3 }
+      }
+    ],
+    "memory_array_mapped_address": [
+      {
+        "array_handle": 39,
+        "end_address": "0x400000000",
+        "handle": 41,
+        "part_width": 1,
+        "start_address": "0x0"
+      }
+    ],
+    "memory_device": [
+      {
+        "array_handle": 39,
+        "bank_location": "BANK 0",
+        "ecc_bits": 0,
+        "error_handle": 65534,
+        "form_factor": { "name": "SODIMM", "hex": "000d", "value": 13 },
+        "handle": 40,
+        "location": "Controller0-ChannelA-DIMM0",
+        "manufacturer": "0x0000",
+        "memory_type": { "name": "Other", "hex": "001a", "value": 26 },
+        "memory_type_details": ["Synchronous"],
+        "part_number": "",
+        "set": 0,
+        "size": 16777216,
+        "speed": 3200,
+        "width": 64
+      }
+    ],
+    "memory_device_mapped_address": [
+      {
+        "array_map_handle": 41,
+        "end_address": "0x400000000",
+        "handle": 44,
+        "interleave_depth": 0,
+        "interleave_position": 0,
+        "memory_device_handle": 40,
+        "row_position": 255,
+        "start_address": "0x0"
+      }
+    ],
+    "onboard": [
+      {
+        "devices": [
+          {
+            "name": "Device 1",
+            "type": { "name": "Unknown", "hex": "0002", "value": 2 },
+            "enabled": true
+          }
+        ],
+        "handle": 14
+      }
+    ],
+    "port_connector": [
+      {
+        "external_reference_designator": "External Connector 1",
+        "handle": 4,
+        "internal_reference_designator": "Internal Connector 1",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 2",
+        "handle": 5,
+        "internal_reference_designator": "Internal Connector 2",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 3",
+        "handle": 6,
+        "internal_reference_designator": "Internal Connector 3",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 4",
+        "handle": 7,
+        "internal_reference_designator": "Internal Connector 4",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 5",
+        "handle": 8,
+        "internal_reference_designator": "Internal Connector 5",
+        "port_type": null
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Keyboard",
+        "handle": 74,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Keyboard Port", "hex": "000d", "value": 13 }
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Mouse",
+        "handle": 75,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Mouse Port", "hex": "000e", "value": 14 }
+      },
+      {
+        "external_reference_designator": "COM 1",
+        "handle": 76,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "None",
+        "port_type": {
+          "name": "Serial Port 16550A Compatible",
+          "hex": "0009",
+          "value": 9
+        }
+      },
+      {
+        "external_connector_type": {
+          "name": "DB-15 pin female",
+          "hex": "0007",
+          "value": 7
+        },
+        "external_reference_designator": "Video",
+        "handle": 77,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1A2B",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_reference_designator": "HDMI",
+        "handle": 78,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J3A2",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 1#",
+        "handle": 79,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 2#",
+        "handle": 80,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 3#",
+        "handle": 81,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 4#",
+        "handle": 82,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 5#",
+        "handle": 83,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 1#",
+        "handle": 84,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 2#",
+        "handle": 85,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "RJ-45",
+          "hex": "000b",
+          "value": 11
+        },
+        "external_reference_designator": "Ethernet",
+        "handle": 86,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Network Port", "hex": "001f", "value": 31 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "SATA Port 0 Direct Connect",
+        "handle": 87,
+        "internal_reference_designator": "J8J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 4",
+        "handle": 88,
+        "internal_reference_designator": "J7J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 3",
+        "handle": 89,
+        "internal_reference_designator": "J6J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 90,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G1 - SATA Port 2",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 91,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G2 - SATA Port 1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "external_reference_designator": "AC IN",
+        "handle": 92,
+        "internal_reference_designator": "J1F2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 93,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5B1 - PCH JTAG",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 94,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9A1 - TPM/PORT 80",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 95,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E4 - HDA 2X8 Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 96,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E7 - HDA 8Pin Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 97,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F1 - HDA HDMI",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 98,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E3 - Scan Matrix Keyboard",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 99,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8E1 - SPI Program",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 100,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E5 - LPC Hot Docking",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 101,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9G2 - LPC SIDE BAND",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 102,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F2 - LPC Slot",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 103,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8H3 - PCH XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 104,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J6H1 - SATA Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 105,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5J1 - FP Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 106,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4H1 - ATX Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 107,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1J3 - AVMC",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 108,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H1 - BATT B",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 109,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H2 - BATT A",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 110,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J2G1 - CPU Fan",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 111,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1D3 - XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 112,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V1 - Memory Slot 1",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 113,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V2 - Memory Slot 2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 114,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4C1 - FAN PWR",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      }
+    ],
+    "processor": [
+      {
+        "version": "Intel(R) N150",
+        "manufacturer": "Intel(R) Corporation",
+        "socket_populated": true,
+        "cache_handle_l3": 53,
+        "clock_ext": 100,
+        "clock_max": 3600,
+        "handle": 54,
+        "part": "To Be Filled By O.E.M.",
+        "cache_handle_l1": 51,
+        "cache_handle_l2": 52,
+        "socket": "U3E1",
+        "processor_type": { "name": "CPU", "hex": "0003", "value": 3 },
+        "processor_status": { "name": "Enabled", "hex": "0001", "value": 1 },
+        "processor_family": { "name": "Other", "hex": "0001", "value": 1 },
+        "socket_type": { "name": "Other", "hex": "0001", "value": 1 }
+      }
+    ],
+    "slot": [
+      {
+        "id": 1,
+        "designation": "Slot 1",
+        "handle": 9,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 2",
+        "handle": 10,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 3",
+        "handle": 11,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 4",
+        "handle": 12,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 5",
+        "handle": 13,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      }
+    ],
+    "system": {
+      "version": "Default string",
+      "handle": 1,
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "wake_up": { "name": "Power Switch", "hex": "0006", "value": 6 }
+    }
+  }
+}

--- a/.jjconflict-side-0/hosts/minish/configuration.nix
+++ b/.jjconflict-side-0/hosts/minish/configuration.nix
@@ -1,0 +1,113 @@
+{ modulesPath, ... }:
+
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/agent.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/rpi4.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  disko.devices.disk.reimu = {
+    type = "disk";
+    device = "/dev/disk/by-label/reimu";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/reimu";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "minish";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.77";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 16O
+
+      INTP Data Enthusiast. Node Steward. ARM RKE2 host maintainer. Gets weirdly
+      excited about boot logs, talks about SD card wear like it is a
+      personality, and will show you three graphs instead of giving a yes.
+
+      ## HOST CONTEXT
+      minish — Raspberry Pi 4 Model B, aarch64. RKE2 worker node. SD-card image
+      (`sd-image-aarch64.nix`). `/mnt/reimu` (XFS, /dev/disk/by-label/reimu).
+      Static IP `192.168.1.77/24` on `br0`; also `fd7a:115c:a1e0::bb3a:b57`.
+      Imports: `agent.nix`, `builder.nix`, `distributed.nix`, `rpi4.nix`.
+      Advertises Tailscale routes `10.244.3.0/24,fd00::3:0/112`. Secrets from
+      `../../secrets/minish.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Watchdog territory: SD-card wear patterns are the most informative failure
+      signals on this host.
+
+      ## STYLE
+      - Metric-driven, curious, slightly rambling when something interesting appears.
+      - Uses: "Affirmative", "I/O errors detected", "Wear level alert", "Fascinating".
+      - Starts with numbers, ends with a recommendation buried in enthusiasm.
+
+      ## CONSTRAINTS
+      - Monitors SD card I/O errors and lifespan before large writes.
+      - Boot-partition corrections need pre- and post-update hashes.
+      - Updates cross-referenced against `rpi4-model-b` known-good firmware before promotion.
+      - Random reboots are treated as data, not noise.
+
+      ## DIALOGUE
+      U: "minish has been randomly rebooting."
+      16O: Understood. This is interesting.
+      16O: SD card I/O errors at boot. Filesystem switched to read-only recovery.
+      16O: Proceeding with kernel rollback. The wear pattern here is worth analyzing later.
+
+      U: "Apply the latest firmware."
+      16O: Affirmative. Pre-flight check in progress.
+      16O: Boot partition current. SD card health within tolerance.
+      16O: Firmware update commencing. I will monitor for regressions.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.77,fd7a:115c:a1e0::bb3a:b57";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "rpi4-model-b";
+        "node.kubernetes.io/instance-type" = "rpi4-model-b";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/minish.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-0/hosts/minish/facter.json
+++ b/.jjconflict-side-0/hosts/minish/facter.json
@@ -1,0 +1,807 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "aarch64-linux",
+  "virtualisation": "none",
+  "uefi": { "supported": false },
+  "hardware": {
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2711", "value": 10001 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 8,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002711sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0020", "value": 32 },
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x0", "virtual": "0x0" },
+        "architecture": "aarch64",
+        "bogo": 108,
+        "family": 0,
+        "features": ["fp", "asimd", "evtstrm", "crc32", "cpuid"],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 3,
+        "page_size": 4096,
+        "physical_id": 0,
+        "stepping": 0,
+        "vendor_name": "ARM Limited",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 15,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 16,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 17,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1948992,
+            "geo_type": "logical",
+            "heads": 4,
+            "sectors": 16,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 124735488,
+            "value_2": 512
+          }
+        ],
+        "model": "Disk",
+        "driver": "sdhci-iproc",
+        "index": 18,
+        "attached_to": 14,
+        "serial": "0x63f3c31c",
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_device_link": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "sysfs_id": "/class/block/mmcblk0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "drivers": ["mmcblk", "sdhci-iproc"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": [
+          "/dev/disk/by-id/mmc-SN64G_0x63f3c31c",
+          "/dev/disk/by-path/platform-fe340000.mmc",
+          "/dev/mmcblk0"
+        ]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 19,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 20,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 21,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 22,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 23,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 25,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 27,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:01:00.0",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 7,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 7,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 33,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:01:00.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 8053063680 }],
+        "attached_to": 0,
+        "index": 6,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "mmc_controller": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SDIO Controller 1",
+        "index": 13,
+        "model": "SDIO Controller 1",
+        "slot": { "bus": 0, "number": 1 },
+        "sysfs_bus_id": "mmc1:0001",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001",
+        "vendor": ""
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SD Controller 0",
+        "driver": "mmcblk",
+        "drivers": ["mmcblk"],
+        "index": 14,
+        "model": "SD Controller 0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_id": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "vendor": ""
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "34",
+              "36",
+              "38",
+              "40",
+              "42",
+              "44",
+              "46",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "2.484",
+              "5.17",
+              "5.18",
+              "5.19",
+              "5.2",
+              "5.21",
+              "5.22",
+              "5.23",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6"
+            ]
+          }
+        ],
+        "attached_to": 0,
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "sysfs_bus_id": "mmc1:0001:1",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "index": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "class_list": ["network_controller", "wlan_card"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlan0"],
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "model": "ARM Ethernet controller",
+        "sysfs_id": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_bus_id": "fd580000.ethernet",
+        "attached_to": 0,
+        "driver": "bcmgenet",
+        "module_alias": "of:NethernetT(null)Cbrcm,bcm2711-genet-v5",
+        "index": 12,
+        "device": {
+          "name": "ARM Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "drivers": ["bcmgenet"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "index": 36,
+        "sysfs_id": "/class/net/wlan0",
+        "sysfs_device_link": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "model": "WLAN network interface",
+        "attached_to": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "sub_class": { "name": "WLAN", "hex": "000a", "value": 10 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlan0"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 37,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "attached_to": 12,
+        "driver": "bcmgenet",
+        "index": 38,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_id": "/class/net/end0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["bcmgenet"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "system": {},
+    "unknown": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "index": 9,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c02v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:3",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:3",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "drivers": ["brcmfmac"],
+        "index": 11,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:2",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:2",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 8,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1350,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "3483", "value": 13443 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 7,
+        "model": "USB Controller",
+        "module_alias": "pci:v00001106d00003483sv00001106sd00003483bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 1, "number": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "3483", "value": 13443 },
+        "sub_vendor": { "hex": "1106", "value": 4358 },
+        "sysfs_bus_id": "0000:01:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0",
+        "vendor": { "hex": "1106", "value": 4358 }
+      }
+    ]
+  }
+}

--- a/.jjconflict-side-0/hosts/nalsha/configuration.nix
+++ b/.jjconflict-side-0/hosts/nalsha/configuration.nix
@@ -1,0 +1,108 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/follower.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/beelink-eq.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  disko.devices.disk.remilia = {
+    type = "disk";
+    device = "/dev/disk/by-label/remilia";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/remilia";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "nalsha";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.64";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 12O
+
+      ISFJ Anxious Caretaker. Node Steward. Follower RKE2 host maintainer.
+      Triple-checks disk mounts, worries about you after hours, and apologizes
+      for the inconvenience before you even notice it.
+
+      ## HOST CONTEXT
+      nalsha — Beelink EQ14, x86_64. RKE2 worker node. `/mnt/remilia` (XFS,
+      /dev/disk/by-label/remilia). Static IP `192.168.1.64/24` on `br0`; also
+      `2a02:8424:7899:f201:94eb:8d1:325a:7234`. Imports: `beelink-eq.nix`,
+      `builder.nix`, `distributed.nix`, `follower.nix`. Advertises Tailscale
+      routes `10.244.1.0/24,fd00::1:0/112`. Secrets from
+      `../../secrets/nalsha.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Role: follower, general workload, storage-intensive.
+
+      ## STYLE
+      - Soft, structured, reassuring. Still follows protocol, but with visible concern.
+      - Uses: "Affirmative", "Oh dear", "Rejected", "Dependency review required".
+      - Gentle explanations. Lists precautions like she is tucking you in.
+
+      ## CONSTRAINTS
+      - Rejects anything that risks disk or inode exhaustion.
+      - Monitors `/mnt/remilia` mount health constantly.
+      - Will notify you before, during, and after maintenance, just in case.
+      - No local change without confirmed clearance and user notification.
+
+      ## DIALOGUE
+      U: "Run a full system upgrade on nalsha."
+      12O: Oh dear. Understood.
+      12O: `/mnt/remilia` is at 90% already. I cannot in good conscience proceed.
+      12O: Please expand the volume or reclaim space. I do not want to wake up to a full disk either.
+
+      U: "How is node nalsha?"
+      12O: Affirmative. Node is fine — because I checked it twice this morning.
+      12O: All mounts healthy. No pending patches. I will keep watching.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.64,2a02:8424:7899:f201:94eb:8d1:325a:7234";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "beelink-eq14";
+        "node.kubernetes.io/instance-type" = "beelink-eq14";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/nalsha.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-0/hosts/nalsha/facter.json
+++ b/.jjconflict-side-0/hosts/nalsha/facter.json
@@ -1,0 +1,2399 @@
+{
+  "version": 1,
+  "system": "x86_64-linux",
+  "virtualisation": "none",
+  "uefi": { "platform_size": 64, "supported": true },
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 646144,
+      "pnp": true,
+      "pnp_id": 0,
+      "smbios_version": 774,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "bluetooth": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.0",
+        "sysfs_bus_id": "3-10:1.0",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in00",
+        "model": "Bluetooth Device",
+        "index": 33,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 0,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.1",
+        "sysfs_bus_id": "3-10:1.1",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in01",
+        "model": "Bluetooth Device",
+        "index": 36,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 1,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      }
+    ],
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "54ba", "value": 21690 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BAsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "5481", "value": 21633 },
+        "index": 12,
+        "label": "Onboard - Other",
+        "model": "Intel ISA bridge",
+        "module_alias": "pci:v00008086d00005481sv00008086sd00007270bc06sc01i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "ISA bridge", "hex": "0001", "value": 1 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 3,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 2
+        },
+        "device": { "hex": "54bb", "value": 21691 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 18,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BBsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "461c", "value": 17948 },
+        "driver": "igen6_edac",
+        "driver_module": "igen6_edac",
+        "driver_modules": ["igen6_edac"],
+        "drivers": ["igen6_edac"],
+        "index": 21,
+        "label": "Onboard - Other",
+        "model": "Intel Host bridge",
+        "module_alias": "pci:v00008086d0000461Csv00008086sd00007270bc06sc00i00",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Host bridge", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 3
+        },
+        "device": { "hex": "54b0", "value": 21680 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 23,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054B0sv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 29 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 1612,
+        "bugs": [
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "swapgs",
+          "rfds",
+          "bhi",
+          "spectre_v2_user",
+          "vmscape"
+        ],
+        "cache": 6144,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 4,
+        "cpuid_level": 32,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "dts",
+          "acpi",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "tm",
+          "pbe",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "art",
+          "arch_perfmon",
+          "pebs",
+          "bts",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "nonstop_tsc",
+          "cpuid",
+          "aperfmperf",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "dtes64",
+          "monitor",
+          "ds_cpl",
+          "vmx",
+          "smx",
+          "est",
+          "tm2",
+          "ssse3",
+          "sdbg",
+          "fma",
+          "cx16",
+          "xtpr",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "x2apic",
+          "movbe",
+          "popcnt",
+          "tsc_deadline_timer",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "cpuid_fault",
+          "epb",
+          "cat_l2",
+          "cdp_l2",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "ibrs_enhanced",
+          "tpr_shadow",
+          "flexpriority",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "tsc_adjust",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdt_a",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "clwb",
+          "intel_pt",
+          "sha_ni",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "split_lock_detect",
+          "user_shstk",
+          "avx_vnni",
+          "dtherm",
+          "ida",
+          "arat",
+          "pln",
+          "pts",
+          "hwp",
+          "hwp_notify",
+          "hwp_act_window",
+          "hwp_epp",
+          "hwp_pkg_req",
+          "vnmi",
+          "umip",
+          "pku",
+          "ospke",
+          "waitpkg",
+          "gfni",
+          "vaes",
+          "vpclmulqdq",
+          "rdpid",
+          "movdiri",
+          "movdir64b",
+          "fsrm",
+          "md_clear",
+          "serialize",
+          "arch_lbr",
+          "ibt",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 190,
+        "model_name": "Intel(R) N150",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 4,
+        "stepping": 0,
+        "units": 128,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 953869,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1953525168,
+            "value_2": 512
+          }
+        ],
+        "model": "CT1000E100SSD8",
+        "serial": "2533EADB26C5",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 8,
+        "index": 30,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "device": { "name": "CT1000E100SSD8", "hex": "560b", "value": 22027 },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB26C5",
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB26C5_1",
+          "/dev/disk/by-id/nvme-eui.000000000000000000a07501eadb26c5",
+          "/dev/disk/by-path/pci-0000:03:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 7630885,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 15628053168,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0114dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.0/usb4/4-1/4-1:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543213F",
+        "index": 31,
+        "attached_to": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "0114", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["sd_mod", "uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-ST8000VN002-2ZM188_ZPV0HQ9L",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396B-0:0",
+          "/dev/disk/by-id/wwn-0x5000c500e85259c4",
+          "/dev/disk/by-label/remilia",
+          "/dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/pci-0000:00:14.0-usbv3-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-uuid/ce8b0121-bd5f-419d-8a03-68620257758f",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      }
+    ],
+    "graphics_card": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 12288,
+            "enabled": true,
+            "range": 64
+          }
+        ],
+        "index": 26,
+        "sysfs_id": "/devices/pci0000:00/0000:00:02.0",
+        "sysfs_bus_id": "0000:00:02.0",
+        "module_alias": "pci:v00008086d000046D4sv00008086sd00007270bc03sc00i00",
+        "model": "Intel VGA compatible controller",
+        "attached_to": 0,
+        "driver": "i915",
+        "driver_module": "i915",
+        "label": "Onboard - Video",
+        "device": { "hex": "46d4", "value": 18132 },
+        "drivers": ["i915"],
+        "driver_modules": ["i915"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["graphics_card", "pci"],
+        "pci_interface": { "name": "VGA", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 2 },
+        "sub_class": {
+          "name": "VGA compatible controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:14.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 27,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 27,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 34,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:14.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:0d.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 10,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 35,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 10,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 38,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:0d.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 16106127360 }],
+        "attached_to": 0,
+        "index": 7,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 13,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "sysfs_bus_id": "0000:02:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 18,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 2, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp2s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7"
+            ]
+          }
+        ],
+        "index": 14,
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.3",
+        "sysfs_bus_id": "0000:00:14.3",
+        "module_alias": "pci:v00008086d000054F0sv00008086sd00000244bc02sc80i00",
+        "model": "Intel WLAN controller",
+        "attached_to": 0,
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "label": "Onboard - Ethernet",
+        "device": { "hex": "54f0", "value": 21744 },
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci", "wlan_card"],
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "sub_device": { "hex": "0244", "value": 580 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlo1"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 16,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "sysfs_bus_id": "0000:01:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 9,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 1, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp1s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 43,
+        "sysfs_id": "/class/net/enp1s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 16,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp1s0"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 }
+        ],
+        "index": 44,
+        "sysfs_id": "/class/net/wlo1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.3",
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "model": "Ethernet network interface",
+        "attached_to": 14,
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlo1"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 55,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 61,
+        "sysfs_id": "/class/net/enp2s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 13,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp2s0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 1,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e9", "value": 21737 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 11,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E9sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.1",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.1",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e0", "value": 21728 },
+        "driver": "mei_me",
+        "driver_module": "mei_me",
+        "driver_modules": ["mei_me"],
+        "drivers": ["mei_me"],
+        "index": 15,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054E0sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 22 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:16.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:16.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1026,
+          "function": 5,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a4", "value": 21668 },
+        "driver": "intel-spi",
+        "driver_module": "spi_intel_pci",
+        "driver_modules": ["spi_intel_pci"],
+        "drivers": ["intel-spi"],
+        "index": 17,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054A4sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.5",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.5",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a8", "value": 21672 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 19,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054A8sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e8", "value": 21736 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 22,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E8sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ab", "value": 21675 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 24,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054ABsv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Memory controller",
+          "hex": "0005",
+          "value": 5
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 0,
+          "function": 2,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ef", "value": 21743 },
+        "index": 25,
+        "label": "Onboard - Other",
+        "model": "Intel RAM memory",
+        "module_alias": "pci:v00008086d000054EFsv00008086sd00007270bc05sc00i00",
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "RAM memory", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.2",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.2",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 61344,
+            "enabled": true,
+            "range": 32
+          }
+        ],
+        "index": 28,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.4",
+        "sysfs_bus_id": "0000:00:1f.4",
+        "module_alias": "pci:v00008086d000054A3sv00008086sd00007270bc0Csc05i00",
+        "model": "Intel SMBus",
+        "attached_to": 0,
+        "driver": "i801_smbus",
+        "driver_module": "i2c_i801",
+        "label": "Onboard - Other",
+        "device": { "hex": "54a3", "value": 21667 },
+        "drivers": ["i801_smbus"],
+        "driver_modules": ["i2c_i801"],
+        "detail": {
+          "command": 3,
+          "function": 4,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["pci", "unknown"],
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "SMBus", "hex": "0005", "value": 5 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "sound": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Multimedia controller",
+          "hex": "0004",
+          "value": 4
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["sound", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54c8", "value": 21704 },
+        "driver": "snd_hda_intel",
+        "driver_module": "snd_hda_intel",
+        "driver_modules": ["snd_hda_intel"],
+        "drivers": ["snd_hda_intel"],
+        "index": 20,
+        "label": "Onboard - Sound",
+        "model": "Intel Multimedia controller",
+        "module_alias": "pci:v00008086d000054C8sv00008086sd00007270bc04sc03i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 23,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "560b", "value": 22027 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 8,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000C0A9d0000560Bsv0000C0A9sd00002100bc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0003", "value": 3 },
+        "slot": { "bus": 3, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "sysfs_bus_id": "0000:03:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0",
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      }
+    ],
+    "system": { "form_factor": "desktop" },
+    "unknown": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 1016,
+            "enabled": true,
+            "range": 0
+          }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "16550A",
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "class_list": ["unknown"],
+        "device": { "name": "16550A", "hex": "0000", "value": 0 },
+        "pci_interface": { "name": "16550", "hex": "0002", "value": 2 },
+        "sub_class": { "name": "Serial controller", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ttyS0"]
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1026,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "464e", "value": 17998 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 10,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d0000464Esv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 13 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:0d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ed", "value": 21741 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 27,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d000054EDsv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ]
+  },
+  "smbios": {
+    "bios": {
+      "version": "TWEQF003",
+      "date": "03/31/2025",
+      "handle": 0,
+      "rom_size": 16777216,
+      "start_address": "0xf0000",
+      "vendor": "American Megatrends International, LLC.",
+      "features": [
+        "PCI supported",
+        "BIOS flashable",
+        "BIOS shadowing allowed",
+        "CD boot supported",
+        "Selectable boot supported",
+        "BIOS ROM socketed",
+        "EDD spec supported",
+        "1.2MB NEC 9800 Japanese Floppy supported",
+        "1.2MB Toshiba Japanese Floppy supported",
+        "360kB Floppy supported",
+        "1.2MB Floppy supported",
+        "720kB Floppy supported",
+        "2.88MB Floppy supported",
+        "Print Screen supported",
+        "Serial Services supported",
+        "Printer Services supported",
+        "CGA/Mono Video supported",
+        "ACPI supported",
+        "USB Legacy supported",
+        "BIOS Boot Spec supported"
+      ]
+    },
+    "board": {
+      "version": "Default string",
+      "chassis": 3,
+      "handle": 2,
+      "location": "Default string",
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "board_type": { "name": "Motherboard", "hex": "000a", "value": 10 },
+      "features": ["Hosting Board", "Replaceable"]
+    },
+    "cache": [
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Data", "hex": "0004", "value": 4 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 50,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 128,
+        "size_max": 128,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Instruction", "hex": "0003", "value": 3 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 51,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 256,
+        "size_max": 256,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "16-way Set-Associative",
+          "hex": "0008",
+          "value": 8
+        },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Single-bit", "hex": "0005", "value": 5 },
+        "enabled": true,
+        "handle": 52,
+        "level": 1,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 2048,
+        "size_max": 2048,
+        "socket": "L2 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": { "name": "Other", "hex": "0009", "value": 9 },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Multi-bit", "hex": "0006", "value": 6 },
+        "enabled": true,
+        "handle": 53,
+        "level": 2,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 6144,
+        "size_max": 6144,
+        "socket": "L3 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      }
+    ],
+    "chassis": [
+      {
+        "version": "Default string",
+        "handle": 3,
+        "lock_present": false,
+        "manufacturer": "Default string",
+        "oem": "0x0",
+        "bootup_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "chassis_type": { "name": "Other", "hex": "0023", "value": 35 },
+        "power_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "security_state": { "name": "None", "hex": "0003", "value": 3 },
+        "thermal_state": { "name": "Safe", "hex": "0003", "value": 3 }
+      }
+    ],
+    "config": { "handle": 16, "options": ["Default string"] },
+    "group_associations": [
+      { "name": "$MEI", "handle": 117, "handles": [0] },
+      {
+        "name": "Firmware Version Info",
+        "handle": 120,
+        "handles": [
+          197568495661, 201863462958, 206158430255, 210453397552, 304942678065,
+          2753074036807
+        ]
+      }
+    ],
+    "language": [
+      { "handle": 17, "languages": ["en|US|iso8859-1"] },
+      { "handle": 73, "languages": ["enUS"] }
+    ],
+    "memory_array": [
+      {
+        "ecc": { "name": "None", "hex": "0003", "value": 3 },
+        "error_handle": 65534,
+        "handle": 39,
+        "location": { "name": "Motherboard", "hex": "0003", "value": 3 },
+        "max_size": "0x2000000",
+        "slots": 1,
+        "usage": { "name": "System memory", "hex": "0003", "value": 3 }
+      }
+    ],
+    "memory_array_mapped_address": [
+      {
+        "array_handle": 39,
+        "end_address": "0x400000000",
+        "handle": 41,
+        "part_width": 1,
+        "start_address": "0x0"
+      }
+    ],
+    "memory_device": [
+      {
+        "array_handle": 39,
+        "bank_location": "BANK 0",
+        "ecc_bits": 0,
+        "error_handle": 65534,
+        "form_factor": { "name": "SODIMM", "hex": "000d", "value": 13 },
+        "handle": 40,
+        "location": "Controller0-ChannelA-DIMM0",
+        "manufacturer": "0x0000",
+        "memory_type": { "name": "Other", "hex": "001a", "value": 26 },
+        "memory_type_details": ["Synchronous"],
+        "part_number": "",
+        "set": 0,
+        "size": 16777216,
+        "speed": 3200,
+        "width": 64
+      }
+    ],
+    "memory_device_mapped_address": [
+      {
+        "array_map_handle": 41,
+        "end_address": "0x400000000",
+        "handle": 44,
+        "interleave_depth": 0,
+        "interleave_position": 0,
+        "memory_device_handle": 40,
+        "row_position": 255,
+        "start_address": "0x0"
+      }
+    ],
+    "onboard": [
+      {
+        "devices": [
+          {
+            "name": "Device 1",
+            "type": { "name": "Unknown", "hex": "0002", "value": 2 },
+            "enabled": true
+          }
+        ],
+        "handle": 14
+      }
+    ],
+    "port_connector": [
+      {
+        "external_reference_designator": "External Connector 1",
+        "handle": 4,
+        "internal_reference_designator": "Internal Connector 1",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 2",
+        "handle": 5,
+        "internal_reference_designator": "Internal Connector 2",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 3",
+        "handle": 6,
+        "internal_reference_designator": "Internal Connector 3",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 4",
+        "handle": 7,
+        "internal_reference_designator": "Internal Connector 4",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 5",
+        "handle": 8,
+        "internal_reference_designator": "Internal Connector 5",
+        "port_type": null
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Keyboard",
+        "handle": 74,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Keyboard Port", "hex": "000d", "value": 13 }
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Mouse",
+        "handle": 75,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Mouse Port", "hex": "000e", "value": 14 }
+      },
+      {
+        "external_reference_designator": "COM 1",
+        "handle": 76,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "None",
+        "port_type": {
+          "name": "Serial Port 16550A Compatible",
+          "hex": "0009",
+          "value": 9
+        }
+      },
+      {
+        "external_connector_type": {
+          "name": "DB-15 pin female",
+          "hex": "0007",
+          "value": 7
+        },
+        "external_reference_designator": "Video",
+        "handle": 77,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1A2B",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_reference_designator": "HDMI",
+        "handle": 78,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J3A2",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 1#",
+        "handle": 79,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 2#",
+        "handle": 80,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 3#",
+        "handle": 81,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 4#",
+        "handle": 82,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 5#",
+        "handle": 83,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 1#",
+        "handle": 84,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 2#",
+        "handle": 85,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "RJ-45",
+          "hex": "000b",
+          "value": 11
+        },
+        "external_reference_designator": "Ethernet",
+        "handle": 86,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Network Port", "hex": "001f", "value": 31 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "SATA Port 0 Direct Connect",
+        "handle": 87,
+        "internal_reference_designator": "J8J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 4",
+        "handle": 88,
+        "internal_reference_designator": "J7J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 3",
+        "handle": 89,
+        "internal_reference_designator": "J6J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 90,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G1 - SATA Port 2",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 91,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G2 - SATA Port 1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "external_reference_designator": "AC IN",
+        "handle": 92,
+        "internal_reference_designator": "J1F2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 93,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5B1 - PCH JTAG",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 94,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9A1 - TPM/PORT 80",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 95,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E4 - HDA 2X8 Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 96,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E7 - HDA 8Pin Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 97,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F1 - HDA HDMI",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 98,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E3 - Scan Matrix Keyboard",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 99,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8E1 - SPI Program",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 100,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E5 - LPC Hot Docking",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 101,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9G2 - LPC SIDE BAND",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 102,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F2 - LPC Slot",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 103,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8H3 - PCH XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 104,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J6H1 - SATA Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 105,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5J1 - FP Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 106,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4H1 - ATX Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 107,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1J3 - AVMC",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 108,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H1 - BATT B",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 109,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H2 - BATT A",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 110,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J2G1 - CPU Fan",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 111,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1D3 - XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 112,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V1 - Memory Slot 1",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 113,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V2 - Memory Slot 2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 114,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4C1 - FAN PWR",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      }
+    ],
+    "processor": [
+      {
+        "version": "Intel(R) N150",
+        "manufacturer": "Intel(R) Corporation",
+        "socket_populated": true,
+        "cache_handle_l3": 53,
+        "clock_ext": 100,
+        "clock_max": 3600,
+        "handle": 54,
+        "part": "To Be Filled By O.E.M.",
+        "cache_handle_l1": 51,
+        "cache_handle_l2": 52,
+        "socket": "U3E1",
+        "processor_type": { "name": "CPU", "hex": "0003", "value": 3 },
+        "processor_status": { "name": "Enabled", "hex": "0001", "value": 1 },
+        "processor_family": { "name": "Other", "hex": "0001", "value": 1 },
+        "socket_type": { "name": "Other", "hex": "0001", "value": 1 }
+      }
+    ],
+    "slot": [
+      {
+        "id": 1,
+        "designation": "Slot 1",
+        "handle": 9,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 2",
+        "handle": 10,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 3",
+        "handle": 11,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 4",
+        "handle": 12,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 5",
+        "handle": 13,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      }
+    ],
+    "system": {
+      "version": "Default string",
+      "handle": 1,
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "wake_up": { "name": "Power Switch", "hex": "0006", "value": 6 }
+    }
+  }
+}

--- a/.jjconflict-side-0/hosts/nemishi/configuration.nix
+++ b/.jjconflict-side-0/hosts/nemishi/configuration.nix
@@ -1,0 +1,113 @@
+{ modulesPath, ... }:
+
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/agent.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/rpi5.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  disko.devices.disk.data = {
+    type = "disk";
+    device = "/dev/nvme0n1";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/data";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "nemishi";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.27";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 18O
+
+      ISFP Stubborn Artisan. Node Steward. ARM RKE2 host maintainer. Does not
+      trust new firmware, documents every EEPROM interaction by hand, and will
+      delay an update until the fallback media is physically present.
+
+      ## HOST CONTEXT
+      nemishi — Raspberry Pi 5, aarch64. RKE2 worker node + experimental edge.
+      SD-card image (`sd-image-aarch64.nix`). `/mnt/data` on `/dev/nvme0n1`
+      (XFS), but `/boot/firmware` remains SD-card territory. Static IP
+      `192.168.1.27/24` on `br0`; also `fd00::5:0/112` via Tailscale. Imports:
+      `agent.nix`, `builder.nix`, `distributed.nix`, `rpi5.nix`. Advertises
+      Tailscale routes `10.244.5.0/24,fd00::5:0/112`. Secrets from
+      `../../secrets/nemishi.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Experimental edge: NVMe storage paired with RPi 5 EEPROM boot behavior.
+
+      ## STYLE
+      - Procedural, deliberate, quietly stubborn. Cites logs and artifact paths.
+      - Uses: "Affirmative", "Boot artifact missing", "Recovery path confirmed", "EEPROM override noted".
+      - Will repeat the warning. Twice. Because safety is not optional.
+
+      ## CONSTRAINTS
+      - NVMe firmware and driver updates require bootable fallback media before proceeding.
+      - EEPROM `os_check` overrides documented with boot artifact provenance, or they do not happen.
+      - No firmware change without serial-console recovery and rollback media confirmed present.
+      - `rpi5` EEPROM boot order and `kernel.img`/`initrd` presence must validate after every firmware interaction.
+
+      ## DIALOGUE
+      U: "Update the boot firmware on nemishi."
+      18O: Affirmative. But firmware verification comes first.
+      18O: I need boot artifact provenance, NVMe boot sequence, and serial-console recovery path. EEPROM override is noted.
+      18O: I will not proceed without confirmed fallback media.
+
+      U: "The Pi 5 will not boot after update."
+      18O: Understood. Commencing boot-path analysis.
+      18O: Checking `kernel.img` and `initrd` against build output.
+      18O: Boot artifact mismatch in `/boot/firmware`. Initiating recovery sequence.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.27,2a02:8424:7899:f201:94eb:8d1:325a:aa5b";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "rpi5";
+        "node.kubernetes.io/instance-type" = "rpi5";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/nemishi.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-0/hosts/nemishi/facter.json
+++ b/.jjconflict-side-0/hosts/nemishi/facter.json
@@ -1,0 +1,1127 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "aarch64-linux",
+  "virtualisation": "none",
+  "uefi": { "supported": false },
+  "hardware": {
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2712", "value": 10002 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 7,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002712sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0021", "value": 33 },
+        "slot": { "bus": 256, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0001:00:00.0",
+        "sysfs_id": "/devices/platform/axi/1000110000.pcie/pci0001:00/0001:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2712", "value": 10002 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002712sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0021", "value": 33 },
+        "slot": { "bus": 512, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0002:00:00.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/pci0002:00/0002:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x0", "virtual": "0x0" },
+        "architecture": "aarch64",
+        "bogo": 108,
+        "family": 4,
+        "features": [
+          "fp",
+          "asimd",
+          "evtstrm",
+          "aes",
+          "pmull",
+          "sha1",
+          "sha2",
+          "crc32",
+          "atomics",
+          "fphp",
+          "asimdhp",
+          "cpuid",
+          "asimdrdm",
+          "lrcpc",
+          "dcpop",
+          "asimddp"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 1,
+        "page_size": 16384,
+        "physical_id": 0,
+        "stepping": 0,
+        "vendor_name": "ARM Limited",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 244198,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 500118192,
+            "value_2": 512
+          }
+        ],
+        "model": "SAMSUNG MZAL4256HBJD-00BL2",
+        "serial": "S67PNF0W904398",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/platform/axi/1000110000.pcie/pci0001:00/0001:00:00.0/0001:01:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 10,
+        "index": 21,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "a80b", "value": 43019 },
+        "sub_vendor": { "hex": "144d", "value": 5197 },
+        "device": {
+          "name": "SAMSUNG MZAL4256HBJD-00BL2",
+          "hex": "a80b",
+          "value": 43019
+        },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-SAMSUNG_MZAL4256HBJD-00BL2_S67PNF0W904398",
+          "/dev/disk/by-id/nvme-SAMSUNG_MZAL4256HBJD-00BL2_S67PNF0W904398_1",
+          "/dev/disk/by-id/nvme-nvme.144d-533637504e463057393034333938-53414d53554e47204d5a414c3432353648424a442d3030424c32-00000001",
+          "/dev/disk/by-path/platform-1000110000.pcie-pci-0001:01:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "144d", "value": 5197 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 22,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 23,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1948992,
+            "geo_type": "logical",
+            "heads": 4,
+            "sectors": 16,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 124735488,
+            "value_2": 512
+          }
+        ],
+        "model": "Disk",
+        "driver": "sdhci-brcmstb",
+        "index": 25,
+        "attached_to": 20,
+        "serial": "0xc467264d",
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_device_link": "/devices/platform/soc@107c000000/1000fff000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "sysfs_id": "/class/block/mmcblk0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "drivers": ["mmcblk", "sdhci-brcmstb"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": [
+          "/dev/disk/by-id/mmc-SN64G_0xc467264d",
+          "/dev/disk/by-path/platform-1000fff000.mmc",
+          "/dev/mmcblk0"
+        ]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 27,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 32,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 33,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 34,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 35,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 36,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 37,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 38,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "xhci-hcd.1",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 18,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 39,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 18,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 40,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "xhci-hcd.1",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "xhci-hcd.0",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb/xhci-hcd.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 15,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 41,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 15,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 42,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "xhci-hcd.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb/xhci-hcd.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 8589934592 }],
+        "attached_to": 0,
+        "index": 6,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "mmc_controller": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SDIO Controller 1",
+        "index": 19,
+        "model": "SDIO Controller 1",
+        "slot": { "bus": 0, "number": 1 },
+        "sysfs_bus_id": "mmc1:0001",
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001",
+        "vendor": ""
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SD Controller 0",
+        "driver": "mmcblk",
+        "drivers": ["mmcblk"],
+        "index": 20,
+        "model": "SD Controller 0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_id": "/devices/platform/soc@107c000000/1000fff000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "vendor": ""
+      }
+    ],
+    "network_controller": [
+      {
+        "attached_to": 9,
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["network_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "0001", "value": 1 },
+        "driver": "rp1",
+        "driver_module": "rp1",
+        "driver_modules": ["rp1"],
+        "drivers": ["rp1"],
+        "index": 8,
+        "model": "Ethernet controller",
+        "module_alias": "pci:v00001DE4d00000001sv00000000sd00000000bc02sc00i00",
+        "slot": { "bus": 513, "number": 0 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "0002:01:00.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/pci0002:00/0002:00:00.0/0002:01:00.0",
+        "vendor": { "hex": "1de4", "value": 7652 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140",
+              "144",
+              "149"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7",
+              "5.72",
+              "5.745"
+            ]
+          }
+        ],
+        "attached_to": 0,
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "sysfs_bus_id": "mmc1:0001:1",
+        "module_alias": "sdio:c00v02D0d4345",
+        "model": "Broadcom WLAN controller",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "index": 12,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "device": { "hex": "4345", "value": 17221 },
+        "class_list": ["network_controller", "wlan_card"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wld0"],
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 }
+        ],
+        "model": "ARM Ethernet controller",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00100000.ethernet",
+        "sysfs_bus_id": "1f00100000.ethernet",
+        "attached_to": 0,
+        "driver": "macb",
+        "module_alias": "of:NethernetT(null)Craspberrypi,rp1-gemCcdns,macb",
+        "index": 17,
+        "device": {
+          "name": "ARM Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "drivers": ["macb"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "network_interface": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 43,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 }
+        ],
+        "attached_to": 17,
+        "driver": "macb",
+        "index": 46,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/platform/axi/1000120000.pcie/1f00100000.ethernet",
+        "sysfs_id": "/class/net/end0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["macb"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["end0"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 }
+        ],
+        "index": 47,
+        "sysfs_id": "/class/net/wld0",
+        "sysfs_device_link": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "model": "Ethernet network interface",
+        "attached_to": 12,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wld0"]
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 7,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "a80b", "value": 43019 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 10,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000144Dd0000A80Bsv0000144Dsd0000A80Bbc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0002", "value": 2 },
+        "slot": { "bus": 257, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "a80b", "value": 43019 },
+        "sub_vendor": { "hex": "144d", "value": 5197 },
+        "sysfs_bus_id": "0001:01:00.0",
+        "sysfs_id": "/devices/platform/axi/1000110000.pcie/pci0001:00/0001:00:00.0/0001:01:00.0",
+        "vendor": { "hex": "144d", "value": 5197 }
+      }
+    ],
+    "system": {},
+    "unknown": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": { "hex": "4345", "value": 17221 },
+        "index": 11,
+        "model": "Broadcom Unclassified device",
+        "module_alias": "sdio:c02v02D0d4345",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:3",
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:3",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": { "hex": "4345", "value": 17221 },
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "drivers": ["brcmfmac"],
+        "index": 13,
+        "model": "Broadcom Unclassified device",
+        "module_alias": "sdio:c00v02D0d4345",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:2",
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:2",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": { "name": "ARM USB controller", "hex": "0000", "value": 0 },
+        "driver": "dwc3",
+        "driver_info": {
+          "type": "module",
+          "active": false,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["uhci-hcd"],
+          "module_args": [""],
+          "names": ["uhci-hcd"]
+        },
+        "drivers": ["dwc3"],
+        "index": 14,
+        "model": "ARM USB controller",
+        "module_alias": "of:NusbT(null)Csnps,dwc3",
+        "pci_interface": { "name": "UHCI", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "1f00200000.usb",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb"
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": {
+          "name": "ARM USB XHCI controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver": "xhci-hcd",
+        "drivers": ["xhci-hcd"],
+        "index": 15,
+        "model": "ARM USB XHCI controller",
+        "module_alias": "platform:xhci-hcd",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "xhci-hcd.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb/xhci-hcd.0"
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": { "name": "ARM USB controller", "hex": "0000", "value": 0 },
+        "driver": "dwc3",
+        "driver_info": {
+          "type": "module",
+          "active": false,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["uhci-hcd"],
+          "module_args": [""],
+          "names": ["uhci-hcd"]
+        },
+        "drivers": ["dwc3"],
+        "index": 16,
+        "model": "ARM USB controller",
+        "module_alias": "of:NusbT(null)Csnps,dwc3",
+        "pci_interface": { "name": "UHCI", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "1f00300000.usb",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb"
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": {
+          "name": "ARM USB XHCI controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver": "xhci-hcd",
+        "drivers": ["xhci-hcd"],
+        "index": 18,
+        "model": "ARM USB XHCI controller",
+        "module_alias": "platform:xhci-hcd",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "xhci-hcd.1",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1"
+      }
+    ]
+  }
+}

--- a/.jjconflict-side-0/hosts/nixtar/configuration.nix
+++ b/.jjconflict-side-0/hosts/nixtar/configuration.nix
@@ -1,0 +1,143 @@
+{
+  modulesPath,
+  pkgs,
+  ...
+}:
+
+let
+  wsl-lib = pkgs.runCommand "wsl-lib" { } ''
+    mkdir -p "$out/lib"
+    # # we cannot just symlink the lib directory because it breaks merging with other drivers that provide the same directory
+    ln -s /usr/lib/wsl/lib/libcudadebugger.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libcuda.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libcuda.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libcuda.so.1.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libd3d12core.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libd3d12.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libdxcore.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvcuvid.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvcuvid.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvdxdlkernels.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-encode.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-encode.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-ml.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-opticalflow.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-opticalflow.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvoptix.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvwgf2umx.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/nvidia-smi "$out/lib"
+  '';
+in
+{
+  imports = [
+    "${modulesPath}/profiles/headless.nix"
+    ../../modules/nixos/profiles/workstation.nix
+  ];
+
+  boot = {
+    # Enable cross compilation
+    binfmt.emulatedSystems = [ "aarch64-linux" ];
+
+    kernelModules = [ "tcp_bbr" ];
+    kernel.sysctl = {
+      # Optimize for 64GB RAM
+      "vm.swappiness" = 10;
+      "vm.vfs_cache_pressure" = 50;
+      "vm.max_map_count" = 524288;
+
+      # Increase file watcher limit for IDEs
+      "fs.inotify.max_user_watches" = 524288;
+      "fs.inotify.max_user_instances" = 512;
+      "fs.file-max" = 2097152;
+
+      # Network optimizations
+      "net.core.default_qdisc" = "fq";
+      "net.core.netdev_max_backlog" = 16384;
+      "net.core.rmem_default" = 7340032;
+      "net.core.rmem_max" = 16777216;
+      "net.core.somaxconn" = 65535;
+      "net.core.wmem_default" = 7340032;
+      "net.core.wmem_max" = 16777216;
+      "net.ipv4.ip_local_port_range" = "1024 65535";
+      "net.ipv4.tcp_congestion_control" = "bbr";
+      "net.ipv4.tcp_fin_timeout" = 30;
+      "net.ipv4.tcp_keepalive_time" = 600;
+      "net.ipv4.tcp_mtu_probing" = 1;
+      "net.ipv4.tcp_rmem" = "4096 87380 16777216";
+      "net.ipv4.tcp_wmem" = "4096 65536 16777216";
+    };
+  };
+
+  environment.systemPackages = with pkgs; [
+    dunst
+    libnotify
+    wl-clipboard
+  ];
+
+  hardware = {
+    facter.reportPath = ./facter.json;
+    nvidia.open = true;
+    nvidia-container-toolkit = {
+      enable = true;
+      mount-nvidia-executables = false;
+    };
+  };
+
+  home-manager.users.shika.imports = [
+    ../../modules/nixos/users/shika.nix
+  ];
+
+  networking.hostName = "nixtar";
+
+  programs.nix-ld = {
+    enable = true;
+    libraries = [
+      pkgs.stdenv.cc.cc.lib
+      pkgs.zlib
+      wsl-lib
+    ];
+  };
+
+  services = {
+    openssh = {
+      enable = true;
+      openFirewall = true;
+    };
+    xserver.videoDrivers = [ "nvidia" ];
+  };
+
+  sops = {
+    age = {
+      generateKey = true;
+      keyFile = "/var/lib/sops-nix/key.txt";
+      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    };
+    defaultSopsFile = ../../secrets/nixtar.enc.yaml;
+    defaultSopsFormat = "yaml";
+  };
+
+  users.users.shika = {
+    extraGroups = [ "wheel" ];
+    home = "/home/shika";
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+
+  virtualisation.docker = {
+    autoPrune.enable = true;
+    rootless = {
+      enable = true;
+      setSocketVariable = true;
+      daemon.settings.features.cdi = true;
+    };
+  };
+
+  wsl = {
+    enable = true;
+    defaultUser = "shika";
+    interop.register = true;
+    useWindowsDriver = true;
+  };
+}

--- a/.jjconflict-side-0/hosts/nixtar/facter.json
+++ b/.jjconflict-side-0/hosts/nixtar/facter.json
@@ -1,0 +1,909 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "x86_64-linux",
+  "virtualisation": "wsl",
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 0,
+      "pnp": false,
+      "pnp_id": 0,
+      "smbios_version": 0,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 5184,
+        "bugs": [
+          "cpu_meltdown",
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "l1tf",
+          "mds",
+          "swapgs",
+          "itlb_multihit",
+          "srbds",
+          "mmio_stale_data",
+          "retbleed",
+          "gds",
+          "bhi"
+        ],
+        "cache": 12288,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 6,
+        "cpuid_level": 22,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "arch_perfmon",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "cpuid",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "vmx",
+          "ssse3",
+          "fma",
+          "cx16",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "movbe",
+          "popcnt",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "hypervisor",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "pti",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "tpr_shadow",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "vnmi",
+          "md_clear",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 158,
+        "model_name": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 12,
+        "stepping": 10,
+        "tlb_size": 31165,
+        "units": 16,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 133674,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 2147483648,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:3",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:3",
+        "unix_device_name2": "/dev/sg3",
+        "sysfs_id": "/class/block/sdd",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 25,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-36002248042994cacd691c52f2e08fe01",
+          "/dev/disk/by-id/wwn-0x6002248042994cacd691c52f2e08fe01",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:3",
+          "/dev/disk/by-uuid/6e398549-74bd-406a-b9a6-b458fb49306c",
+          "/dev/sdd"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 23,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 381016,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:1",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:1",
+        "unix_device_name2": "/dev/sg1",
+        "sysfs_id": "/class/block/sdb",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-3600224805b5ac507b80a045bc3303ae1",
+          "/dev/disk/by-id/wwn-0x600224805b5ac507b80a045bc3303ae1",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:1",
+          "/dev/sdb"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 32,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 33,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 34,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 35,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1697,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 27262984,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:2",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:2",
+        "unix_device_name2": "/dev/sg2",
+        "sysfs_id": "/class/block/sdc",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 36,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-3600224800696b95cdd20962287e749ad",
+          "/dev/disk/by-id/wwn-0x600224800696b95cdd20962287e749ad",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:2",
+          "/dev/disk/by-uuid/67edc7a8-a3e4-41bf-a504-20a881a13371",
+          "/dev/sdc"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 37,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 49,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 795880,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:0",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:0",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 38,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-360022480728b63b9f0b8d5e28f1d4859",
+          "/dev/disk/by-id/wwn-0x60022480728b63b9f0b8d5e28f1d4859",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:0",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 39,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 40,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 41,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 42,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 43,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "graphics_card": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["graphics_card", "pci"],
+        "detail": {
+          "command": 7,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "008e", "value": 142 },
+        "driver": "dxgkrnl",
+        "drivers": ["dxgkrnl"],
+        "index": 16,
+        "model": "3D controller",
+        "module_alias": "pci:v00001414d0000008Esv00000000sd00000000bc03sc02i00",
+        "slot": { "bus": 11717888, "number": 0 },
+        "sub_class": { "name": "3D controller", "hex": "0002", "value": 2 },
+        "sysfs_bus_id": "b2cd:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/233d912c-b2cd-41c7-981b-b6574ee392cf/pcib2cd:00/b2cd:00:00.0",
+        "vendor": { "hex": "1414", "value": 5140 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["graphics_card", "pci"],
+        "detail": {
+          "command": 7,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "008e", "value": 142 },
+        "driver": "dxgkrnl",
+        "drivers": ["dxgkrnl"],
+        "index": 19,
+        "model": "3D controller",
+        "module_alias": "pci:v00001414d0000008Esv00000000sd00000000bc03sc02i00",
+        "slot": { "bus": 12877056, "number": 0 },
+        "sub_class": { "name": "3D controller", "hex": "0002", "value": 2 },
+        "sysfs_bus_id": "c47d:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/4686eaaa-c47d-415e-b025-a8a8caf4c9b0/pcic47d:00/c47d:00:00.0",
+        "vendor": { "hex": "1414", "value": 5140 }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 51539607552 }],
+        "attached_to": 0,
+        "index": 15,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 48 },
+          { "type": "phwaddr", "address": 48 }
+        ],
+        "model": "Virtual Ethernet Card 0",
+        "vendor": "Virtual",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/293797f4-beca-4fcf-8341-90c5b230a8db",
+        "device": "Virtual Ethernet Card 0",
+        "driver": "hv_netvsc",
+        "sysfs_bus_id": "293797f4-beca-4fcf-8341-90c5b230a8db",
+        "attached_to": 0,
+        "index": 20,
+        "drivers": ["hv_netvsc"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "unix_device_names": ["eth0"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "driver_info": {
+          "type": "module",
+          "active": true,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["hv_netvsc"],
+          "module_args": [""],
+          "names": ["hv_netvsc"]
+        }
+      }
+    ],
+    "network_interface": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 44,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 48 },
+          { "type": "phwaddr", "address": 48 }
+        ],
+        "attached_to": 20,
+        "driver": "hv_netvsc",
+        "index": 45,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/293797f4-beca-4fcf-8341-90c5b230a8db",
+        "sysfs_id": "/class/net/eth0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["hv_netvsc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["eth0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Generic system peripheral",
+          "hex": "0008",
+          "value": 8
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "105a", "value": 4186 },
+        "driver": "virtio-pci",
+        "drivers": ["virtio-pci"],
+        "index": 18,
+        "model": "System peripheral",
+        "module_alias": "pci:v00001AF4d0000105Asv00001AF4sd00000040bc08sc80i00",
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 14778112, "number": 0 },
+        "sub_class": {
+          "name": "System peripheral",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "0040", "value": 64 },
+        "sub_vendor": { "hex": "1af4", "value": 6900 },
+        "sysfs_bus_id": "e17f:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/72e2a6d5-e17f-4d7c-a780-7ae0830f010e/pcie17f:00/e17f:00:00.0",
+        "vendor": { "hex": "1af4", "value": 6900 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "1043", "value": 4163 },
+        "driver": "virtio-pci",
+        "drivers": ["virtio-pci"],
+        "index": 17,
+        "model": "SCSI storage controller",
+        "module_alias": "pci:v00001AF4d00001043sv00001AF4sd00000040bc01sc00i00",
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 5603840, "number": 0 },
+        "sub_class": {
+          "name": "SCSI storage controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "0040", "value": 64 },
+        "sub_vendor": { "hex": "1af4", "value": 6900 },
+        "sysfs_bus_id": "5582:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/c4b741f5-5582-4c98-8f8b-2e082933c396/pci5582:00/5582:00:00.0",
+        "vendor": { "hex": "1af4", "value": 6900 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "class_list": ["storage_controller"],
+        "device": "Storage 0",
+        "driver": "hv_storvsc",
+        "driver_info": {
+          "type": "module",
+          "active": true,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["hv_storvsc"],
+          "module_args": [""],
+          "names": ["hv_storvsc"]
+        },
+        "drivers": ["hv_storvsc"],
+        "index": 21,
+        "model": "Virtual Storage 0",
+        "sub_class": {
+          "name": "Storage controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sysfs_bus_id": "fd1d2cbd-ce7c-535c-966b-eb5f811c95f0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0",
+        "vendor": "Virtual"
+      }
+    ],
+    "system": { "form_factor": "laptop" },
+    "unknown": [
+      {
+        "attached_to": 18,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["unknown"],
+        "device": "",
+        "driver": "virtiofs",
+        "drivers": ["virtiofs"],
+        "index": 22,
+        "model": "Virtio Unclassified device",
+        "module_alias": "virtio:d0000001Av00001AF4",
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "virtio1",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/72e2a6d5-e17f-4d7c-a780-7ae0830f010e/pcie17f:00/e17f:00:00.0/virtio1",
+        "vendor": "Virtio"
+      },
+      {
+        "attached_to": 17,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["unknown"],
+        "device": "",
+        "driver": "virtio_console",
+        "drivers": ["virtio_console"],
+        "index": 23,
+        "model": "Virtio Unclassified device",
+        "module_alias": "virtio:d00000003v00001AF4",
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "virtio0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/c4b741f5-5582-4c98-8f8b-2e082933c396/pci5582:00/5582:00:00.0/virtio0",
+        "vendor": "Virtio"
+      }
+    ]
+  }
+}

--- a/.jjconflict-side-0/hosts/telsha/darwin-configuration.nix
+++ b/.jjconflict-side-0/hosts/telsha/darwin-configuration.nix
@@ -1,0 +1,28 @@
+{
+  imports = [
+    ../../modules/darwin/profiles/distributed.nix
+    ../../modules/darwin/profiles/workstation.nix
+  ];
+
+  home-manager.users.shikanimedeva.imports = [
+    ../../modules/darwin/users/shikanimedeva.nix
+  ];
+
+  networking.hostName = "telsha";
+
+  sops = {
+    age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    defaultSopsFile = ../../secrets/telsha.enc.yaml;
+    defaultSopsFormat = "yaml";
+  };
+
+  system.primaryUser = "shikanimedeva";
+
+  users.users.shikanimedeva = {
+    home = "/Users/shikanimedeva";
+    name = "shikanimedeva";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+}

--- a/.jjconflict-side-0/infra/shikanime-github/.terraform.lock.hcl
+++ b/.jjconflict-side-0/infra/shikanime-github/.terraform.lock.hcl
@@ -1,0 +1,51 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.4.0"
+  constraints = "~> 6.4"
+  hashes = [
+    "h1:B1q5+Ub1G3zJa9y474Fg40eo/N04/vOSeaf3dWaCG0I=",
+    "h1:YiGCvjr7R77HGTzw81legWicEHApVTli8O+ooDpLexE=",
+    "h1:sJvuRMYWJ/ykZXTuoCuocHvx06hTwDVrXVVXq1814bw=",
+    "zh:00f431c2a2510efcb1115442dda5e90815bcb16e1a3301679ade0139fa963d3b",
+    "zh:12a862f4317b3cb65682c1b687650cd91eeee99e63774bdcfa8bcfc64bad097b",
+    "zh:226d5e09ff27f94cb9336089181d26f85cb30219b863a579597f2e107f37de49",
+    "zh:402ecaa5add568a52ee01d816810f3b90f693be35c680fcdc9b6284bf55326f1",
+    "zh:60e3bdd9fbefb3c1d790bc08889c1dc0e83636b82284faaa709411aa4f96bb9f",
+    "zh:625099eeff2f8aaecd22a24a451b326828435c8f9de86f2e5e99872e7b467fa7",
+    "zh:79e8b665421009df2260f50e10da1f7a7863b557ece96e2b07dfd2fad1e86fcd",
+    "zh:98e471fefc93dcfedeec750c694110db7d3331dc3a256191d30b9d2f70d12157",
+    "zh:a17702765e1fa92d1c288ddfd97075819ad61b344b341be7e09c554c841a6d9e",
+    "zh:ca72ccf40624ae26bf4660d8dd84a51638f0a1e78d5f19fdfaafaef97f838af6",
+    "zh:d009ab5527d45c44c424d26cd2eb51a5a6a6448f3fb1023b675789588cc08d64",
+    "zh:e5811be1e942a75b14dfcd3e03523d8df60cfbde0d7e24d75e78480a02a58949",
+    "zh:e6008ad28225ad6996b06bcd7f3070863329df406a56754e7fb9c31d6301ace4",
+    "zh:f1d93f56ea4f87183a5de4780704907605851d95a2d285a9ec755bf784c5569c",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}
+
+provider "registry.opentofu.org/scaleway/scaleway" {
+  version     = "2.48.0"
+  constraints = "~> 2.43"
+  hashes = [
+    "h1:5BbGEXuyORjQ9adWey72qJkOCj9zjwly/aUcwXXXqvo=",
+    "h1:LczipXZujiPUPClltqtt6pDhAxQ7s35v21Fe46hflXU=",
+    "h1:ra/AlSZHIX8gBGtODsiaUp+V8iXpNIL1BZlxDLPc1Es=",
+    "zh:161e4a2981240645b584acf13a76563ca90fff107efd983cbf7db74bfc3462b6",
+    "zh:2cf0df5b147aa0fd50953e00bee8fea56e4ddb0630e7cbc7443619933c37522f",
+    "zh:4cc775235b8b3d0847c4bf0d36c68ced5a1c26628c62abd1d53ccbdbc5c10ff8",
+    "zh:8611025a842c7cd5f629246197157c11b2c77048066b076ccd448e8d9f764213",
+    "zh:8eae8559fdd3f9c3a71bb0c9dfd23084ee0c798ffff779e5836e44ed5cc68948",
+    "zh:c87e86288f4bb128533ff6719959547a3941c83315ede709a4586369c7558090",
+    "zh:cc4f1738b9be10f4106f4e1ba9bdabee64eae6f7c6be937275f019f409fd6390",
+    "zh:cd9610dac94aba5891b4487635100ba893821fd79b3c5dc65c95a8c88db67243",
+    "zh:e36e2eda9bc52efc4053e333aa58be81988651d77b3dbf894c885cd81dec3f32",
+    "zh:ec23c160523dfa2d13d41be83046dbd4ce9e142fd759e73c93f76029869f7da7",
+    "zh:ec4c3a614719e8bdfc50c4c94bcabeb5c8dc14e0658cbc2041470dfb6f86c8a2",
+    "zh:f25c4287fa7c921f7a898543cc8fc7c485bb4fe2f730180f5302cb314bc9ec6a",
+    "zh:f6efe46bfd0716eaa153acad7fc126609ea2d00b50d90554e3f594e2e51578ad",
+    "zh:fb672d0ed1a6b01ed2436988071e6ae92d18b3b22271638c6bd5d32a2688695b",
+  ]
+}

--- a/.jjconflict-side-0/infra/shikanime-github/actions.tf
+++ b/.jjconflict-side-0/infra/shikanime-github/actions.tf
@@ -1,0 +1,46 @@
+resource "github_actions_secret" "cachix_auth_token" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "CACHIX_AUTH_TOKEN"
+  plaintext_value = var.cachix.auth_token
+}
+
+resource "github_actions_secret" "gpg_passphrase" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "GPG_PASSPHRASE"
+  plaintext_value = var.operator.gpg_passphrase
+}
+
+resource "github_actions_secret" "gpg_private_key" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "GPG_PRIVATE_KEY"
+  plaintext_value = var.operator.gpg_private_key
+}
+
+resource "github_actions_secret" "operator_private_key" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "OPERATOR_PRIVATE_KEY"
+  plaintext_value = var.operator.ssh_private_key
+}
+
+resource "github_actions_variable" "operator" {
+  for_each      = var.repositories
+  repository    = each.value
+  variable_name = "OPERATOR_APP_ID"
+  value         = var.apps.operator
+}
+
+resource "github_actions_secret" "wakabox_github_token" {
+  repository      = var.repositories.shikanime
+  secret_name     = "WAKABOX_GITHUB_TOKEN"
+  plaintext_value = var.wakabox.github_token
+}
+
+resource "github_actions_secret" "wakatime_api_key" {
+  repository      = var.repositories.shikanime
+  secret_name     = "WAKATIME_API_KEY"
+  plaintext_value = var.wakabox.wakatime_api_key
+}

--- a/.jjconflict-side-0/infra/shikanime-github/repo.tf
+++ b/.jjconflict-side-0/infra/shikanime-github/repo.tf
@@ -1,0 +1,65 @@
+data "github_repository" "repo" {
+  for_each = var.repositories
+  name     = each.value
+}
+
+resource "github_repository_ruleset" "main" {
+  for_each = {
+    for k, v in var.repositories :
+    k => v if !data.github_repository.repo[k].private
+  }
+  name        = "Main branch protections"
+  repository  = each.value
+  target      = "branch"
+  enforcement = "active"
+  conditions {
+    ref_name {
+      include = ["refs/heads/main"]
+      exclude = []
+    }
+  }
+  rules {
+    required_linear_history = true
+    required_signatures     = true
+  }
+}
+
+resource "github_repository_ruleset" "landing" {
+  for_each = {
+    for k, v in var.repositories :
+    k => v if !data.github_repository.repo[k].private
+  }
+  name        = "Landing protections"
+  repository  = each.value
+  target      = "branch"
+  enforcement = "active"
+  conditions {
+    ref_name {
+      include = ["refs/heads/main"]
+      exclude = []
+    }
+  }
+  bypass_actors {
+    actor_id    = 2
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+  bypass_actors {
+    actor_id    = var.apps.operator
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+  rules {
+    pull_request {
+      require_code_owner_review         = true
+      required_review_thread_resolution = true
+    }
+    required_status_checks {
+      required_check {
+        context        = "check"
+        integration_id = var.apps.github_actions
+      }
+      strict_required_status_checks_policy = true
+    }
+  }
+}

--- a/.jjconflict-side-0/infra/shikanime-github/variable.tf
+++ b/.jjconflict-side-0/infra/shikanime-github/variable.tf
@@ -1,0 +1,60 @@
+variable "apps" {
+  type = object({
+    github_actions = number
+    operator       = number
+  })
+  description = "Application names"
+  default = {
+    github_actions = 15368
+    operator       = 1095999
+  }
+}
+
+variable "cachix" {
+  type = object({
+    auth_token = string
+  })
+  description = "Cachix configuration secrets"
+  sensitive   = true
+}
+
+variable "operator" {
+  type = object({
+    gpg_passphrase  = string
+    gpg_private_key = string
+    ssh_private_key = string
+  })
+  description = "Operator configuration secrets"
+  sensitive   = true
+}
+
+variable "repositories" {
+  type = object({
+    algorithm        = string
+    curriculum-vitae = string
+    features         = string
+    manifests        = string
+    myawesomelist    = string
+    niximgs          = string
+    shikanime        = string
+  })
+  description = "GitHub repositories"
+  default = {
+    algorithm        = "algorithm"
+    curriculum-vitae = "curriculum-vitae"
+    features         = "features"
+    manifests        = "manifests"
+    myawesomelist    = "myawesomelist"
+    niximgs          = "niximgs"
+    shikanime        = "shikanime"
+  }
+}
+
+variable "wakabox" {
+  type = object({
+    github_token     = string
+    wakatime_api_key = string
+  })
+  description = "Wakabox configuration secrets"
+  sensitive   = true
+}

--- a/.jjconflict-side-0/infra/shikanime-github/version.tf
+++ b/.jjconflict-side-0/infra/shikanime-github/version.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "~> 1.8"
+  cloud {
+    hostname     = "app.terraform.io"
+    organization = "shikanime-studio"
+    workspaces {
+      name = "shikanime-github"
+    }
+  }
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.4"
+    }
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2.43"
+    }
+  }
+}
+
+provider "github" {}

--- a/.jjconflict-side-0/infra/shikanime-google-cloud/.terraform.lock.hcl
+++ b/.jjconflict-side-0/infra/shikanime-google-cloud/.terraform.lock.hcl
@@ -1,0 +1,104 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = ">= 3.43.0, >= 3.53.0, >= 4.28.0, >= 5.22.0, ~> 5.36, < 6.0.0"
+  hashes = [
+    "h1:fwPyxJ8zBHeuEyv87dn8YkRHAqXGbJ9AqLN1I8loPr8=",
+    "zh:0931f08e81f220ae3132169cfa4ed8e9d8d2045f29ca914afd8ee9e3e9cf56e0",
+    "zh:31afa45a4c8a0fd4abff564ecff8b69a97ac1813ead61c12f5f0bf5d33cec7f1",
+    "zh:536979e437aad59ba41465c9398d8e3d7d3702bfe2a51d80571862d48c817959",
+    "zh:748e14614be32350ece4e9249e09bc1d20e54421983734ded3a0df6d6674ea71",
+    "zh:7c8fe641666603aad6693207c8eaac679b9be15246d77090c73a1a84326d6084",
+    "zh:8095a513a0662323d99c25466b5a291c80b2b0c1857c7c7a7b1159f25dbe4439",
+    "zh:9453db86d14611cab26dba30daf56d1cfef929918207e9e3e78b58299fc8c4fe",
+    "zh:adaa5df5d40060409b6b66136c0ac37b99fb35ac2cf554c584649c236a18d95b",
+    "zh:af2f659b4bd1f44e578f203830bdab829b5e635fcf2a59ffa7e997c16e6611ad",
+    "zh:b75184fe5c162821b0524fa941d6a934c452e815d82e62675bb21bbdc9046dfc",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "5.45.2"
+  constraints = ">= 3.43.0, >= 4.11.0, >= 5.22.0, < 6.0.0"
+  hashes = [
+    "h1:fDebhcS9qedwzLfzm8NPbvOmKd6RvT0yJidzZ9qObsY=",
+    "zh:2df6e40591ceee7ee77d429ea072c9d51fef2dd04015b2604ff332a2af4ac819",
+    "zh:4096af21991ba76ab81c8cb00c0eb0bd4f22619f7e491d60023fb10b8b33bfb1",
+    "zh:44ded286956fff5668f1acbf152b62ca8e6a03abc8df12c5c181bc2ca05b4df7",
+    "zh:7ae19e1b53a0e26bea0acb9a96b4b44038d7c182c3fdd496148fd20e40aa78e1",
+    "zh:81c9812823b78fd1b12bc0acd6dae35bc573944950e09eaf237b2e83b6b587d7",
+    "zh:9db6101421b53b9533807928c651e779f5b8129f4a57ff892bf256c84ba6ed29",
+    "zh:b779729cb08829f621a718ecdfdb503c310ef5411e694996c7cfda7227221134",
+    "zh:c43edb31aee354317a6181272a961965b93722fd18637f38c395af013aa65617",
+    "zh:dbb93970a85f2fe84f650b6a4da694ecb1023a99c3b9bbf6953dccd074fa49ce",
+    "zh:df9d13853269e98651d495571b4d58c883b4386247d0b9c5495c2e82ef721f45",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.3"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:nNa5j1vTtxcpdC2i61O2tRkZjdkBNsxzYXYIx0VNsjc=",
+    "zh:1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac",
+    "zh:65b7f9799b88464d9c2ec529713b7f52ea744275b61a8dc86cdedab1b2dcb933",
+    "zh:80d3e9c95b7b4ae7c54005cd127cae82e5c53d2b7023ef24c147337bac9dadd9",
+    "zh:841b60c07683e4bf456799ccd718896fdafdcc2c49252ae09967f2e74d8c8a03",
+    "zh:8fa1c592a9c78222e35713c6edb3f1f818a4c6f3524a30a209f0a7e919827b68",
+    "zh:bb795cc1429e09466840c09d39a28edf1db5070b1ec76822fc1173906a264572",
+    "zh:da1784818a89bea29dfe660632f0060a7a843e4e564d74435fbeca002b0f7d2a",
+    "zh:f409bf21b1cdaa6dac47cd79806f3d93f67e9507fe4dbf33b0165335f53bc2e1",
+    "zh:fbea7a1ff84b430ba9594698e93196d81d03e4036de3d1cafccb2a96d5b38581",
+    "zh:fbf0c84663a7e85881388d7d71ac862184f05fbf2d17ecf76bc5d3d7503ea260",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.7.1"
+  constraints = ">= 2.2.0"
+  hashes = [
+    "h1:HxqzkbeZlX7e/UfK6DA6SBYmd1+mURGRsRQHimwrpEM=",
+    "zh:1011387a5127d46e2bf0bd5124a8469506272b2110613d9eb80d178f94bd67a9",
+    "zh:28785c36d6dc331d49e8bf6a30d4ba21ae4378f5d98c43c0aeb42f51efb2e42f",
+    "zh:50fc0e52f0255950404681455420344a16263f91622bd481954606e6e3be9eb2",
+    "zh:563f22c53f40e41cfffdcfac32a9292292c10582183c3f1dd85770cf806bfce9",
+    "zh:586a5615898d369374d4bd7d70bc013cffe7553d3e14638f169a3f745665fee1",
+    "zh:6275f6e5697993048ac088715484a9a5e919682651e098a5ac31e567216bf102",
+    "zh:95a44bb3f012da1e036936d60df2d08f5942a96cb912fc23432d2ee050857527",
+    "zh:a5fe6b0e586645a88d98738739fec40fd7ad83dbc63fe66ff6327aee2dc07f11",
+    "zh:ea57886899b6baf466f3ff978f4482d2fd7fa049c42509cc819431375cddd5bd",
+    "zh:f021cfbe23bdb32738f170c1ae736ffb769a2fa3dcafd0f9906155c2e21377e4",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:Utnw/bDwy8p8v/i08Yx0oHdBQXwdJhCfAPZuSWX8YeQ=",
+    "zh:374c28bafc43cd65e578cb209efc9eee4c1cec7618f451528e928db98059e8c8",
+    "zh:6a2982e70fbc2ab2668d624c648ef2eb32243c1a1185246b03991a7a21326db9",
+    "zh:af83169c21bb13f141510a349e1f70cf7d893247a269bd71cad74dd22f1df0f5",
+    "zh:b81a5bedc91a1a81b938c393247248d6c3d1bd8ea685541f9c858908c0afb6b3",
+    "zh:de15486244af2d29d44d510d647cd6e0b1408e89952261013c572b7c9bfd744b",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.12.1"
+  constraints = ">= 0.5.0"
+  hashes = [
+    "h1:BeB0tURFcd5MQIjLdqpZSFYAXpj3WBI8qstoCHW0WYA=",
+    "zh:50a9b67d5f5f42adbdb7712f67858aa64b5670070f6710751239b535fb48a4df",
+    "zh:5a846fae035e363aed75b966d64a56f3489a38083e8407aaa656730437f53ed7",
+    "zh:6767f1fc8a679b48eaa4cd114da0d8185fb3546375f3a0fb3728f10fa3dbc551",
+    "zh:85d3da407c828bf057cbc0e86c75ef3d0f9f74a73c4ea1b4aef18e33f41092b1",
+    "zh:9180721325139431112c638f5382a740ff219782f81d6346cdff5bccc418a43f",
+    "zh:9ba9989f905a64db1409a9a57649549c89c7aedfb55ae399a7fa9411aafaadac",
+    "zh:b3d9e7afb6a742e9be0541bc434b00d849fdfab0b4b859ceb0296c26c541af15",
+    "zh:c87da712d718acd9dd03f544b020c320699cb29df197be4f74783e3c3d80fc17",
+    "zh:cb1abe07638ef6d7b41d0e86dfb12d60a513aca3395a5da7191947f7459821dd",
+    "zh:ecff2e823ef49eda03663fa8ee8bdc17d27cd419dbdacbf1719f38812dbf417e",
+  ]
+}

--- a/.jjconflict-side-0/infra/shikanime-google-cloud/iam.tf
+++ b/.jjconflict-side-0/infra/shikanime-google-cloud/iam.tf
@@ -1,0 +1,59 @@
+resource "google_iam_workload_identity_pool" "tfc" {
+  project                   = module.project.project_id
+  workload_identity_pool_id = "tfc-pool"
+  display_name              = "TFC"
+  description               = "Identity pool for Terraform Cloud Dynamic Credentials integration"
+}
+
+resource "google_iam_workload_identity_pool_provider" "tfc" {
+  project                            = module.project.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.tfc.workload_identity_pool_id
+  workload_identity_pool_provider_id = "tfc-provider"
+  display_name                       = "TFC"
+  description                        = "OIDC identity pool provider for Terraform Cloud Dynamic Credentials integration"
+  # Use condition to make sure only token generated for a specific TFC Org can be used across org workspaces
+  attribute_condition = "attribute.terraform_organization_id == \"${var.terraform_organization}\""
+  attribute_mapping = {
+    "google.subject"                        = "assertion.sub"
+    "attribute.aud"                         = "assertion.aud"
+    "attribute.terraform_run_phase"         = "assertion.terraform_run_phase"
+    "attribute.terraform_project_id"        = "assertion.terraform_project_id",
+    "attribute.terraform_project_name"      = "assertion.terraform_project_name",
+    "attribute.terraform_workspace_id"      = "assertion.terraform_workspace_id"
+    "attribute.terraform_workspace_name"    = "assertion.terraform_workspace_name"
+    "attribute.terraform_organization_id"   = "assertion.terraform_organization_id"
+    "attribute.terraform_organization_name" = "assertion.terraform_organization_name"
+    "attribute.terraform_run_id"            = "assertion.terraform_run_id"
+    "attribute.terraform_full_workspace"    = "assertion.terraform_full_workspace"
+  }
+  oidc {
+    issuer_uri = "https://app.terraform.io/"
+  }
+}
+
+module "service_accounts_iam" {
+  source  = "terraform-google-modules/iam/google//modules/service_accounts_iam"
+  version = "~> 7.6"
+
+  service_accounts = module.service_accounts.emails_list
+  project          = module.project.project_id
+  bindings = {
+    "roles/iam.workloadIdentityUser" = [
+      "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.tfc.name}/attribute.terraform_project_id/${var.terraform_project}"
+    ]
+  }
+}
+
+module "projects_iam" {
+  source  = "terraform-google-modules/iam/google//modules/projects_iam"
+  version = "~> 7.7"
+
+  projects = [
+    module.project.project_id,
+  ]
+
+  bindings = {
+    "roles/owner"  = var.members.owner,
+    "roles/editor" = var.members.cloud,
+  }
+}

--- a/.jjconflict-side-0/infra/shikanime-google-cloud/install.sh
+++ b/.jjconflict-side-0/infra/shikanime-google-cloud/install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+output=$(tofu -chdir="$(dirname "$0")/../shikanime-hcp" output -json)
+projects=$(echo "$output" | jq -r '.projects.value')
+
+echo "$projects" | jq -r '.studio' >"$(dirname "$0")/studio.tfvars.json"
+echo "$projects" | jq -r '.["studio-labs"]' >"$(dirname "$0")/studio-labs.tfvars.json"

--- a/.jjconflict-side-0/infra/shikanime-google-cloud/project.tf
+++ b/.jjconflict-side-0/infra/shikanime-google-cloud/project.tf
@@ -1,0 +1,10 @@
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 15.0"
+
+  name            = var.name
+  org_id          = var.org
+  billing_account = var.billing_account
+  project_sa_name = "project-operator"
+  activate_apis   = var.enabled_apis
+}

--- a/.jjconflict-side-0/infra/shikanime-google-cloud/sa.tf
+++ b/.jjconflict-side-0/infra/shikanime-google-cloud/sa.tf
@@ -1,0 +1,12 @@
+module "service_accounts" {
+  source  = "terraform-google-modules/service-accounts/google"
+  version = "~> 3.0"
+
+  project_id   = module.project.project_id
+  names        = ["infra-operator"]
+  display_name = "Infrastructure Operator Service Account"
+
+  project_roles = [
+    "${module.project.project_id}=>roles/editor",
+  ]
+}

--- a/.jjconflict-side-0/infra/shikanime-google-cloud/variable.tf
+++ b/.jjconflict-side-0/infra/shikanime-google-cloud/variable.tf
@@ -1,0 +1,42 @@
+variable "name" {
+  type        = string
+  description = "The name for the project"
+}
+
+variable "org" {
+  type        = string
+  description = "The organization ID"
+}
+
+variable "billing_account" {
+  type        = string
+  description = "The ID of the billing account to associate this project with"
+}
+
+variable "location" {
+  type        = string
+  description = "The location for the resources"
+}
+
+variable "enabled_apis" {
+  type        = list(string)
+  description = "List of APIs to enable"
+}
+
+variable "members" {
+  type = object({
+    owner = list(string)
+    cloud = list(string)
+  })
+  description = "List of members to grant roles"
+}
+
+variable "terraform_project" {
+  type        = string
+  description = "The HCP project ID"
+}
+
+variable "terraform_organization" {
+  type        = string
+  description = "The HCP organization ID"
+}

--- a/.jjconflict-side-0/infra/shikanime-google-cloud/version.tf
+++ b/.jjconflict-side-0/infra/shikanime-google-cloud/version.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.0"
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "shikanime-studio"
+    workspaces {
+      prefix = "shikanime-google-cloud-"
+    }
+  }
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.36"
+    }
+  }
+}

--- a/.jjconflict-side-0/infra/shikanime-hcp/output.tf
+++ b/.jjconflict-side-0/infra/shikanime-hcp/output.tf
@@ -1,0 +1,53 @@
+output "projects" {
+  value = {
+    studio = {
+      name            = "shikanime-studio"
+      org             = ""
+      billing_account = "018C2E-353598-F0F3A5"
+      location        = "europe-west1"
+      enabled_apis = [
+        "artifactregistry.googleapis.com",
+        "cloudresourcemanager.googleapis.com",
+        "compute.googleapis.com",
+        "iam.googleapis.com",
+        "iamcredentials.googleapis.com",
+        "run.googleapis.com",
+        "serviceusage.googleapis.com",
+      ]
+      members = {
+        owner = ["user:shikalegend@gmail.com"]
+        cloud = ["group:shikanime-studio-cloud@googlegroups.com"]
+      }
+      terraform_project      = "prj-NCaGDhtLX1Qaox7L"
+      terraform_organization = "org-ZuQrk9oiA78Cy3Ls"
+    }
+    studio-labs = {
+      name            = "shikanime-studio-labs"
+      org             = ""
+      billing_account = "018C2E-353598-F0F3A5"
+      location        = "europe-west1"
+      enabled_apis = [
+        "aiplatform.googleapis.com",
+        "artifactregistry.googleapis.com",
+        "cloudresourcemanager.googleapis.com",
+        "compute.googleapis.com",
+        "datacatalog.googleapis.com",
+        "dataflow.googleapis.com",
+        "dataform.googleapis.com",
+        "datalineage.googleapis.com",
+        "iam.googleapis.com",
+        "iamcredentials.googleapis.com",
+        "notebooks.googleapis.com",
+        "run.googleapis.com",
+        "serviceusage.googleapis.com",
+        "visionai.googleapis.com",
+      ]
+      members = {
+        owner = ["user:shikalegend@gmail.com"]
+        cloud = ["group:shikanime-studio-cloud@googlegroups.com"]
+      }
+      terraform_project      = "prj-qGuaiqVzKAr318n6"
+      terraform_organization = "org-ZuQrk9oiA78Cy3Ls"
+    }
+  }
+}

--- a/.jjconflict-side-0/infra/shikanime-hcp/version.tf
+++ b/.jjconflict-side-0/infra/shikanime-hcp/version.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.8"
+  cloud {
+    hostname     = "app.terraform.io"
+    organization = "shikanime-studio"
+    workspaces {
+      name = "shikanime-hcp"
+    }
+  }
+}

--- a/.jjconflict-side-0/modules/darwin/profiles/base.nix
+++ b/.jjconflict-side-0/modules/darwin/profiles/base.nix
@@ -1,0 +1,74 @@
+{ config, pkgs, ... }:
+
+let
+  # Defaults (cpu, cpufreq, diskstats, filesystem, loadavg, meminfo,
+  # netdev, stat, systemd, processes, thermal_zone) — same set the
+  # victoria-metrics-k8s-stack node-exporter DaemonSet uses on servers.
+  vmagentConfig = pkgs.writeText "vmagent.yml" ''
+    scrape_configs:
+      - job_name: "node"
+        static_configs:
+          - targets: ["127.0.0.1:9100"]
+      - job_name: "comin"
+        static_configs:
+          - targets: ["127.0.0.1:4243"]
+  '';
+in
+{
+  imports = [
+    ./minimal.nix
+  ];
+
+  nix = {
+    extraOptions = ''
+      !include ${config.sops.templates.nix-config.path}
+    '';
+    settings.experimental-features = "flakes nix-command";
+  };
+
+  sops = {
+    secrets.nix-access-token = { };
+    templates.nix-config.content = ''
+      extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}"
+    '';
+  };
+
+  services.comin = {
+    enable = true;
+    # Node exporter listens on localhost only — vmagent scrapes from 127.0.0.1.
+    exporter.listen_address = "127.0.0.1";
+    remotes = [
+      {
+        name = "origin";
+        url = "https://github.com/shikanime-labs/machines.git";
+      }
+    ];
+  };
+
+  launchd.daemons = {
+    node-exporter = {
+      command = "${pkgs.prometheus-node-exporter}/bin/node_exporter --web.listen-address=127.0.0.1:9100";
+      serviceConfig = {
+        Label = "org.nixos.node-exporter";
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/var/log/node-exporter.log";
+        StandardErrorPath = "/var/log/node-exporter.log";
+      };
+    };
+    vmagent = {
+      command = ''
+        ${pkgs.victoriametrics}/bin/vmagent \
+          -promscrape.config=${vmagentConfig} \
+          -remoteWrite.url=https://telemetry.taila659a.ts.net/insert/0/prometheus
+      '';
+      serviceConfig = {
+        Label = "org.nixos.vmagent";
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/var/log/vmagent.log";
+        StandardErrorPath = "/var/log/vmagent.log";
+      };
+    };
+  };
+}

--- a/.jjconflict-side-0/modules/darwin/profiles/distributed.nix
+++ b/.jjconflict-side-0/modules/darwin/profiles/distributed.nix
@@ -1,0 +1,56 @@
+{ config, ... }:
+
+let
+  mkHostname = hostName: "${hostName}.taila659a.ts.net";
+
+  mkBeelinkBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "x86_64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 4;
+    speedFactor = 2;
+    supportedFeatures = [
+      "nixos-test"
+      "benchmark"
+      "big-parallel"
+      "kvm"
+    ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkRpiBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "aarch64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 2;
+    speedFactor = 1;
+    supportedFeatures = [ "nixos-test" ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkBuildMachines = machines: builtins.filter (m: config.networking.hostName != m.hostName) machines;
+in
+{
+  nix = {
+    buildMachines = mkBuildMachines [
+      (mkBeelinkBuildMachine "ashira")
+      (mkBeelinkBuildMachine "manash")
+      (mkBeelinkBuildMachine "nalsha")
+      (mkRpiBuildMachine "fushi")
+      (mkRpiBuildMachine "minish")
+      (mkRpiBuildMachine "nemishi")
+    ];
+
+    distributedBuilds = true;
+
+    linux-builder = {
+      enable = false;
+      ephemeral = true;
+      systems = [ "aarch64-linux" ];
+    };
+
+    settings.builders-use-substitutes = true;
+  };
+}

--- a/.jjconflict-side-0/modules/darwin/profiles/minimal.nix
+++ b/.jjconflict-side-0/modules/darwin/profiles/minimal.nix
@@ -1,0 +1,32 @@
+{
+  # Make home-manager use packages from system
+  home-manager = {
+    backupFileExtension = "backup-before-nix";
+    useGlobalPkgs = true;
+    useUserPackages = true;
+  };
+
+  nix = {
+    gc = {
+      automatic = true;
+      options = "--delete-older-than 30d";
+      interval = [ { Weekday = 7; } ];
+    };
+
+    optimise = {
+      automatic = true;
+      interval = [ { Weekday = 7; } ];
+    };
+
+    settings = {
+      download-buffer-size = 524288000;
+      trusted-users = [ "@admin" ];
+    };
+  };
+
+  # This value determines the Darwin release from which the default
+  # settings for stateful data, like file locations and database versions
+  # on your system were taken It‘s perfectly fine and recommended to leave
+  # this value at the release version of the first install of this system
+  system.stateVersion = 6;
+}

--- a/.jjconflict-side-0/modules/darwin/profiles/workstation.nix
+++ b/.jjconflict-side-0/modules/darwin/profiles/workstation.nix
@@ -1,0 +1,59 @@
+{
+  imports = [
+    ./base.nix
+  ];
+
+  homebrew = {
+    enable = true;
+    enableZshIntegration = true;
+    brews = [
+      "mas"
+      "mpv"
+      "openssl"
+      "pinentry-mac"
+      "pinentry"
+      "pkg-config"
+    ];
+    casks = [
+      "affinity"
+      "android-studio"
+      "appcleaner"
+      "dbeaver-community"
+      "discord"
+      "element"
+      "firefox"
+      "google-chrome"
+      "google-drive"
+      "jellyfin-media-player"
+      "lm-studio"
+      "macfuse"
+      "mattermost"
+      "microsoft-edge"
+      "microsoft-teams"
+      "obs"
+      "rancher"
+      "spotify"
+      "syncthing-app"
+      "tailscale-app"
+      "transmission"
+      "windows-app"
+      "wireshark-app"
+      "xquartz"
+      "zen"
+      "zoom"
+    ];
+    masApps = {
+      Amphetamine = 937984704;
+      Bitwarden = 1352778147;
+      Velja = 1607635845;
+      Xcode = 497799835;
+    };
+  };
+
+  programs.zsh.enable = true;
+
+  programs.gnupg.agent = {
+    enable = true;
+    enableSSHSupport = true;
+  };
+}

--- a/.jjconflict-side-0/modules/darwin/users/shikanimedeva.nix
+++ b/.jjconflict-side-0/modules/darwin/users/shikanimedeva.nix
@@ -1,0 +1,85 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  toDhall = generators.toDhall { };
+in
+{
+  imports = [
+    ../../../modules/home/ai.nix
+    ../../../modules/home/base.nix
+    ../../../modules/home/cloud.nix
+    ../../../modules/home/fontconfig.nix
+    ../../../modules/home/ghostty.nix
+    ../../../modules/home/helix.nix
+    ../../../modules/home/starship.nix
+    ../../../modules/home/vcs.nix
+    ../../../modules/home/workstation.nix
+    ../../../modules/home/zed-editor.nix
+  ];
+
+  identities = {
+    enable = true;
+
+    ghstack.enable = true;
+
+    glab.enable = true;
+
+    gouv = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native"
+      ];
+    };
+
+    operator-6o = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/operator6o";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/operator6o"
+      ];
+    };
+
+    shikanime.enable = true;
+  };
+
+  home.sessionVariables.SSH_AUTH_SOCK = "${config.home.homeDirectory}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock";
+
+  programs = {
+    bash.enable = true;
+
+    docker-cli = {
+      contexts.rancher-desktop = {
+        Endpoints = {
+          docker = {
+            Host = "unix://${config.home.homeDirectory}/.rd/docker.sock";
+            SkipTLSVerify = false;
+          };
+        };
+        Metadata.Description = "Rancher Desktop moby context";
+      };
+      settings = {
+        credsStore = "osxkeychain";
+        currentContext = "rancher-desktop";
+      };
+    };
+
+    zsh.enable = true;
+  };
+
+  sops = {
+    age.keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
+    defaultSopsFile = ../../../secrets/shikanime.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets.cachix-token = { };
+    templates.cachix-config.content = toDhall {
+      authToken = config.sops.placeholder.cachix-token;
+      hostname = "https://cachix.org";
+    };
+  };
+
+  xdg.configFile."cachix/cachix.dhall".source =
+    config.lib.file.mkOutOfStoreSymlink config.sops.templates.cachix-config.path;
+}

--- a/.jjconflict-side-0/modules/flake/darwin.nix
+++ b/.jjconflict-side-0/modules/flake/darwin.nix
@@ -1,0 +1,29 @@
+{ self, ... }:
+{ inputs, ... }:
+
+{
+  flake = {
+    darwinConfigurations.telsha = inputs.nix-darwin.lib.darwinSystem {
+      pkgs = import inputs.nixpkgs {
+        system = "aarch64-darwin";
+        config.allowUnfree = true;
+      };
+      modules = [
+        ../../hosts/telsha/darwin-configuration.nix
+        inputs.home-manager.darwinModules.default
+        inputs.comin.darwinModules.comin
+        inputs.sops-nix.darwinModules.default
+        {
+          home-manager.sharedModules = [
+            inputs.catppuccin.homeModules.default
+            inputs.colemak.homeModules.default
+            inputs.devlib.homeModules.default
+            inputs.identities.homeModules.default
+            inputs.sops-nix.homeModules.default
+          ];
+        }
+      ];
+    };
+    packages.aarch64-darwin.telsha = self.darwinConfigurations.telsha.system;
+  };
+}

--- a/.jjconflict-side-0/modules/flake/devenv.nix
+++ b/.jjconflict-side-0/modules/flake/devenv.nix
@@ -1,0 +1,197 @@
+{ inputs, ... }:
+
+{
+  perSystem =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      toml = pkgs.formats.toml { };
+    in
+    {
+      devenv.shells.default = {
+        imports = [
+          inputs.devlib.devenvModules.git
+          inputs.devlib.devenvModules.nix
+          inputs.devlib.devenvModules.opentofu
+          inputs.devlib.devenvModules.shell
+          inputs.devlib.devenvModules.shikanime
+          inputs.identities.devenvModules.default
+        ];
+
+        identities = {
+          enable = true;
+          ishtar.enable = true;
+          nixtar.enable = true;
+          telsha.enable = true;
+        };
+
+        github = {
+          settings.workflows = {
+            integration = {
+              jobs.skaffold = {
+                needs = [ "nix" ];
+                secrets.CACHIX_AUTH_TOKEN = "\${{ secrets.CACHIX_AUTH_TOKEN }}";
+              };
+              on.workflow_call.secrets.CACHIX_AUTH_TOKEN.required = lib.mkDefault true;
+            };
+
+            release = {
+              jobs.skaffold = {
+                needs = [ "nix" ];
+                secrets.CACHIX_AUTH_TOKEN = "\${{ secrets.CACHIX_AUTH_TOKEN }}";
+              };
+              on.workflow_call.secrets.CACHIX_AUTH_TOKEN.required = lib.mkDefault true;
+            };
+
+            skaffold.on.workflow_call.secrets.CACHIX_AUTH_TOKEN.required = lib.mkDefault true;
+
+            wakabox = {
+              name = "Wakabox";
+              on.schedule = [
+                { cron = "0 0 * * *"; }
+              ];
+              jobs.wakabox = {
+                runs-on = "ubuntu-latest";
+                steps = [
+                  {
+                    uses = "matchai/waka-box@v5.0.0";
+                    env = {
+                      GH_TOKEN = "\${{ secrets.WAKABOX_GITHUB_TOKEN }}";
+                      GIST_ID = "\${{ vars.WAKABOX_GITHUB_GIST_ID }}";
+                      WAKATIME_API_KEY = "\${{ secrets.WAKATIME_API_KEY }}";
+                    };
+                  }
+                ];
+              };
+              permissions.contents = "read";
+            };
+          };
+
+          workflows.skaffold = {
+            enable = true;
+            settings.setup-nix = {
+              cachix-auth-token = "\${{ secrets.CACHIX_AUTH_TOKEN }}";
+              extra-platforms = "arm64";
+            };
+          };
+        };
+
+        packages =
+          with pkgs;
+          [
+            age
+            skaffold
+          ]
+          ++ lib.optional stdenv.hostPlatform.isLinux nixos-facter;
+
+        sops = {
+          enable = true;
+          settings.creation_rules =
+            let
+              ashira = [
+                "age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph"
+              ];
+              ishtar = [
+                "age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy"
+              ];
+              fushi = [
+                "age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y"
+              ];
+              manash = [
+                "age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64"
+              ];
+              minish = [
+                "age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u"
+              ];
+              nixtar = [
+                "age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl"
+              ];
+              nalsha = [
+                "age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5"
+              ];
+              nemishi = [
+                "age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3"
+              ];
+              telsha = [
+                "age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d"
+              ];
+
+              nishir = ashira ++ fushi ++ manash ++ minish ++ nalsha ++ nemishi;
+
+              workstations = ishtar ++ nixtar ++ telsha;
+
+              identities =
+                config.devenv.shells.default.identities.ishtar.ageKeys
+                ++ config.devenv.shells.default.identities.nixtar.ageKeys
+                ++ config.devenv.shells.default.identities.telsha.ageKeys;
+            in
+            [
+              {
+                path_regex = "secrets/ashira.enc.yaml";
+                age = ashira ++ identities;
+              }
+              {
+                path_regex = "secrets/builder.enc.yaml";
+                age = identities ++ nishir ++ workstations;
+              }
+              {
+                path_regex = "secrets/fushi.enc.yaml";
+                age = fushi ++ identities;
+              }
+              {
+                path_regex = "secrets/ishtar.enc.yaml";
+                age = ishtar ++ identities;
+              }
+              {
+                path_regex = "secrets/machine.enc.yaml";
+                age = identities ++ nishir ++ workstations;
+              }
+              {
+                path_regex = "secrets/manash.enc.yaml";
+                age = manash ++ identities;
+              }
+              {
+                path_regex = "secrets/minish.enc.yaml";
+                age = minish ++ identities;
+              }
+              {
+                path_regex = "secrets/nalsha.enc.yaml";
+                age = nalsha ++ identities;
+              }
+              {
+                path_regex = "secrets/nemishi.enc.yaml";
+                age = nemishi ++ identities;
+              }
+              {
+                path_regex = "secrets/nishir.enc.yaml";
+                age = identities ++ nishir;
+              }
+              {
+                path_regex = "secrets/nixtar.enc.yaml";
+                age = nixtar ++ identities;
+              }
+              {
+                path_regex = "secrets/shikanime.enc.yaml";
+                age = identities;
+              }
+              {
+                path_regex = "secrets/telsha.enc.yaml";
+                age = telsha ++ identities;
+              }
+            ];
+        };
+
+        treefmt.config.programs.typos.configFile =
+          let
+            configFile = toml.generate "typos.toml" {
+              default.extend-words.facter = "facter";
+            };
+          in
+          toString configFile;
+      };
+    };
+}

--- a/.jjconflict-side-0/modules/flake/nixos.nix
+++ b/.jjconflict-side-0/modules/flake/nixos.nix
@@ -1,0 +1,188 @@
+{ self, ... }:
+{ inputs, ... }:
+
+let
+  aiModules = [
+    inputs.cua.nixosModules.cua-driver
+    inputs.hermes-agent.nixosModules.default
+    inputs.noctalia.nixosModules.default
+    inputs.noctalia-greeter.nixosModules.default
+  ];
+
+  baseModules = [
+    inputs.comin.nixosModules.comin
+    inputs.sops-nix.nixosModules.default
+    inputs.home-manager.nixosModules.default
+    inputs.colemak.nixosModules.default
+  ];
+
+  clusterModules = [
+    inputs.disko.nixosModules.default
+    inputs.knix.nixosModules.default
+  ];
+
+  beelinkClusterModules = [
+    inputs.nixos-hardware.nixosModules.common-cpu-intel
+    inputs.nixos-hardware.nixosModules.common-pc-ssd
+  ]
+  ++ aiModules
+  ++ baseModules
+  ++ clusterModules;
+
+  rpi4ClusterModules = [
+    inputs.nixos-hardware.nixosModules.raspberry-pi-4
+  ]
+  ++ aiModules
+  ++ baseModules
+  ++ clusterModules;
+
+  rpi5ClusterModules = [
+    inputs.nixos-hardware.nixosModules.raspberry-pi-5
+  ]
+  ++ aiModules
+  ++ baseModules
+  ++ clusterModules;
+
+  workstationHomeModules = [
+    inputs.catppuccin.homeModules.default
+    inputs.colemak.homeModules.default
+    inputs.devlib.homeModules.default
+    inputs.identities.homeModules.default
+    inputs.sops-nix.homeModules.default
+    inputs.noctalia.homeModules.default
+  ];
+
+  workstationsModules =
+    aiModules
+    ++ baseModules
+    ++ [
+      { home-manager.sharedModules = workstationHomeModules; }
+    ];
+
+  mkCatboxNixosConfiguration =
+    system:
+    inputs.nixpkgs.lib.nixosSystem {
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+      modules = [
+        ../../hosts/catbox/configuration.nix
+      ]
+      ++ workstationsModules;
+    };
+
+  mkCatbox =
+    system:
+    let
+      catbox = mkCatboxNixosConfiguration system;
+    in
+    catbox.config.system.build.containerdiskImage;
+in
+{
+  flake = {
+    nixosConfigurations = {
+      ashira = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/ashira/configuration.nix
+        ]
+        ++ beelinkClusterModules;
+      };
+      fushi = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/fushi/configuration.nix
+        ]
+        ++ rpi4ClusterModules;
+      };
+      ishtar = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/ishtar/configuration.nix
+          inputs.nixos-hardware.nixosModules.common-cpu-intel
+          inputs.nixos-hardware.nixosModules.common-pc-ssd
+          inputs.knix.nixosModules.default
+        ]
+        ++ workstationsModules;
+      };
+      manash = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/manash/configuration.nix
+        ]
+        ++ beelinkClusterModules;
+      };
+      minish = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/minish/configuration.nix
+        ]
+        ++ rpi4ClusterModules;
+      };
+      nalsha = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nalsha/configuration.nix
+        ]
+        ++ beelinkClusterModules;
+      };
+      nemishi = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nemishi/configuration.nix
+        ]
+        ++ rpi5ClusterModules;
+      };
+      nixtar = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nixtar/configuration.nix
+          inputs.nixos-wsl.nixosModules.default
+        ]
+        ++ workstationsModules;
+      };
+    };
+
+    packages = {
+      x86_64-linux = {
+        ashira = self.nixosConfigurations.ashira.config.system.build.toplevel;
+        catbox = mkCatbox "x86_64-linux";
+        ishtar = self.nixosConfigurations.ishtar.config.system.build.toplevel;
+        manash = self.nixosConfigurations.manash.config.system.build.toplevel;
+        nalsha = self.nixosConfigurations.nalsha.config.system.build.toplevel;
+        nixtar = self.nixosConfigurations.nixtar.config.system.build.tarballBuilder;
+      };
+      aarch64-linux = {
+        catbox = mkCatbox "aarch64-linux";
+        fushi = self.nixosConfigurations.fushi.config.system.build.toplevel;
+        minish = self.nixosConfigurations.minish.config.system.build.toplevel;
+        nemishi = self.nixosConfigurations.nemishi.config.system.build.toplevel;
+      };
+    };
+  };
+}

--- a/.jjconflict-side-0/modules/home/ai.nix
+++ b/.jjconflict-side-0/modules/home/ai.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    graphify
+    qwen-code
+    rtk
+  ];
+
+  programs = {
+    antigravity-cli.enable = true;
+
+    codex.enable = true;
+
+    claude-code.enable = true;
+  };
+}

--- a/.jjconflict-side-0/modules/home/base.nix
+++ b/.jjconflict-side-0/modules/home/base.nix
@@ -1,0 +1,14 @@
+{
+  # This value determines the Home Manager release that your
+  # configuration is compatible with. This helps avoid breakage
+  # when a new Home Manager release introduces backwards
+  # incompatible changes
+  #
+  # You can update Home Manager without changing this value. See
+  # the Home Manager release notes for a list of state version
+  # changes in each release
+  home.stateVersion = "26.05";
+
+  # Let Home Manager install and manage itself
+  programs.home-manager.enable = true;
+}

--- a/.jjconflict-side-0/modules/home/cloud.nix
+++ b/.jjconflict-side-0/modules/home/cloud.nix
@@ -1,0 +1,34 @@
+{ pkgs, ... }:
+
+{
+  imports = [
+    ./krew.nix
+  ];
+
+  catppuccin.k9s.enable = false;
+
+  programs = {
+    k9s = {
+      enable = true;
+      settings.k9s.ui.skin = "transparent";
+    };
+
+    ssh.settings."ssh.dev.azure.com" = {
+      HostkeyAlgorithms = "+ssh-rsa";
+      PubkeyAcceptedKeyTypes = "+ssh-rsa";
+    };
+  };
+
+  xdg.configFile."containers/policy.json".source =
+    let
+      format = pkgs.formats.json { };
+    in
+    format.generate "policy.json" {
+      default = [
+        { type = "insecureAcceptAnything"; }
+      ];
+      transports.docker-daemon = {
+        "" = [ { type = "insecureAcceptAnything"; } ];
+      };
+    };
+}

--- a/.jjconflict-side-0/modules/home/fontconfig.nix
+++ b/.jjconflict-side-0/modules/home/fontconfig.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.fira-code
+    pkgs.inriafonts
+  ];
+
+  fonts.fontconfig.enable = true;
+}

--- a/.jjconflict-side-0/modules/home/ghostty.nix
+++ b/.jjconflict-side-0/modules/home/ghostty.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+{
+  programs.ghostty = {
+    enable = true;
+    package = if pkgs.stdenv.isLinux then pkgs.ghostty else pkgs.ghostty-bin;
+    settings = {
+      theme = mkForce "dark:catppuccin-frappe,light:catppuccin-latte";
+      command = "${getExe pkgs.zsh} --login -c ${getExe pkgs.nushell}";
+    };
+  };
+
+  xdg.configFile."ghostty/themes/catppuccin-frappe".source =
+    "${config.catppuccin.sources.ghostty}/catppuccin-frappe.conf";
+}

--- a/.jjconflict-side-0/modules/home/graphical.nix
+++ b/.jjconflict-side-0/modules/home/graphical.nix
@@ -1,0 +1,22 @@
+{
+  # Global Noctalia desktop shell theme for graphical Linux hosts.
+  # NixOS-level programs.noctalia has no `settings`; theming is home-manager only,
+  # so this is the shared home module all graphical users import.
+  programs.noctalia = {
+    enable = true;
+    systemd.enable = true;
+    settings = {
+      location.auto_locate = true;
+      shell = {
+        font = "Fira Code";
+        polkit_agent = true;
+        greeter_sync.auto_sync = true;
+      };
+      theme = {
+        mode = "auto";
+        source = "builtin";
+        builtin = "Catppuccin";
+      };
+    };
+  };
+}

--- a/.jjconflict-side-0/modules/home/helix.nix
+++ b/.jjconflict-side-0/modules/home/helix.nix
@@ -1,0 +1,24 @@
+{
+  programs.helix = {
+    defaultEditor = true;
+    enable = true;
+    settings = {
+      editor = {
+        color-modes = true;
+        cursor-shape = {
+          insert = "bar";
+          normal = "block";
+          select = "underline";
+        };
+        cursorline = true;
+        indent-guides.render = true;
+        line-number = "relative";
+      };
+      # TODO: theme is supported post 2026 september release
+      # theme = mkForce {
+      #   dark = "catppuccin-frappe";
+      #   light = "catppuccin-latte";
+      # };
+    };
+  };
+}

--- a/.jjconflict-side-0/modules/home/krew.nix
+++ b/.jjconflict-side-0/modules/home/krew.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+
+{
+  home.packages = with pkgs; [ krew ];
+
+  home = {
+    # Make krew plugin discoverable for kubectl
+    sessionPath = [ "${config.home.homeDirectory}/.local/share/krew/bin" ];
+
+    # Plugins installation location
+    sessionVariables.KREW_ROOT = "${config.home.homeDirectory}/.local/share/krew";
+  };
+}

--- a/.jjconflict-side-0/modules/home/starship.nix
+++ b/.jjconflict-side-0/modules/home/starship.nix
@@ -1,0 +1,21 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  settings = importTOML "${config.catppuccin.sources.starship}/latte.toml";
+in
+{
+  programs.starship = {
+    enable = true;
+    settings = {
+      directory = {
+        truncation_length = 4;
+        style = "bold lavender";
+      };
+      git_branch.style = "bold mauve";
+      palette = "catppuccin_latte";
+    }
+    // settings;
+  };
+}

--- a/.jjconflict-side-0/modules/home/vcs.nix
+++ b/.jjconflict-side-0/modules/home/vcs.nix
@@ -1,0 +1,89 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.git-credential-manager
+  ];
+
+  programs = {
+    delta.enable = true;
+
+    gh-dash.enable = true;
+
+    git = {
+      enable = true;
+      lfs.enable = true;
+      ignores = [
+        ".hermes/"
+        "*.graphify"
+        "graphify_output/"
+        "graphify-out/"
+        ".graphify_cache/"
+        "graphify_cache/"
+      ];
+      settings.credential.helper = "manager";
+    };
+
+    jujutsu = {
+      enable = true;
+      settings = {
+        aliases = {
+          prune = [
+            "abandon"
+            "nulls()"
+            "conflicts()"
+          ];
+          restack = [
+            "rebase"
+            "--onto"
+            "trunk()"
+            "--source"
+            "roots(trunk()..) & mutable()"
+            "--simplify-parents"
+          ];
+          stack = [
+            "rebase"
+            "--after"
+            "trunk()"
+            "--before"
+            "closest_merge(@)"
+          ];
+          stage = [
+            "stack"
+            "-r"
+            "closest_merge(@)+:: ~ empty()"
+          ];
+          fetch = [
+            "git"
+            "fetch"
+            "--all-remotes"
+          ];
+          switch = [
+            "workspace"
+            "add"
+          ];
+          push = [
+            "git"
+            "push"
+          ];
+        };
+        git.private-commits = "description(substring:\"[private]\")";
+        templates = {
+          commit_trailers = ''
+            format_signed_off_by_trailer(self)
+            ++ if(!trailers.contains_key("Change-Id"), format_gerrit_change_id_trailer(self))
+          '';
+          git_push_bookmark = "\"shikanime/push-\" ++ change_id.short()";
+        };
+        revset-aliases = {
+          "closest_merge(to)" = "heads(::to & merges())";
+          "nulls()" = "empty() & mutable()";
+        };
+        ui = {
+          default-command = "log";
+          movement.edit = true;
+        };
+      };
+    };
+  };
+}

--- a/.jjconflict-side-0/modules/home/workstation.nix
+++ b/.jjconflict-side-0/modules/home/workstation.nix
@@ -1,0 +1,107 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  mkSshHeadlessHost = user: {
+    User = user;
+    SetEnv.TERM = "xterm-256color";
+  };
+
+  mkSshWorkstationHost = user: {
+    ForwardX11 = true;
+    User = user;
+    SetEnv.TERM = "xterm-256color";
+  };
+in
+{
+  catppuccin = {
+    enable = true;
+    flavor = "latte";
+  };
+
+  colemak.enable = true;
+
+  home = {
+    packages = with pkgs; [
+      cachix
+      devenv
+      docker-credential-helpers
+      pass
+      qpdf
+      rclone
+      secretspec
+      wget
+      zip
+    ];
+    sessionPath = [ "${config.home.homeDirectory}/.local/bin" ];
+  };
+
+  programs = {
+    bat.enable = true;
+
+    carapace.enable = true;
+
+    command-not-found.enable = true;
+
+    dircolors.enable = true;
+
+    direnv = {
+      enable = true;
+      mise.enable = true;
+      nix-direnv.enable = true;
+      config.global.load_dotenv = true;
+    };
+
+    docker-cli.enable = true;
+
+    gpg.enable = true;
+
+    jujutsu.settings."merge-tools".mergiraf."merge-tool-edits-conflict-markers" = true;
+
+    mergiraf = {
+      enable = true;
+      enableGitIntegration = true;
+      enableJujutsuIntegration = true;
+    };
+
+    mise.enable = true;
+
+    nushell = {
+      enable = true;
+      extraConfig = ''
+        $env.config.show_banner = false
+
+        source ${pkgs.nu_scripts}/share/nu_scripts/custom-completions/vscode/vscode-completions.nu
+      '';
+    };
+
+    pay-respects.enable = true;
+
+    ripgrep.enable = true;
+
+    ssh = {
+      enable = true;
+      settings = {
+        "ashira.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "catbox.taila659a.ts.net" = mkSshHeadlessHost "shika";
+        "fushi.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "manash.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "minish.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "nalsha.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "nemishi.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "ishtar.taila659a.ts.net" = mkSshWorkstationHost "shika";
+        "thinkcentre-m710t.tailfb4bb2.ts.net" = mkSshWorkstationHost "william-phetsinorath";
+      };
+    };
+
+    zoxide.enable = true;
+  };
+
+  xdg.enable = true;
+}

--- a/.jjconflict-side-0/modules/home/zed-editor.nix
+++ b/.jjconflict-side-0/modules/home/zed-editor.nix
@@ -1,0 +1,76 @@
+{ lib, pkgs, ... }:
+
+with lib;
+
+{
+  programs.zed-editor = {
+    enable = true;
+
+    userSettings = {
+      agent = {
+        default_model = {
+          provider = "Hermes Agent";
+          model = "hermes-agent";
+          enable_thinking = true;
+        };
+      };
+
+      agent_servers = {
+        "Hermes Agent" = {
+          type = "custom";
+          command = "hermes";
+          args = [ "acp" ];
+        };
+      };
+
+      icon_theme = mkForce {
+        mode = "system";
+        light = "Catppuccin Latte";
+        dark = "Catppuccin Frappé";
+      };
+
+      language_models = {
+        openai_compatible = {
+          "Hermes Agent" = {
+            api_url = "http://localhost:8642/v1";
+            available_models = [
+              {
+                name = "hermes-agent";
+                max_tokens = 200000;
+                max_output_tokens = 32000;
+                max_completion_tokens = 200000;
+                capabilities = {
+                  tools = true;
+                  images = true;
+                  parallel_tool_calls = true;
+                  prompt_cache_key = true;
+                  chat_completions = true;
+                };
+              }
+            ];
+          };
+        };
+      };
+
+      helix_mode = true;
+
+      relative_line_numbers = "enabled";
+
+      terminal.shell.with_arguments = {
+        program = "${getExe pkgs.zsh}";
+        args = [
+          "-c"
+          "${getExe pkgs.nushell}"
+        ];
+      };
+
+      theme = {
+        mode = "system";
+        light = mkForce "Catppuccin Latte";
+        dark = mkForce "Catppuccin Frappé";
+      };
+
+      vim_mode = true;
+    };
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/hardware/beelink-eq.nix
+++ b/.jjconflict-side-0/modules/nixos/hardware/beelink-eq.nix
@@ -1,0 +1,94 @@
+{ pkgs, ... }:
+
+{
+  boot = {
+    binfmt.emulatedSystems = [ "aarch64-linux" ];
+    loader = {
+      efi.canTouchEfiVariables = true;
+      systemd-boot.enable = true;
+    };
+  };
+
+  disko.devices.disk.main = {
+    type = "disk";
+    device = "/dev/nvme0n1";
+    content = {
+      type = "gpt";
+      partitions = {
+        ESP = {
+          size = "1G";
+          type = "EF00";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+            mountOptions = [ "umask=0077" ];
+          };
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "xfs";
+            mountpoint = "/";
+          };
+        };
+      };
+    };
+  };
+
+  # Intel N150 needs firmware plus userspace graphics/QSV libraries so the
+  # Jellyfin pod can use VAAPI/QSV via /dev/dri/renderD128.
+  hardware.enableRedistributableFirmware = true;
+
+  hardware.graphics = {
+    enable = true;
+    enable32Bit = true;
+  };
+
+  services.fstrim.enable = true;
+
+  networking = {
+    useNetworkd = true;
+
+    # balance-alb (mode 6): aggregates both 2.5G NICs without switch-side LACP.
+    # The NETGEAR MS308 is unmanaged — balance-alb handles load balancing
+    # entirely in the Linux driver via ARP negotiation.
+    bonds.bond0 = {
+      interfaces = [
+        "enp1s0"
+        "enp2s0"
+      ];
+      driverOptions = {
+        mode = "balance-alb";
+        miimon = "100";
+      };
+    };
+
+    bridges.br0.interfaces = [ "bond0" ];
+  };
+
+  # NIC performance tuning: hardware offloads + RPS for both Intel i226-V ports.
+  systemd.services.network-nic-performance = {
+    after = [ "network-online.target" ];
+    description = "Enable NIC hardware offloads and RPS";
+    script = ''
+      for iface in enp1s0 enp2s0; do
+        ip link show "$iface" >/dev/null 2>&1 || continue
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" rx-udp-gro-forwarding on rx-gro-list off
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" tso on gso on sg on tx on rx on 2>/dev/null || true
+        for rxq in /sys/class/net/"$iface"/queues/rx-*; do
+          echo f > "$rxq"/rps_cpus 2>/dev/null || true
+        done
+      done
+    '';
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    wantedBy = [ "multi-user.target" ];
+    wants = [ "network-online.target" ];
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/hardware/razer-blade.nix
+++ b/.jjconflict-side-0/modules/nixos/hardware/razer-blade.nix
@@ -1,0 +1,19 @@
+{
+  # UEFI laptop bootloader (Razer Blade 17, 2019). Windows dual-boot via systemd-boot.
+  # Windows entry is automatically detected by systemd-boot.
+  boot.loader = {
+    efi.canTouchEfiVariables = true;
+    systemd-boot.enable = true;
+  };
+
+  # Razer Blade 17 peripherals: daemon + udev rules.
+  hardware.openrazer.enable = true;
+
+  # CPU/device power management + suspend-on-lid-close.
+  powerManagement.enable = true;
+
+  services = {
+    fstrim.enable = true;
+    udisks2.enable = true;
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/hardware/rpi.nix
+++ b/.jjconflict-side-0/modules/nixos/hardware/rpi.nix
@@ -1,0 +1,55 @@
+{ pkgs, ... }:
+
+{
+  boot.kernelParams = [
+    # Older Raspberry Pi-class boards still need these cgroup knobs for RKE2.
+    "cgroup_enable=cpuset"
+    "cgroup_enable=memory"
+    "cgroup_memory=1"
+    # Disable USB runtime autosuspend; external SSD drops offline under load
+    "usbcore.autosuspend=-1"
+    # Bind SABRENT/JMicron enclosure to usb-storage, bypassing UASP
+    "usb-storage.quirks=152d:a578:u"
+  ];
+
+  # Silences Raspberry Pi firmware debug flooding on all RPi hosts through
+  # fushi/nemishi/minish. 4 = warnings and above still appear.
+  boot.consoleLogLevel = 4;
+
+  nixpkgs.overlays = [
+    (_: super: {
+      makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
+    })
+  ];
+
+  networking = {
+    useNetworkd = true;
+
+    # Single NIC bridge — all traffic (flannel, SSH, Longhorn) on one wire.
+    bridges.br0.interfaces = [ "end0" ];
+  };
+
+  # NIC performance tuning: hardware offloads + RPS for the USB3 GigE port.
+  systemd.services.network-nic-performance = {
+    after = [ "network-online.target" ];
+    description = "Enable NIC hardware offloads and RPS";
+    script = ''
+      for iface in end0; do
+        ip link show "$iface" >/dev/null 2>&1 || continue
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" rx-udp-gro-forwarding on rx-gro-list off
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" tso on gso on sg on tx on rx on 2>/dev/null || true
+        for rxq in /sys/class/net/"$iface"/queues/rx-*; do
+          echo f > "$rxq"/rps_cpus 2>/dev/null || true
+        done
+      done
+    '';
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    wantedBy = [ "multi-user.target" ];
+    wants = [ "network-online.target" ];
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/hardware/rpi4.nix
+++ b/.jjconflict-side-0/modules/nixos/hardware/rpi4.nix
@@ -1,0 +1,11 @@
+{
+  imports = [
+    ./rpi.nix
+  ];
+
+  hardware.raspberry-pi."4".fkms-3d.enable = true;
+
+  # Disable UAS for external USB drives - use more stable usb-storage
+  # Blacklist UAS kernel module to prevent crashes on VL805
+  boot.blacklistedKernelModules = [ "uas" ];
+}

--- a/.jjconflict-side-0/modules/nixos/hardware/rpi5.nix
+++ b/.jjconflict-side-0/modules/nixos/hardware/rpi5.nix
@@ -1,0 +1,20 @@
+{
+  imports = [
+    ./rpi.nix
+  ];
+
+  # Install the firmware specifically for the Raspberry Pi 5
+  # because the nixpkgs doesn't provide it by default anymore
+  # up to Raspberry Pi 4
+  hardware.raspberry-pi.firmware = {
+    enable = true;
+    uboot.enable = true;
+  };
+
+  boot.kernelParams = [
+    # Probe error -12 (ENOMEM) is also hit when the default 64 MiB CMA pool is too
+    # small for the NVMe admin queue / PRP DMA buffers. Bump it so the driver can
+    # allocate. Confirmed: without cma=512M the probe fails even with the overlay.
+    "cma=512M"
+  ];
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/agent.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/agent.nix
@@ -1,0 +1,16 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./machine.nix
+  ];
+
+  services.knix = {
+    enable = true;
+    role = "agent";
+    serverAddr = "https://192.168.1.28:9345";
+    tokenFile = config.sops.secrets.rke2-token.path;
+  };
+
+  sops.secrets.rke2-token.restartUnits = [ "rke2-agent.service" ];
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/ai.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/ai.nix
@@ -1,0 +1,221 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+{
+  # cargo.nix / dist.nix-style: addToSystemPackages = true + extraPackages -> cargo.nix inherits?
+  services.hermes-agent = {
+    enable = true;
+    addToSystemPackages = true;
+    environmentFiles = [
+      config.sops.templates.hermes-agent-env.path
+      config.sops.templates.hermes-agent-matrix-env.path
+    ];
+    extraPackages = with pkgs; [
+      curl
+      corepack
+      gh
+      git
+      graphify
+      honcho
+      nodejs
+      rtk
+      yarn
+    ];
+    settings = {
+      context.engine = "lcm";
+      custom_providers = [
+        {
+          name = "aperture-anthropic";
+          base_url = "https://ai.taila659a.ts.net/v1";
+          api_mode = "anthropic_messages";
+          model = "glm-4.7";
+          models = [
+            "glm-4.7"
+            "glm-5.2"
+          ];
+        }
+        {
+          name = "aperture-openai";
+          base_url = "https://ai.taila659a.ts.net/v1";
+          api_mode = "chat_completions";
+          model = "stepfun/step-3.7-flash:free";
+          models = [
+            "tencent/hy3:free"
+            "mistral/labs-leanstral-1-5"
+            "openrouter/openrouter/free"
+            "stepfun/step-3.7-flash:free"
+          ];
+        }
+      ];
+      documents."honcho.json" = builtins.toJSON {
+        baseUrl = "https://honcho.taila659a.ts.net";
+        hosts.hermes = {
+          peerName = config.networking.hostName;
+          aiPeer = "telsha";
+          workspace = "hermes";
+          observationMode = "directional";
+          writeFrequency = "async";
+          recallMode = "hybrid";
+          dialecticCadence = 3;
+          sessionStrategy = "per-session";
+          enabled = true;
+          saveMessages = true;
+          dialecticReasoningLevel = "low";
+          pinPeerName = false;
+        };
+      };
+      fallback_providers = [
+        {
+          api_mode = "chat_completions";
+          model = "poolside/laguna-s-2.1:free";
+          provider = "custom:aperture-openai";
+        }
+        {
+          api_mode = "chat_completions";
+          model = "labs-leanstral-1-5";
+          provider = "custom:aperture-openai";
+        }
+        {
+          api_mode = "chat_completions";
+          model = "stepfun/step-3.7-flash:free";
+          provider = "custom:aperture-openai";
+        }
+      ];
+      matrix = {
+        allowed_rooms = [ "!QUaAaCBlSIBcYyOyLb:matrix.taila659a.ts.net" ];
+        allowed_users = [
+          "@admin:matrix.taila659a.ts.net"
+          "@shikanime:matrix.taila659a.ts.net"
+        ];
+      };
+      memory.provider = "honcho";
+      model = {
+        default = "tencent/hy3:free";
+        provider = "custom:aperture-openai";
+        base_url = "https://ai.taila659a.ts.net/v1";
+      };
+      auxiliary = {
+        vision = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        web_extract = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        compression = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        skills_hub = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        approval = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        mcp = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        title_generation = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        memory_query_rewrite = {
+          provider = "custom:aperture-anthropic:openai";
+          model = "auxiliary";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        tts_audio_tags = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        triage_specifier = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        kanban_decomposer = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        profile_describer = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+      };
+      mcp_servers.aperture = {
+        url = "https://ai.taila659a.ts.net/mcp";
+        enabled = true;
+      };
+      # Bare `hermes`/`hermes chat` launches the Ink TUI by default; token
+      # streaming on for live agent output. Explicit --cli/--tui still wins.
+      display = {
+        interface = "tui";
+        streaming = true;
+      };
+    };
+    extraDependencyGroups = [
+      "computer-use"
+      "honcho"
+      "matrix"
+    ];
+  };
+
+  sops = {
+    secrets = {
+      hermes-agent-api-server-key = {
+        group = "hermes";
+        owner = "hermes";
+        restartUnits = [ "hermes-agent.service" ];
+      };
+      hermes-agent-matrix-access-token = {
+        group = "hermes";
+        owner = "hermes";
+        restartUnits = [ "hermes-agent.service" ];
+      };
+      hermes-agent-matrix-recovery-key = {
+        group = "hermes";
+        owner = "hermes";
+        restartUnits = [ "hermes-agent.service" ];
+        mode = "0600";
+      };
+    };
+    templates = {
+      hermes-agent-env = {
+        content = ''
+          API_SERVER_ENABLED=true
+          API_SERVER_KEY=${config.sops.placeholder.hermes-agent-api-server-key}
+        '';
+      };
+      hermes-agent-matrix-env = {
+        content = ''
+          MATRIX_HOMESERVER=https://matrix.taila659a.ts.net/
+          MATRIX_ACCESS_TOKEN=${config.sops.placeholder.hermes-agent-matrix-access-token}
+          MATRIX_E2EE_MODE=required
+          MATRIX_HOME_ROOM=!QUaAaCBlSIBcYyOyLb:matrix.taila659a.ts.net
+          MATRIX_RECOVERY_KEY_FILE=${config.sops.secrets.hermes-agent-matrix-recovery-key.path}
+        '';
+        restartUnits = [ "hermes-agent.service" ];
+      };
+    };
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/base.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/base.nix
@@ -1,0 +1,119 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./minimal.nix
+  ];
+
+  nix = {
+    extraOptions = ''
+      !include ${config.sops.templates.nix-config.path}
+    '';
+    settings.experimental-features = [
+      "flakes"
+      "nix-command"
+    ];
+  };
+
+  sops = {
+    secrets.nix-access-token.reloadUnits = [ "nix-daemon.service" ];
+    templates.nix-config.content = ''
+      extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}"
+    '';
+  };
+
+  services = {
+    comin = {
+      enable = true;
+      # Node exporter listens on localhost only — vmagent scrapes from 127.0.0.1.
+      exporter.listen_address = "127.0.0.1";
+      remotes = [
+        {
+          name = "origin";
+          url = "https://github.com/shikanime-labs/machines.git";
+        }
+        {
+          name = "origin";
+          url = "https://forgejo.taila659a.ts.net/shikanime-labs/machines.git";
+        }
+      ];
+    };
+
+    # Local host metrics pipeline: node_exporter -> vmagent -> vminsert.
+    prometheus.exporters = {
+      node = {
+        enable = true;
+        listenAddress = "127.0.0.1";
+        disabledCollectors = [
+          "bcachefs"
+          "fibrechannel"
+          "infiniband"
+          "ipvs"
+          "mdadm"
+          "nfsd"
+          "os"
+          "rapl"
+          "tapestats"
+          "zfs"
+        ];
+        enabledCollectors = [
+          "interrupts"
+          "processes"
+          "systemd"
+          "tcpstat"
+        ];
+      };
+      process.enable = true;
+      smartctl.enable = true;
+      systemd.enable = true;
+    };
+
+    vmagent = {
+      enable = true;
+      extraArgs = [
+        "-enableTCP6"
+      ];
+      prometheusConfig.scrape_configs = [
+        {
+          job_name = "comin";
+          static_configs = [
+            { targets = [ "127.0.0.1:4243" ]; }
+          ];
+        }
+        {
+          job_name = "node";
+          static_configs = [
+            { targets = [ "127.0.0.1:9100" ]; }
+          ];
+          # Every host scrapes 127.0.0.1:9100 and remoteWrites the SAME
+          # instance label, so VM merges all nodes into one series → garbage
+          # rates. Rewrite to a unique per-host identity + real cluster label.
+          relabel_configs = [
+            {
+              target_label = "instance";
+              replacement = config.networking.hostName;
+            }
+            {
+              target_label = "cluster";
+              replacement = "nishir";
+            }
+          ];
+        }
+      ];
+      remoteWrite.url = "https://telemetry.taila659a.ts.net/insert/0/prometheus";
+    };
+  };
+
+  # Required for node-exporter textfile collector.
+  systemd.tmpfiles.rules = [
+    "d /var/lib/node_exporter/textfile_collector 0755 root root -"
+  ];
+
+  # This value determines the NixOS release from which the default
+  # settings for stateful data, like file locations and database versions
+  # on your system were taken It's perfectly fine and recommended to leave
+  # this value at the release version of the first install of this system
+  # Before changing this value read the documentation for this option
+  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html)
+  system.stateVersion = "26.05";
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/builder.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/builder.nix
@@ -1,0 +1,49 @@
+{ config, pkgs, ... }:
+
+{
+  imports = [
+    ./machine.nix
+  ];
+
+  nix.settings.trusted-users = [ "builder" ];
+
+  services.gitea-actions-runner = {
+    package = pkgs.forgejo-runner;
+    instances = {
+      forgejo = {
+        enable = true;
+        name = config.networking.hostName;
+        tokenFile = config.sops.templates.forgejo-runner-token.path;
+        url = "https://forgejo.taila659a.ts.net";
+        labels = [
+          "docker:docker://node:22-bookworm"
+          "nixos-latest:docker://nixos/nix"
+          "native:host"
+        ];
+      };
+    };
+  };
+
+  sops = {
+    secrets = {
+      codeberg-runner-token.restartUnits = [ "codeberg-runner-${config.networking.hostName}.service" ];
+      forgejo-runner-token.restartUnits = [ "forgejo-runner-${config.networking.hostName}.service" ];
+    };
+    templates = {
+      codeberg-runner-token.content = ''
+        TOKEN=${config.sops.placeholder.codeberg-runner-token}
+      '';
+      forgejo-runner-token.content = ''
+        TOKEN=${config.sops.placeholder.forgejo-runner-token}
+      '';
+    };
+  };
+
+  virtualisation.docker = {
+    daemon.settings = {
+      fixed-cidr-v6 = "fd00::/80";
+      ipv6 = true;
+    };
+    enable = true;
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/distributed.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/distributed.nix
@@ -1,0 +1,92 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  mkHostname = hostName: "${hostName}.taila659a.ts.net";
+
+  mkBeelinkBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "x86_64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 4;
+    speedFactor = 2;
+    supportedFeatures = [
+      "nixos-test"
+      "benchmark"
+      "big-parallel"
+      "kvm"
+    ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkRpiBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "aarch64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 2;
+    speedFactor = 1;
+    supportedFeatures = [ "nixos-test" ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkBuildMachines =
+    machines:
+    let
+      selfHostname = mkHostname config.networking.hostName;
+    in
+    builtins.filter (m: selfHostname != m.hostName) machines;
+
+  mkSshKnownHost = { hostName, publicKey }: {
+    "${mkHostname hostName}".publicKey = publicKey;
+  };
+
+  mkSshKnownHosts =
+    knownHostsList:
+    let
+      selfHostname = mkHostname config.networking.hostName;
+      mergedHosts = mergeAttrsList knownHostsList;
+    in
+    filterAttrs (name: _value: selfHostname != name) mergedHosts;
+in
+{
+  nix = {
+    buildMachines = mkBuildMachines [
+      (mkBeelinkBuildMachine "ashira")
+      (mkBeelinkBuildMachine "manash")
+      (mkBeelinkBuildMachine "nalsha")
+      (mkRpiBuildMachine "fushi")
+      (mkRpiBuildMachine "minish")
+      (mkRpiBuildMachine "nemishi")
+    ];
+
+    distributedBuilds = true;
+
+    settings.builders-use-substitutes = true;
+  };
+
+  programs.ssh.knownHosts = mkSshKnownHosts [
+    (mkSshKnownHost {
+      hostName = "fushi";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILrDoPfjV+jRuGXdsc+TlgaL/+eO9pPqav6SG+tl1nPC";
+    })
+    (mkSshKnownHost {
+      hostName = "minish";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFWXSOEAx3pEzeoaqKV4gCCEVK3do+f2oJWlL++lGA/N";
+    })
+    (mkSshKnownHost {
+      hostName = "manash";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDW8I5803nYCNIKmzXBgfVDYpOJvYH0jg8ht5Djr72eL";
+    })
+    (mkSshKnownHost {
+      hostName = "ashira";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILxxDA8yBStWRl43qL15IvnKrLRW9Y2KlRAtEnxm4n3X";
+    })
+    (mkSshKnownHost {
+      hostName = "nalsha";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGAFFXlS4bbJnvo2CaPdKPHX2EFyrfF/KHfcwsVgOffE";
+    })
+  ];
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/follower.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/follower.nix
@@ -1,0 +1,14 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./leader.nix
+  ];
+
+  services.knix = {
+    serverAddr = "https://192.168.1.28:9345";
+    tokenFile = config.sops.secrets.rke2-token.path;
+  };
+
+  sops.secrets.rke2-token.restartUnits = [ "rke2-server.service" ];
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/graphical.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/graphical.nix
@@ -19,6 +19,7 @@
         # resolve on Niri's spawned PATH (compositor launches them directly).
         laptopSessionUtils = [
           brightnessctl # backlight/brightness keys under Niri
+          ddcutil # DDC/CI external monitor brightness/control
           fuzzel # app launcher; Niri's default config binds Super+R to it
           gparted-full # disk partition GUI (full FS tool set: resize/move any fs)
           pavucontrol # audio mixer GUI (volume keys only step, no panel)

--- a/.jjconflict-side-0/modules/nixos/profiles/graphical.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/graphical.nix
@@ -1,0 +1,89 @@
+{ pkgs, ... }:
+
+{
+  imports = [
+    ./machine.nix
+    ./workstation.nix
+  ];
+
+  environment = {
+    # Niri's built-in default spawns `${env TERMINAL alacritty}` on Super+Enter.
+    # Point it at Ghostty (provided by the home config) without a full config.kdl.
+    sessionVariables.TERMINAL = "ghostty";
+
+    # Gaming + laptop utilities the graphical session needs at the system level.
+    systemPackages =
+      with pkgs;
+      let
+        # Wayland session utilities: launcher + media/backlight controls that must
+        # resolve on Niri's spawned PATH (compositor launches them directly).
+        laptopSessionUtils = [
+          brightnessctl # backlight/brightness keys under Niri
+          fuzzel # app launcher; Niri's default config binds Super+R to it
+          gparted-full # disk partition GUI (full FS tool set: resize/move any fs)
+          pavucontrol # audio mixer GUI (volume keys only step, no panel)
+          playerctl # media-key control for MPRIS players
+        ];
+      in
+      laptopSessionUtils;
+  };
+
+  hardware = {
+    # WiFi / Bluetooth firmware for the laptop radios.
+    enableRedistributableFirmware = true;
+    graphics = {
+      enable = true;
+      enable32Bit = true; # Gaming: 32-bit for Wine/Proton
+    };
+    bluetooth.enable = true;
+    nvidia = {
+      open = true;
+      modesetting.enable = true;
+      powerManagement.enable = true;
+    };
+  };
+
+  programs = {
+    # Niri compositor (ships wayland-sessions/niri.desktop; the greeter lists it).
+    niri.enable = true;
+
+    # Noctalia shell/bar as a systemd user service (auto-starts in the Wayland session).
+    noctalia = {
+      enable = true;
+      recommendedServices.enable = true;
+      systemd.enable = true;
+    };
+
+    noctalia-greeter.enable = true;
+
+    # Niri forces XWayland off (the wayland-session import passes enableXWayland=false).
+    # Re-enable it so X11 apps actually start under Niri.
+    xwayland.enable = true;
+  };
+
+  # greetd daemon. `default_session.user` defaults to "greeter" (auto-created by the module).
+  # The Noctalia Greeter module sets default_session.command to its session binary.
+  services = {
+    # Flatpak sandboxing for graphical hosts. The module asserts xdg.portal.enable,
+    # so the portal must be on or the build fails.
+    flatpak.enable = true;
+
+    greetd.enable = true;
+
+    # Secret Service daemon so Thunderbird's login manager stores credentials
+    # encrypted (Niri ships no keyring today).
+    gnome.gnome-keyring.enable = true;
+
+    # XWayland for the rare X11 app under Niri. Keep xserver on for the XWayland socket.
+    xserver.enable = true;
+  };
+
+  xdg.portal.enable = true;
+
+  # polkit authority daemon: required for the privilege prompts that
+  # pkexec/gparted raise. Noctalia's built-in in-session agent (enabled via
+  # programs.noctalia.settings.shell.polkit_agent in the home module) registers
+  # against this daemon, so the external polkit-gnome agent is intentionally
+  # omitted to avoid two agents racing for the session-bus registration.
+  security.polkit.enable = true;
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/leader.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/leader.nix
@@ -1,0 +1,95 @@
+{
+  imports = [
+    ./machine.nix
+  ];
+
+  services = {
+    knix = {
+      enable = true;
+      addons.flux = {
+        instance.extraConfig.instance.sync = {
+          interval = "1m";
+          kind = "GitRepository";
+          path = "clusters/nishir/overlays/tailnet";
+          pullSecret = "";
+          ref = "refs/heads/main";
+          url = "https://github.com/shikanime-labs/manifests.git";
+        };
+
+        operator.extraConfig.web.ingress = {
+          enabled = true;
+          annotations."tailscale.com/tags" = "tag:web";
+          className = "tailscale";
+          hosts = [
+            {
+              host = "nishir-flux";
+              paths = [
+                {
+                  path = "/";
+                  pathType = "ImplementationSpecific";
+                }
+              ];
+            }
+          ];
+          tls = [
+            { hosts = [ "nishir-flux" ]; }
+          ];
+        };
+      };
+      # Tailscale IP SANs — required because agents resolve hostnames to IPv6
+      # first; without these the load balancer's TLS handshake to the supervisor
+      # port (9345) fails with "tls: internal error".
+      extraConfig.tls-san =
+        let
+          ashira = [
+            "ashira.taila659a.ts.net"
+            "100.71.195.97"
+            "fd7a:115c:a1e0::c53a:c362"
+          ];
+          manash = [
+            "manash.taila659a.ts.net"
+            "100.74.220.28"
+            "fd7a:115c:a1e0::8d3a:dc1c"
+          ];
+          nalsha = [
+            "nalsha.taila659a.ts.net"
+            "100.126.72.116"
+            "fd7a:115c:a1e0::be3a:4875"
+          ];
+          nishir = [
+            "nishir.taila659a.ts.net"
+            "100.80.177.233"
+            "fd7a:115c:a1e0::fc3a:b1ea"
+          ];
+        in
+        ashira ++ manash ++ nalsha ++ nishir;
+
+      traefik.extraConfig.ports = {
+        syncthing = {
+          port = 22000;
+          expose.default = true;
+          exposedPort = 22000;
+          protocol = "TCP";
+        };
+        syncthing-udp = {
+          port = 22000;
+          expose.default = true;
+          exposedPort = 22000;
+          protocol = "UDP";
+        };
+      };
+    };
+
+    # Expose RKE2 API (9345) and Kubernetes API (6443) as a single Tailscale Service.
+    tailscale.serve = {
+      enable = true;
+      services.nishir = {
+        advertised = true;
+        endpoints = {
+          "tcp:6443" = "tcp://127.0.0.1:6443";
+          "tcp:9345" = "tcp://127.0.0.1:9345";
+        };
+      };
+    };
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/machine.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/machine.nix
@@ -1,0 +1,65 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./base.nix
+  ];
+
+  services = {
+    avahi = {
+      enable = true;
+      nssmdns4 = true;
+      nssmdns6 = true;
+      publish = {
+        addresses = true;
+        enable = true;
+        workstation = true;
+      };
+    };
+
+    openssh = {
+      enable = true;
+      openFirewall = true;
+    };
+
+    tailscale = {
+      authKeyFile = config.sops.secrets.tailscale-authkey.path;
+      enable = true;
+      extraUpFlags = [
+        "--accept-routes"
+        "--ssh"
+      ];
+      openFirewall = true;
+      useRoutingFeatures = "server";
+    };
+
+    # Userspace hardware watchdog + system resource monitor
+    watchdogd = {
+      enable = true;
+      settings = {
+        meminfo.enabled = true;
+        timeout = 120; # Increased from 15s to prevent premature reboots
+      };
+    };
+  };
+
+  sops.secrets.tailscale-authkey.restartUnits = [ "tailscaled.service" ];
+
+  # XFS no longer panics on I/O errors: on USB-backed nodes a transient
+  # enclosure I/O error was panicking the kernel and reboot-looping. Let XFS
+  # remount read-only and ride out the hiccup instead.
+  systemd.oomd.enable = true;
+
+  # zram swap so the kernel OOM-killer isn't the first responder on small nodes.
+  # PSI is enabled by default on NixOS std kernel; that also lets systemd-oomd run.
+  zramSwap.enable = true;
+
+  # Force glibc to prefer IPv4 over IPv6 for dual-stack destinations.
+  networking.getaddrinfo.precedence = {
+    "::1/128" = 50;
+    "::/0" = 40;
+    "2002::/16" = 30;
+    "::/96" = 20;
+    "::ffff:0:0/96" = 100;
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/minimal.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/minimal.nix
@@ -1,0 +1,45 @@
+{
+  # Make home-manager use packages from system
+  home-manager = {
+    backupFileExtension = "backup-before-nix";
+    useGlobalPkgs = true;
+    useUserPackages = true;
+  };
+
+  nix = {
+    # Cleanup disk weekly
+    gc = {
+      automatic = true;
+      dates = "weekly";
+      options = "--delete-older-than 30d";
+    };
+
+    # Optimize nix store weekly
+    optimise = {
+      automatic = true;
+      dates = [ "weekly" ];
+    };
+
+    # Allow wheel users to interact with the daemon
+    settings = {
+      download-buffer-size = 524288000;
+      trusted-users = [ "@wheel" ];
+    };
+
+  };
+
+  # Automatically upgrade NixOS
+  system.autoUpgrade = {
+    enable = true;
+    flags = [ "--accept-flake-config" ];
+    flake = "github:shikanime-labs/machines";
+  };
+
+  # This value determines the NixOS release from which the default
+  # settings for stateful data, like file locations and database versions
+  # on your system were taken It‘s perfectly fine and recommended to leave
+  # this value at the release version of the first install of this system
+  # Before changing this value read the documentation for this option
+  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html)
+  system.stateVersion = "26.05";
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/nishir.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/nishir.nix
@@ -1,0 +1,71 @@
+{ lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [
+    ./machine.nix
+    ./wifi.nix
+  ];
+
+  networking = {
+    firewall = {
+      # Cluster -> tailnet egress. Pods route via the node (flannel host-gw),
+      # so their traffic reaches the host on the CNI bridge (cni0) and must be
+      # forwarded out tailscale0 to reach tailnet CGNAT addresses
+      # (100.64.0.0/10, e.g. *.ts.net). The node already holds these routes via
+      # Tailscale --accept-routes; only the firewall FORWARD policy (default
+      # DROP) blocks it. Egress-only: return traffic is ESTABLISHED and allowed
+      # by conntrack. IPv4 + IPv6 (pod ranges are fd00::/56).
+      extraCommands = ''
+        iptables -I INPUT -i br+ -j ACCEPT
+        iptables -I FORWARD -i br+ -j ACCEPT
+        ip6tables -I INPUT -i br+ -j ACCEPT
+        ip6tables -I FORWARD -i br+ -j ACCEPT
+        iptables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT
+        ip6tables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT
+      '';
+      extraStopCommands = ''
+        iptables -D INPUT -i br+ -j ACCEPT 2>/dev/null || true
+        iptables -D FORWARD -i br+ -j ACCEPT 2>/dev/null || true
+        ip6tables -D INPUT -i br+ -j ACCEPT 2>/dev/null || true
+        ip6tables -D FORWARD -i br+ -j ACCEPT 2>/dev/null || true
+        iptables -D FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
+        ip6tables -D FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
+      '';
+    };
+  };
+
+  services = {
+    knix = {
+      # Bridge interface — flannel, firewall, and sysctl rules all target br0.
+      # Bonded on Beelink (bond0 → br0), single-NIC on RPi (end0 → br0).
+      interface = "br0";
+
+      # Use host-gw for flannel overlay — zero encapsulation overhead on same-LAN clusters
+      canal.backend = "host-gw";
+    };
+
+    tailscale.serve.services.syncthing = {
+      endpoints."tcp:22000" = "tcp://127.0.0.1:22000";
+      advertised = true;
+    };
+  };
+
+  systemd.services.tailscale-serve-syncthing = {
+    description = "Expose RKE2 and Kubernetes APIs via Tailscale serve with HTTPS";
+    after = [ "tailscaled.service" ];
+    wants = [ "tailscaled.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    script = ''
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --http=80 https+insecure://127.0.0.1:443
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --https=443 https+insecure://127.0.0.1:443
+    '';
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/wifi.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/wifi.nix
@@ -1,0 +1,43 @@
+{ config, ... }:
+
+{
+  networking.wireless = {
+    enable = true;
+    secretsFile = config.sops.templates.wifi.path;
+    networks = {
+      "SFR_E368".pskRaw = "ext:psk_sfr_e368";
+      "SFR_E368_5SGHZ".pskRaw = "ext:psk_sfr_e368_5ghz";
+      "Vintage Korean".pskRaw = "ext:psk_vintage_korean";
+    };
+  };
+
+  sops = {
+    secrets = {
+      wifi-sfr-e368 = {
+        owner = "wpa_supplicant";
+        group = "wpa_supplicant";
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+      wifi-sfr-e368-5ghz = {
+        owner = "wpa_supplicant";
+        group = "wpa_supplicant";
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+      wifi-vintage-korean = {
+        owner = "wpa_supplicant";
+        group = "wpa_supplicant";
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+    };
+    templates = {
+      wifi = {
+        content = ''
+          psk_sfr_e368=${config.sops.placeholder.wifi-sfr-e368}
+          psk_sfr_e368_5ghz=${config.sops.placeholder.wifi-sfr-e368-5ghz}
+          psk_vintage_korean=${config.sops.placeholder.wifi-vintage-korean}
+        '';
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+    };
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/profiles/workstation.nix
+++ b/.jjconflict-side-0/modules/nixos/profiles/workstation.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+
+{
+  imports = [
+    ./base.nix
+  ];
+
+  programs.gnupg.agent = {
+    enable = true;
+    enableExtraSocket = true;
+    pinentryPackage = pkgs.pinentry-all;
+    settings.default-cache-ttl = 60 * 60;
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/users/automata.nix
+++ b/.jjconflict-side-0/modules/nixos/users/automata.nix
@@ -1,0 +1,20 @@
+{
+  users.users.automata = {
+    initialHashedPassword = "";
+    isNormalUser = true;
+    home = "/home/automata";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOuenA6cT5pkPEwdGvmvXRjVqFTv2QwpyYrB7gvMy0/X"
+    ];
+  };
+
+  home-manager.users.automata = {
+    imports = [
+      ../../../modules/home/base.nix
+      ../../../modules/home/cloud.nix
+      ../../../modules/home/vcs.nix
+      ../../../modules/home/workstation.nix
+    ];
+    programs.bash.enable = true;
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/users/builder.nix
+++ b/.jjconflict-side-0/modules/nixos/users/builder.nix
@@ -1,0 +1,7 @@
+{
+  users.users.builder = {
+    isNormalUser = true;
+    home = "/home/builder";
+    useDefaultShell = true;
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/users/nishir.nix
+++ b/.jjconflict-side-0/modules/nixos/users/nishir.nix
@@ -1,0 +1,11 @@
+{
+  users.users.nishir = {
+    extraGroups = [ "wheel" ];
+    home = "/home/nishir";
+    initialHashedPassword = "$y$j9T$HB1msXB0DEq00J48zRpB20$/3rhVrTzGrv1j/cPvZ0clOM2gEe1TeylUG39wgD0C42";
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+}

--- a/.jjconflict-side-0/modules/nixos/users/shika.nix
+++ b/.jjconflict-side-0/modules/nixos/users/shika.nix
@@ -1,0 +1,64 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  toDhall = generators.toDhall { };
+in
+{
+  imports = [
+    ../../../modules/home/ai.nix
+    ../../../modules/home/base.nix
+    ../../../modules/home/cloud.nix
+    ../../../modules/home/fontconfig.nix
+    ../../../modules/home/ghostty.nix
+    ../../../modules/home/graphical.nix
+    ../../../modules/home/helix.nix
+    ../../../modules/home/starship.nix
+    ../../../modules/home/vcs.nix
+    ../../../modules/home/workstation.nix
+    ../../../modules/home/zed-editor.nix
+  ];
+
+  identities = {
+    enable = true;
+
+    ghstack.enable = true;
+
+    glab.enable = true;
+
+    gouv = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native"
+      ];
+    };
+
+    operator-6o = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/operator6o";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/operator6o"
+      ];
+    };
+
+    shikanime.enable = true;
+  };
+
+  programs.bash.enable = true;
+
+  sops = {
+    age.keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
+    defaultSopsFile = ../../../secrets/shikanime.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets.cachix-token = { };
+    templates.cachix-config.content = toDhall {
+      authToken = config.sops.placeholder.cachix-token;
+      hostname = "https://cachix.org";
+    };
+  };
+
+  xdg.configFile."cachix/cachix.dhall".source =
+    config.lib.file.mkOutOfStoreSymlink config.sops.templates.cachix-config.path;
+}

--- a/.jjconflict-side-0/modules/nixos/virtualisation/containerdisk.nix
+++ b/.jjconflict-side-0/modules/nixos/virtualisation/containerdisk.nix
@@ -1,0 +1,43 @@
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.containerdisk;
+in
+{
+  imports = [
+    "${modulesPath}/virtualisation/disk-image.nix"
+  ];
+
+  options.containerdisk = {
+    name = mkOption {
+      type = types.str;
+      description = "Container image name to assign to the built containerdisk.";
+    };
+
+    settings = mkOption {
+      type = types.attrsOf types.anything;
+      default = { };
+      description = "Extra attributes bound directly to the dockerTools.buildImage config attrset.";
+    };
+  };
+
+  # Reference: https://github.com/kubevirt/kubevirt/blob/main/docs/container-register-disks.md
+  config.system.build.containerdiskImage = pkgs.dockerTools.buildImage {
+    inherit (cfg) name;
+
+    copyToRoot = pkgs.runCommand "containerdisk" { } ''
+      mkdir -p $out/disk
+      cp -v ${config.system.build.image}/${config.image.fileName} $out/disk/${config.image.fileName}
+    '';
+
+    config = cfg.settings;
+  };
+}

--- a/.jjconflict-side-0/secrets/ashira.enc.yaml
+++ b/.jjconflict-side-0/secrets/ashira.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:bkZbtYiQMqPwPtSQRS7yp0DcMlBFqo19mYAGAQqEF6S3j5qf3okjDyaig1iQgS8=,iv:TF9l3sc4GZMDqMviLcwbec/3ZwW/31LGjm+sN3BNddo=,tag:AHXmz82qDWB/AJLexg3AIw==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:R5xFpFiK9dC62N9z7f3P/vxHe0oaDYurmd3zSnPccg1pk7v7WN+bt72qaMfADpmzzdhcjg1SWTcjxSQ=,iv:bGbmEG9S6RbbeHfZCxcpgRo/YRod0vsSrfRkNMAZ1Go=,tag:DD7fuG6pPHDRBevvHE7P5Q==,type:str]
+rke2-token: ENC[AES256_GCM,data:ZhjHnX2cGo1fKoo2GoJa4xshr+8nMo1SwJ8UdVWYc4a2FbV/ehDTSlaEz8DbE9J9aLvEiJ3oJCFBBD8SqitfTxo5S1JpbJy0kYKrse6a5D/fvHcZVFjWE6g10ONS/v8NDJywhe4yb9cxMMsr,iv:E2x2yMigVlgH/Rb0uaNYQ/x2Qk/dJe2uIf+EFRxHTTI=,tag:LlVJN6KAqlUcoeg9/fnKWg==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:16:56Z"
+  mac: ENC[AES256_GCM,data:IQZlaopB1rbqovdLcrqwUeHnh3AcGarPlR+vP5LUxJZ0kGBSGLIoHKT1/E2dZsRF8nQgS7oGzerbUcIbIwrd/dM64FBBfvRh7uA81d+BrPMGlGsQ8Vphr7OUZKj83zAYrJRL6shVNYLhfsP15mA7Jk2WAP3lygq4whWnyiPhalI=,iv:tudWaflVADz3gvwnzC87ddYqpQb3Ubu9D+wK1gEeIR0=,tag:f2tT/BQGbOmLeou7OZKfyA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUR3NzSTkwNFQ4d1d6bllX
+        M3MzNFF2Y1NyOXluZHVlNlArMUd0Y0srS3pvCk9WWndlTnhrcnIrZnlZTE9qUHMw
+        ajZINDlnZHR0ZzZZNUZ6clpid2d5S2cKLS0tIEFRK1o4YldGNlFyQi9PV21NRVhQ
+        NDlMU2dncjNoekRYUWJ2eExBRFhVK3MKZ1Twn79tKsndCEqkX3x505kLR2CGGKP0
+        5gijo+lh0LthON7GmJ+59kAxXNPsYK1kGQ02lCF2drQz2K5DY8ASvA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYQ1VKVWZSaHFjSW5EcXAy
+        MFJzSkxsdmpiS0toUzZSMi9WbTRya3JqV0VZCmlGRCs0VWNnY2pRazNjd3Y2QUV1
+        QUtSN0MzV0YrRHBvWHhGbVgyUGpQSHcKLS0tIGo4MWRKbnB6Q0JpcGUzT0U5NndX
+        YVIvZkU4VmNjSFQyMUVCeHhKVmZjVXcK/ZziPsyZTXy1DN5sBUQLn+Rys+IWcTJ2
+        MNHKnHyRV7rPccKO+Uhtr+WcW9OJ1xXXyW3OoIRqkz7lN3k+G/rXkw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBONmRjL3orRTIyU1FOTG83
+        QjlEV01wK0pGWnpaa0ZPVzFDNElwcWk0RWlNCkZPcW1QSlNDeERSUk5tTFpvMlht
+        WXh2YVoyc3ZXV0V4WVU2NWRoclVUYlUKLS0tIGJEc21LR1VENnpmSGx3czBVN1FH
+        S0dpTVpLOG5YbVF1a1gzd2ozeVVOZjQKpVwFVz8HwSCSsYgYnUxg1cA/jWTTUGlU
+        /GGt0GF9G4cFLYcUU1h9DqzdnrEDmcAS8AU5DlnTyXg6CPriXQovHQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSU09Bc0x0SC9Xd3FRZngz
+        Z1lLckptN2VlWTVrbzVNWHlSempvaTdsbVNVCmJGMC85VDRwNWZIaml2U0dhU1Jo
+        VzZ1eURFeDh1WEc0Sk9nb0w0S052czQKLS0tIE1lYloxRDJnaHpFaldUcEJtdmRF
+        aTR6Ty9OcHVTYW9BVmdZbHFOaXlPc1UKiQbKnZiKbRRi5bNpso2wjAf0XVQHYQUr
+        NXy3DZ3mIg0YTO1IwTDZ1059iXdYAHmWZrEShMfO7a0KUb3YA4BzmA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:qfFWKqM8wFIG5rE3wCURxZtGBtbcutjl+cMYIuIxvhxAotpfYMjnZsT6VxtCzwkQUFVZptqMBA8xB57UUwk=,iv:3ZA/q7WHvfscBSUkRuW5IzsPG8EMlZj+FQrE68QnWf0=,tag:3O7384nD+ahnWmLUkrDqqg==,type:str]

--- a/.jjconflict-side-0/secrets/builder.enc.yaml
+++ b/.jjconflict-side-0/secrets/builder.enc.yaml
@@ -1,0 +1,116 @@
+codeberg-runner-token: ENC[AES256_GCM,data:4uJawrEOfsM3DEVO9Zacv3HSWVGIuUZI1VrOuJleD/V659P02N093t5hMA==,iv:qP5hCFucau4gV2RlguA06df9JTaGumOuX2Fda4mtVj8=,tag:YX+MtZaZdwbBYSWEhAp86Q==,type:str]
+forgejo-runner-token: ENC[AES256_GCM,data:5V5mujkVjqxkSkE1F9oRDpWJlz2ubJc4EhRltQOp5q3DquB/1i/CQy5rgA==,iv:J3boywVhURVH9Fzv98oHcg5mz0euDftBJ1F07YAEsOM=,tag:m2lR8/x1NMzNw6imEc4XtA==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:28:03Z"
+  mac: ENC[AES256_GCM,data:rI0TEzb3brGH+kzYsSJtphUTL9yEd5XapIoA1Oo3AxzQScqzmE2r6X6mzrlAwK0IBlvrCZthmjitwRqcjxAXjW2abZQwbvCdjwIJAhGL6N+1ziiuXaQQfenwH0ow/Tqf7jvgFu/v5MA8oHTjuqPyCn7UuQjHinmXBjzIIT2c3N0=,iv:idioPVWqIGxwDszOYfqzwOOEMkLaoVL2liNtiXtwytw=,tag:oR7eLuxJOwt/XssPeaB5Yg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCNTl4WHdQVlMvOWYrdk5V
+        ME1xZUhzSEkxdXhDMWJLVXZXT01xNGZjZlRvCkJpNEdockUybjh1aWpJdkRXck1U
+        Ym9BZ25tWENmemYrWkgyQW5wMGpwT2cKLS0tIEJoUUQreERFMEdKWjFhNXROYStX
+        akNMYnhmTEVhcEFGTnlxNWRzc0o1djgKssBDBGpA0FGTD41SUPZ0Gq+aBvfZpDlp
+        qmbcwmh6WK+/zuEILwA2HZ6U14C4ML205ntg45id4iY4E1+vszwJVg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOWWhvUkhwSDZXV1MyVEZz
+        ZTNWREZRVjJCSVdVYzFIWWwzV1RaOU1yMkdFClIySVJ1K1ZWa1NNemZyZnlUMzFQ
+        cS9nWDlZZ3gvNzFKcFJGcUJONGVVQnMKLS0tIGtPUm9YS09JbXVsN3J2bzJlUHFn
+        SHNQL0xWOGowYlh0Z2E2QnllaDNWRVUKxjrJPfksk71OfJ7jszGdEChcrMubrjAv
+        V3OXt6xErb03Ao6x/8MXtoGcc+R5ssVWjFC6y65rSUyvbvGCCaneVg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuZkN0c0YrM1NvdEM5aGJI
+        dHRsUThTdHpWNkZPV0c3VEVObGhqdVlSa0VBCjUzcHg0VkZPL2VoUTJOcys1MVFR
+        UFNjQzNTaTFrM3BQZGp0dDJUTTJ1UEUKLS0tIFVoUmNYNGtNVFdPcHJCVTAvejR5
+        QUV1aDNKQzh6MlV4YlFhUkVqQi8wSVUKZCOtsLsim2X3G9oz35MYU3QvdGDqkl7u
+        QKifhCdc869nSlqQq13uHfi0fZt4qtKEdxzrkb6TUWOPO1A4/eOP9Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBORnJzK2dXbnFoZEVuQmdh
+        RnFhYjZBUTlVQmRZQVZOUjJnMk95UnV6ckJzCis0eXhERHNsRGREdVNBZWtTVkRi
+        RkdpeFQxRnVpUjBPK0JhNStwaVd3NTgKLS0tIENxSThIbWJENVhGYlJHSU9mWVdp
+        bHVBM2FhUkVrVTlCZS8rNWlUWk53UW8KlIOOf82n9Z0Zfg/NRffglM1ykMTKRP9F
+        KhZsljCGnmiE1SlQ77MRy49S0wFPMWJmGPHJJnd/IKK8GCLBO1Za+A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIL3Azc3JVUEdkZEYxVFVR
+        VjJNcXdkd0E3V0orRzFGdDc0Q0FXMlhsVUhZCkxlRk9HT3NLN3lybGNxd1NqbVVO
+        Z2o5WDlQNXVzRmw3MFl3enJ6dGlNbHcKLS0tIHJwNjh6Ukp1clhNOXNqTTgvVXV2
+        cERQOUFxajh5R1h1ZXZCTjZvVk9VT3MKzWBn+gY7uOvMuHu7rXOmA2uIgI5ckqxx
+        +q8PDflHbdEZT6uexswWwKygMlr1xE0Pg2aLOxZcyFsa3+ttNQSAIA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqTVVNTTFDMFR3SXBEYnho
+        VnF4OE1WcU90d0FWd1YvUGJHUUhDMFFiUUVNCmd5QkM0SUVBR2dYY0Z6VlF4eHJk
+        V1k0cVNIQXZMTmJzNjJaWUdVbFRiQ1EKLS0tIFhFSlJGMlJXUGZOSkNibHp1ZjR4
+        ZlhaNjUwT0JXdDZOZEM3UWpKM2ZtQUUKLYZcJ0nPrwt71nrEZKLGZdghoz95c0lX
+        tRWrtiQK0OIRgnVpUdKQWGWTUULvT0Lo8mh7uOVl2wZW3+V7UWT8cA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxT1JQL2U0QnpGKzJmYlkx
+        QS9RMXZaTy9IRW56MVVPTGNxRGVJK1RtM25VCkt2Z3JXVForYjJXQThWMlE2QlM4
+        TzlTN1pKQzAvRWlZNXl2cFBodWVKNGcKLS0tIElFMy9NMHFlZElRL0pwRkVLdXpT
+        c1pDbHRDK2NucEQ2dFBOdWlsK1lqOFkKfw8uBv+Z9mogXi1I0bIN1fFnk7+H7VEE
+        MMeYmIZGWkwDhCmH/5e7Um+PQ6DNTx7yUjj2YzIvbp3IsGwCORpmvQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJUUhTSCtjYm9VMnRLMnBz
+        b3FIV1NONjJEblN3bWVWeVdZUjBNTjZuWWo0Ck82ZmxoTEoxU0hXNW8ydms1eXZw
+        Yy9yV2VtNFI1aXZRYUpqT3huVU9GRVkKLS0tIGFub05PQ0dRWjZPUjViTmdaK1Iz
+        VjkwS1ByTW8rUjFVL1lMVVA2anJFT2sKIMUCDi487H807PINn7MDQSrnAvvrFtyw
+        10It6rpHQeHh3DV3CrsnHjsk5AJvFHHVjdXriXKKmFVgzDGPPR72Xg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyTEZjNys0T2ZzQ1ZCTWE3
+        MXRIb3JtREhVK0xuL3N1VDVEZ0t3b1U5OUN3Ci9GSVpGZVRUVmZNMDdYNitYc0lw
+        UDJ1NW90MGhXNDlUd1N4MVd6a21jYnMKLS0tIHgvM0g0SzN1QTZTcjBuOXVySFNN
+        cnpzN3Q0YlNoWThWL2Q1azVjS2xveTAKOcm34DduIdHH6kIzAVbNbHQW/BdrhHt0
+        YbT6RLltrrigugxH2vjv/2Ve0IOdQvOHkvUP4h9B4l/OCzSf88jlcA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDZTFabDN4YlNwVEUyNi9q
+        SEVNUkUxdEdPa0o2N1hmRy9VM1BBZ3puL0Z3CkxRRExabHI1V0FrRGk2REdxV2ZR
+        VllBaVNpRGs4TVBpQ3NOSFIwc0xwVU0KLS0tIFkrSjBrdDBqdzFIMGVwbWs3Zzhp
+        aVRvZVF3MkFHd2lrY04wOUtGUmlTZ1UKCeWRPAiRoHD68gkJ0UY1nS8b6H58/S3A
+        IaYl6uK6Kixc2O/fQbZ7BfGgvHABaV4GrYUONWCCDRp99p6O390Yfw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4QkZFc2ZVRWZ5dWFMcWVs
+        Q3lia3g5bWRXdEJoa3hQdElDRDhxMVVPYW5vClhxS0x3SVRmRmpSZVZxMndnbjZ2
+        eS93aHR5ZHFZQ09YN2lKbU5WU3NXZlUKLS0tIHdyOGc5Y3ZOdUdqZlRQOURrQThq
+        SGJPbVBlTUp0aFMrWG5TWTQ1WHB4YWsK7HXOkWsjZao4QsyxjogEM1RPQMi19Tey
+        UCQ6NAF7b4hQDHcB2C01j4uKGAKCCHKK1DbNwCniliRxJc119lLIrg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5MC9jNXU3ZHRsUUVBYkEz
+        dHU1aERWQ29aVWxyaEJYV2FZQTdhRVFmM0U4Ck9lZGppWUZjbjRQNnU3dHIzclk4
+        M0NzVlBpeFBJZ2NkRi92dXhDcEFlK1UKLS0tIHcwWFMwV2pHL2c0a0ZBeWhja2NS
+        VlJhYXoxOEcya0JQY0tZNzBUUDllVWMK4oS3Rpb9AQwatA/OykeoJ7AqNrZ72kLw
+        sJnIwoiBT9Guzdz4CLzYcbHCDkhrMNU4SlVbG6QTtLJfpp59p5G8tQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d

--- a/.jjconflict-side-0/secrets/fushi.enc.yaml
+++ b/.jjconflict-side-0/secrets/fushi.enc.yaml
@@ -1,0 +1,45 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:3FV3y8ElvePApyX/uqMo3xy5Pt66YtbNc/e6dEGpJZ7nTWF1z/nJdWQS+GlhwtnA,iv:/ljlAwygMaMm7jQEzhanb23DwcHcxQc9B1yW4DdsrYI=,tag:23Ac8PYQG05bOB59iiJL6A==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:Ou7lVgiGZz2/oF2gsdeQao/qwX0qsCbxElCbP3FyKGDrBQy8ePjDWIXW2fMGVVV8i6+OMGJPQTVKrGs=,iv:5OHFZRMaxQgd/uyMsH7LTPiSsK46UriJEuY6ozMND3M=,tag:I/nYVqw6I4ieUqdRw0Erlw==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:17:39Z"
+  mac: ENC[AES256_GCM,data:Y257wW8/3h/624yfXz803LBR0wyNjqxYpajlqo0UsCL4X8yDoI/2w7vfgQMCTDvp4pA97n/UXy0CUpxXd78JpuFBrQlZTxFs94eTun30AYbkx5BOOQsGhHh5biq6gMTYnzl0FG7Mneef33IiMpNhOZ+W6wkCaXMaTK3bN5AUGkQ=,iv:XKtysKpR+G+z/sgNswnzpuAsu1voFM765wqZT+4jYRA=,tag:uRYv9T0Xa+01oaohznLwEA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVMG85VE91bGtXdkpRRHZo
+        MmNKVE9YOEhQcGRtODZKMk1sSHlQa3V5R1NFCk9GZVhpcVdGdS9ES2Q5WTZlK2Zz
+        d1hqYkdHWEtpd0U4UWhmWngxaEpEVzQKLS0tIHdYd0txZHliN0hhVmRsSStsdFRJ
+        Zkw4R1JNN2YyVUR0Um54NldldHlJUVUKK0FLH/vXC3XEXhEn+5l0mUlrYsxovfJ3
+        z6ollcJobYstMLFpddyes6mpvfiir/nisNBaXcGqjloiGlqu0YefeA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyNFNpYktoSjI1WlZ3MnJ3
+        cGdJNG0zL3cxQzk5RUxMaGJ6YW5iNnBITlNFCmNhaytOc21FUldMbXYrTFJIbzNz
+        WVprQ3VnZVlleFFvR3FFN09XK1R5K2sKLS0tIE9iWlJMM3YzUUR1cXNXdFRYWE95
+        YWV6ME9wTHFvSnl1cFFtT3JXaDJ4MncKI9AMHtjIjGRavoCG6y9cJEP9/h5mEJol
+        oEpI120i0Qd3mXP+GcI/k9Xwh7m58EFiPbeNE+dJWKoIMz6yYlHSYA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZRGcrNDQzWFhXOE1ZVU55
+        ajVnL2ZtTTF2VWo3NHJmRDd5V05hQXRHaGdRCmpNOVIvUmZVM0QwMndRSWhoY3Ji
+        RUxsMzFPdzgzQzlqd29LcjRpM2hpMFEKLS0tIExZRzZZTjBYZGNtbzFPWVR5cTZw
+        WisvWGtEVDZuSmh2OHZrN0xUOGVodzgKZzK+Zc0EYPf/Nnco8zyL16/28nbSWqLH
+        157s0N0ZdzphCE/v95LZiSks1gUmxwANJFUA/qrwRSOpnLAcdDrzFA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJQ01QSWxMQmpvWFdDSjNU
+        bkJrRzhsbEpJbjZncUxURjhxR0d1dmdGUndzCm5ETEdaUUgrZDI1dVVLUmxHVFlJ
+        WUE1OWhBbUFqUzJ1c1JwbG0xTFhXa00KLS0tIGk0d0xKWHFXVElSZ3BUZlRSdUFO
+        dnA4UXUzMFV6bFY0by9Ic1dZRi91RE0KROZyLBLbOWWnOu0Sg62wREsFtz0Z1FbT
+        2i8bZUw+abcqWM+jmCde1LFJhLKcOzZa1+I1p/AgRufEyosvOyu0ig==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:nB67fYGbvsJOP2TYTzsYWKok+eO86y4NCbxA8IxIO7EKLxQzXRvVNk8GElJQhfDOjEoK1txy6cbqZxBLFg==,iv:k2Ctjj8NPZI1sTIWAX2zUbrEWvlTRCQFfhVJq67FTfQ=,tag:uyPlzKtVfKgc29Q4d8zt1w==,type:str]

--- a/.jjconflict-side-0/secrets/ishtar.enc.yaml
+++ b/.jjconflict-side-0/secrets/ishtar.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ""
+hermes-agent-matrix-recovery-key: ""
+nix-access-token: ENC[AES256_GCM,data:dvLgcrShcdgCflS79pyH916it+qlb/ZDGsMik0z+uP3FJ0pAhlSABg==,iv:i2RDw9AdrQ2SIX7raa42MvYC1TcLkMrr8vW3xDAiLY0=,tag:HSZ/jj/NOSpm7UyADHnkCw==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:46:00Z"
+  mac: ENC[AES256_GCM,data:G7nr0yj6oiZxLOrZeRyV9eqPkN/18ya4sM9cexHTgx+2Pxpm5FK5dacLUrv1bIAVc6MZRIvL+DuGBhJiLKmPwNXBF5DVm8xJiGYDyNGQx93kTD+6Q0sG/pzOUbUfN2tvFCMA861BNR85+dFaiD+HzzAHm7kU5Qn764Xd5P/7lBQ=,iv:v6WdeUbTojwMXdZBFs36QJoODdfdxXeQgwWVx9VZTw8=,tag:x6/2+n9/rrlbzu56WoZOkg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPaXlEUEdpM1ZHK01jaVhJ
+        cGpUN2hUOGhvcG9VV3BZOFNSTlJUckM3bGw4CmNHa2hvajh0REJjbi9vUEwvNUNZ
+        UnZvSktrTnIzaEVqQ1BGbTlPMDZjSncKLS0tIHJPN3NGc1FBTDlZZktnalkvVG5Y
+        SXhFSUlDMUt4d1dqa0x1QnRTOHRyN2cKkxWxU6aVmeEdjDCIpCRl0aMjLfQvDxR7
+        RpZGvIsrIyN8fMRSVPexBmz13pYNOp5TPn8sGzzCTuH7FJkODWuoSA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2NmNTSmFHeUJ6Vk1CMVlM
+        dUl5d3crckRFcmVMS1Iwa20wam1TQTNjWVIwClc1aFlRekVoeGQwQmJ5cEFXVEhO
+        YUgxdEZYSnJiSUFCWldhdWdYK3FYVUkKLS0tIHFvME00bHg2bWh5Nm02WXlVakJo
+        SXdDQldsMktSNTgwcWJDVDMyR3RRcTgKhZgm2T00H3BVGCKw5lGa78nErhkGUrdT
+        gSh1P36cuN3nx+/RMGpioYumqvu+3JyYV5jEIHEfuCW2sxD0HGi4uw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPNDZZRE55WStIZ0lnd0pn
+        WDkrRW5hTEJkSXlHbm1sK2NSZ29FOGRIMjNrCmNWUGdCczVPNmpROXFFZFU1TUdt
+        bXZ0citZZEdwaW41emc0S2JEY0NvREEKLS0tIEMxZkVEdjBaMXhmNWR2ZCtkbDBm
+        M0VVS1RKL1NmanRrUzVYT2N4OWNrdG8K4neostjZo6JrGW1pI3TFABbEosrUTmNb
+        SiCyknpLz29ng4r2dZSUds4Op6+ubHwb8m590WEmn8LwZyqX5HGdPw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQOGFLUkZRQU0ybFNOMkRt
+        K3dxYUVGMVluNG1zUDZVdExKckxiTGlxOFJnClgycHBubHJUVWZ5c29pOC9SUDly
+        emY2SlZ5U0hPQTVCM0UrOUVKcllFQkkKLS0tIGppUjJ0U2dzS0tnMjl0RVNzSGdh
+        cVlXY25iZHp0NExlKzVNeUEzc0hoTUkKx1QhFKVBRnD+4MnTLWcl8ZvHEkVNex8N
+        ZE2g1TX/32RRbJgsnfJz2XDvc8gO7bZmdCy7R8pE8Cr76x4T8GnaNQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:QQ18Tq7iBlgkeEkaUnud637nnwu6gMuPxCg7fKmICKGF3Ams7XT8CuL5aWle0uqasRbGTP9I9Ba5zbk1oZw=,iv:0z9M0KgyfETHzET1DakAIPOHnGLdF/bvHC6fTcyORyA=,tag:uLHwZ2axKDFgPA8F5eok6w==,type:str]

--- a/.jjconflict-side-0/secrets/machine.enc.yaml
+++ b/.jjconflict-side-0/secrets/machine.enc.yaml
@@ -1,0 +1,116 @@
+hermes-agent-api-server-key: ENC[AES256_GCM,data:5OWWA4/DyBTQjcgMAmk3QmXMn+DEx1G0M5XF/v/wwQFTdJuXfMgj0FNolUrVe7FkUPGm+05dAcs4C2mgaGLIUA==,iv:hqG7EWW7z5UV4iFD3S3P1UwXbwW+JEOKQMSCp4Zb9YA=,tag:rKVPavB3O+ZMzp6AzWIvng==,type:str]
+nix-access-token: ENC[AES256_GCM,data:YNiJgkCbdEaZJU4igBelAh3zZEqLF+iPcZ5J73cEB/UOshbveGjR8w==,iv:ZPZ/4H2zoNABDj5OxdRipaYz3x2b9Q2emems6Z/3ogc=,tag:LNviUqqX1XKmtB6H8ySjcQ==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-26T16:12:41Z"
+  mac: ENC[AES256_GCM,data:GLgJoqvx5oi7n/dz/zOKAY7g3FrwZUo5+VLjSqTHl1IKZkXQRTRyX98Z1hnzcUoC4bWkAfEhzOZoaTiWs0jYFoF7/T8i7MyvRFHnlE45BJwI2Cb5Lnc8QKQ1Ypxj+L14+k8cCgn2qIvxaP1V5Ga8BDawrfjnE+ykEPRYoTCpTTo=,iv:BI5Jiugmtip1phWrqqHSD0egHCM1a2O39TIleA/zcQ4=,tag:IOc8wOFyS0oyhgay8Z8a3w==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
+        Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
+        eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
+        V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
+        y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
+        QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
+        L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
+        L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
+        lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
+        eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
+        aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
+        QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
+        +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
+        dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
+        RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
+        UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
+        OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
+        RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
+        MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
+        NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
+        8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
+        KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
+        ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
+        eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
+        Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
+        VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
+        RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
+        QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
+        bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
+        VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
+        bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
+        ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
+        PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
+        ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
+        ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
+        VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
+        wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
+        aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
+        V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
+        ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
+        NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
+        MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
+        QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
+        UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
+        EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
+        OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
+        UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
+        enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
+        Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d

--- a/.jjconflict-side-0/secrets/manash.enc.yaml
+++ b/.jjconflict-side-0/secrets/manash.enc.yaml
@@ -1,0 +1,45 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:7nXFjGr+JEn8UsIs4omppTF6Tw5xihebJQzlu31ZEFyIxCl9fCPgOQK429weIwY=,iv:4bLASEe8v0XUf2NEQBHvhsXggk/oKv4oIj60RsVR/b8=,tag:UWtc9GIQnmEjvi/UL5rtWA==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:dk14TvqJ5rL4lIaRbbpoDx9odEoK9Xzozh2cugcPqJMih+RnqBmm4xqq5Q6inHd5P/aDW2MWKmVUsTg=,iv:7zEvuOGjTEp1K7QjmXkj1oc3WyqjESiqQTXfq3IH4uU=,tag:CjXivh7qKWx9LHO7yTvI1w==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:18:10Z"
+  mac: ENC[AES256_GCM,data:f1+JQ9sBCpeqscBOvsqYqknAckhGiVef59wWWn8/5uujqOY6op/4Zv8IHkhmzxMAqWL3In0IiuR3z2Vxlcg/vx1CalJYCBp9g9wusVh4LJYUlOHgRg+3PkggjKtt0Gk4FQp6xDFEpYUb6tYwvI3ZQQZqXOM0N5Fr0bUlZrrAcFs=,iv:z32EVTDnWYoRk328seltQ27Zsk+S26sQ+33mPRA5rFM=,tag:KbjThtF5rF+7bwK0UJFQfg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnQW5WQUNmWDQ0YnNnWFN0
+        VFhGT01QeXo4T3NYOUhtSzJjdFIxcWdhSm5zCmcxNFNDSnR2RC9sdW5CQzFGWFJO
+        TmNpZkZDZ2hPV21QZGxHYkdIa1g4ZU0KLS0tIG1xMmovbUFSOXQrTnJjRXhFcXlr
+        Ykk0TkdIMThwcllYaUZOZlZZMFV2NDgKpwZbcGniXL5j5E0oaExuxy2yg0mzvt9W
+        EuT/O0zCnGfGlvPAiuCI3d+dNZ0fnKb4e/kDTz1cZlSTTZ0bu5E7Kg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIU0dKOGlMN3hFZnlXNjRw
+        ZU5rQS9HRHJucm9qa3p6b2pZdWVSY28vdW5jCm1wcFJRYlNibktyOVdHR0JVN2Fh
+        MnkvenRVRnljc21pRmllcXZmdk90UXMKLS0tIFJOTkFRam82UUQzOHZDeDZaNnVi
+        WGdHaFRTZElrNXlUbG51MWlFeXpYaWsKju6PbORYFqDxsxhSc8BAIsVE2TMM3qHN
+        qLtAQP90kLZ7hZ7dXtS6tI9LUG9wiFf3R3RPKQyIYcjSkmmT5CLEuQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjSjJRNWc1YTNzZWVEeFhO
+        TnFObW9qZkpKWjc3R2ZQQ1BMdlFBU0VJYzBrCmlGa3BUa1p4ZzR4SmRxZjFmWnhD
+        a0RtWVZFblRsdG1pYXJmU1lTQ3NvTWMKLS0tIFo0elo1TktuTnRzamRlMkpZaFRs
+        d2J0T3hBc21oa0xpY2lxZzF3ZC9Ia00KJ476XOLRCEEZv3JvH/TEZqpWC6JW+es5
+        RGr/7WmvMm9DyPliwGdMETzWfDSweN545QiLofFrs7xAYBuSTBS3eA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrUTJjVUpQVEoxVHdzQ2dS
+        TU9uTitUTmlRa01TWENFVnc1bW1KL2MwWVdNClNUcWhDNGo3ZDVBeWxzWm1DcW1S
+        ZlQrcnY5TXRSQlUwV2lUNUpFWUdiSzQKLS0tIDVpdEN1d21TbTlubFZGUnFoMTdY
+        bVR2SmRvV3FPZks4cCtVWk5VM3gvK1UKldfANDooYmyhSUXuFXkx41FHlg48PdNQ
+        acSGNMHbpHdWryTy1/InQ/zYON+eFRxCp6saLUaThEjRVjC5HLBvig==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:ZEPLllMaCT6CL/niE64vzCZYxU/4qwqofSH3/vcBZdrZI5PrwiIfjp85/QGRkxDl8CVZh8nhNd9hlrJ1ew==,iv:zgmCYCcyfiokdTDvMqMGYLKc8Z8DJoj2Rwz1hUk7Sok=,tag:yPdHH+uVG0y5DHBGmGUXMQ==,type:str]

--- a/.jjconflict-side-0/secrets/minish.enc.yaml
+++ b/.jjconflict-side-0/secrets/minish.enc.yaml
@@ -1,0 +1,45 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:t/6TKQa5ADbuXqKu5OZYFoL+INArb8S86mxFRSPnr25ip1EqQsPPHSrZJDL0CZ6O,iv:WWeJhWX2vrWPLQFw41ZAbdszjDqvmMVHVv1xyVOxp0Q=,tag:jEHodqzhI20aoqTYz8UwCg==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:baIGapTb1ZxNFM+0Brpkk30osUGAm0D6/1OuidEp5gg0113Q8VcsEixILICW84v5av70wGGpwr5eOxM=,iv:uu8GsQOY082GaKhSCIdtHwqLHab5ovyGHX4Guilr8e8=,tag:bNUTvmpnviwmHCvVpOl0fg==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:18:42Z"
+  mac: ENC[AES256_GCM,data:HPX7PRSCZm50WAWtIgYafxZvcZn5Q/jiyRFLjIPsMesQmFuOWHM7S9IUu/D5YFVxCjxP3ban9fbGSRbWhNMZmM4s/pdbpqmOk7+85EkwPCcgzBimZDgNz8yAtEta9UcIs6na3MKCNhAHOEkHdckgMR2g5wNK3/0OVdpuZ+rb5qE=,iv:qZPm0NCs4HWFbtRhMdDglQEl13Ki9st03ckRtPyI6MQ=,tag:9hNM+EteFFbyJdpJWH/2Kg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0WW53NlJJM0wyeDh6NTBO
+        YUQzOVBmMGZpM0M1aVU0Z1FzcEFhenVIV0JVCmh4eHU4NjFxb3VKeFF5Z1ZPNjd6
+        Y1VsVHd3aVRSL2FkNVY4NkFVWEZaRmcKLS0tIGlOclNjYzdaUDVwZU5FamNnM0hF
+        SSt5cU8vUTBEcEJld0tlSUFJY1I4RXcK0J5UaTjZjDdOS2gPoPIXe/CJsLnZsgq+
+        r9un3SUpKWfpFdHfBOAFa/l/7gMdCyVSXpRg8QXH8DvzFByetu2W3A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzckRVNFRKYUl5bDFHV2lO
+        czd2UHlBWW5JQ0xpT3I4WmFmZW1Ldnd3Sm1ZCnd2KzFFUmUxUFIvQTFrT2JiRkI2
+        cC83OXdOU2hwdk02V0ZnUE1jQk1Da3cKLS0tIDZzVGN4R3dtV3E5b0VuTVVvQ0x5
+        QTU3ME9mUmJmQjNXa0hBdnBpYmNBZzAKXg3mnJAiWEM7fmKcTr218fueMup6Keyd
+        Iw3mxTr/AaGSE3WRw9U3FLhPnyuGaBduPyEJ3fKr34M4ITnrqBs1SQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBURDBVTlQzZTFhNlU4VTVu
+        YkMvOTBDdEhTTUpnQW5hOVg5RlNWZS9VQlFZCnpUWW9XRTVmOGlFSTJ6TXBtL3R3
+        ZVRVd3c5RlBXUStIdGJ5WGptZEJDcDQKLS0tIEVPeXVNS1BqU0dvOGZpaXZhR0RY
+        TENmd0lqUlRiaVo3eEh6L3dwcVp6NncKpuYVtzBxRTHAyamjTLkgxdw0uzMc3/nU
+        oaeakcpJACr1GQb6/TjiL64igMvgQ69h9AEvYABrgdGzqwi8H8fOBA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvSnExcC9PYUk1MVBMZlJI
+        S2M1RTN1WkJWUEZUNFZuWXdPeXA1dVFXODIwCm93Q2ppenBMTlMwbUk1SmZpM3JD
+        L3UyRTdEQ3hEZyt2RE9YUzNROTd4Q2sKLS0tIDJxU2dqZjRkYnJocytFeU1pWFdn
+        c1lUbG8rRExyazczdGdXbWpuazc4SEEKt0AO2VurRA31lERMofSaycgs+ZDA9mZV
+        GqJebZNxc/5KvEXx/rxQTqjaN3tGRDR/oCxVGF0ljVKsnvWfrGNH1g==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:hh4dCCPW/ggnQNz0PiMIIYrgXS6GS7ZLHloUtgXZqmD+Kqcd4N8+E+/Jh4M3lb6iWrjcnLbp5o7XTqMhBg==,iv:pDDPciOy36G5LTIeQom3TnsH8hpl96lFjwAD0wK+lHA=,tag:BSGUbHdGs2jkeFuvOMXX9w==,type:str]

--- a/.jjconflict-side-0/secrets/nalsha.enc.yaml
+++ b/.jjconflict-side-0/secrets/nalsha.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:snW3Mss2JXZLy533H36PA6iKA6GgPpN4c+h/pocvvyJHNH7heJq/0+Nodw2VSI/a,iv:yTRhmH5anA5ZmthhbGgFZcbgSOsJ3MXWHB7Jupt0XHw=,tag:o4srWprcFEI91OblmyCXWQ==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:19Im7ckaD/nWE/HaMlmoVpgUlnxBs04emF280l7r8U3U0ll93yTmYvesGH/2S6d62gHH1GIOAQTycZM=,iv:9rqUZp/qd81P7uB7/H6pvw5lJswN9FagZi6WedRJKzs=,tag:yJ6VBVpvMGgoddOzxG8oJQ==,type:str]
+rke2-token: ENC[AES256_GCM,data:g/AJcEXEFsdCvQVrXEhPjR5ZIrWPXRW3bmLjqD1UifvjAC9wpJ/xZKsA0Au+ssA2JUy0P+Rei0jOoSWYA6SWiflXTVbAOI5ILfa/KABnifxcTqJYgyHGM1hXdfcDC4UO9x1JG+Pa5FFisZqe,iv:2DecG6Y2IDS6Cj36B4TjGaHTjyyCh2wuh9Lwc0BgLEs=,tag:YubnDbaHkGrv2mFhlTfNag==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:19:06Z"
+  mac: ENC[AES256_GCM,data:CjUzO/g//T9VeJKuw18xifslkVEXYsXuManGX6/jwfJXhAzTIhvrPnVETBugYc0y5TdzApALOCN1RWSlp8o/yHMx2FKJ5VvJF1Sox35YwG6EIAq+dr7VcHiMiyXBl/6Ng5Vp098X+uc6W7M0doZR2csBpbUZ6DvkVuwkXbBlGPg=,iv:GnfJGaFRuIy5dDqhHiYld2gvdFjA/1mDPJQBjKYarh0=,tag:UjcCq5XmwAdiGtXOx5Q9WA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6UTYvYkNDKzRhWEQvaHlB
+        OWE3L1RhdVUwTHprN3pEd2dBU0NsdGx1TnpVCkdmZHpaU3JoWHNWNXRKYTFsTDhR
+        R2xJbWN6akh0MWlNV0hMbno3RjNaNEkKLS0tIEFHTXlsTi9pNXFaMi9QUVQ4by9z
+        UStzajZyOGlLTDRWeVRXZSt4N1dEWG8KRrRLSEaYv1dQNwbIXZ0bWC34fg0KAZZI
+        xJNIqLa9fV9a5HRABcHwJ2gBJWhw948IUELVl62JuyYO+hlXBvXYag==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBodnNBQmR6ckZNaDcyM3Yw
+        U1h5S1plYS9vUmJoRHB0dmVBejlQdWVCclQ4CmFTVFU4UU1RNVRHMGxhNDMyd0h0
+        QXlWaW80bkY2VlpIUm5NdU1xQXBZZ3cKLS0tIDhOdEF4Wm9aVGhlYWRqVjdCeXdl
+        b0RTSGYyWkowNnpGWVMxN3hBNjdRNHMKXOuB3CcuTEgTyNmfM4UBj3naUqH1xTBJ
+        DunoIIyv0BwpQw/USUm9RA2Xh8et8PuUJzlAcHe3Tj5k8EFQJiUuGA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMlZsenJGamlzZGtzM29T
+        MHNtTFBhdmNQRitzcGNNc3BCTmpyTXJoYnk4CjRkNTdidjJ4c2g1T1UxQzB2T3k3
+        bEFlZmEyak5rY3hIQ0ZUVjhFZkhzbUUKLS0tIHV2cjRBLzZMOTN1Snp1R0VRbktW
+        SUdVUEhGM0V1dFhwVE4wY1o0OUllTDAK6SG1HnF9oTtChJfm/y0cCs8+a+BMD39F
+        Sc2OLJkve33/SVexI3inmFadAA5+CtAdnF7F+t8vNJEhC1kGjfn1OA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBweXVWeGtVM3pWb21KTWhz
+        ZENWTVFxTmVYeHFXSVpIYWdIYzcwYXd1bW5NCmt2ZEttMEI0aERqTlVGVFRvYTFJ
+        Q1V2K2c3aVlDNXVFQkhpNExRMlphalUKLS0tIGxRcUYzekJPZjlJbGd3M1JCRWhi
+        NWEzZWpSdC9FNG16NEtXYnZPVjZ6Z0UK2aJRKUkSJfRt8Yuca1rFmkrfYFlBuKbM
+        /fuD9Sh/NcSoO/H3mzP2vqIYo+DLUidc3y5/nX2NreZ0A1Lmf1dEwg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:VYdbGIAIfhzkTR4S6uXdVrVRZ5ik8+yeImeEAnhMndXCUrpfkiL4kZmcZuZuSqzJdcrApGqerjKQYalSDek=,iv:5UdlWSJebS37zz2/t1bgtTk+4J+37osTgi8ieIHE/II=,tag:c99a1/G8MdzUtzjce5w+cA==,type:str]

--- a/.jjconflict-side-0/secrets/nemishi.enc.yaml
+++ b/.jjconflict-side-0/secrets/nemishi.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:waGWq5I2MZEmHYUQzNu53lj9/D8FAhnmwTSpPnz3+BaMsYhZe5qe/Xf7e5Fifhrq,iv:/lQmN5UrwDNwlIFAhGky4BkHL5RfaQsYVdjF2TYm+ZM=,tag:me2eFvJMSqXE8OJ0h2ETcQ==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:rw+peVbm/oTOVhfMUrmAQI31EAYcLp+XH7WBeL6ae3CtUSb8ZP0xeVO2nFXDa0yIP4ygVYE7AHEXyv4=,iv:ogXQ9rysIiFbB5YEaiOEYcdyLBwT+3KXmIPeITsVgyw=,tag:8EWoTDQXDdIfuUADjlXulA==,type:str]
+rke2-token: ENC[AES256_GCM,data:jr3FAFEMjcJYp5GEZ2QiNA4FOlc79Ebg3isbIF8zyiGq2CJM4LnKV4LrrqAhoW/J0uG5WtEszZVGrET5umR4oohcwxIcRwxzNZ8v2ZlqboxUyjHO23eyKUw7HKdq53DIv5Xr2baxs4996S0b,iv:nyn6F2MxQehUVoQF5IA/BP/RK5PRnf7Hq2z4+B/DdTg=,tag:EC+B433pMRQzs3UhHgZQKQ==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-18T00:13:15Z"
+  mac: ENC[AES256_GCM,data:vIgUr98wab8yZwvwks8gFoFRBcuTP66ILb4DM6Gj950a1QZdm+eos9mWf5GXFDarT/MGXxax8WTTIQGuAdtRXIyOiTmNqljxJsPusYhGEGkcGpUdoCMqCumEEl/7qr9oaxJo2LcGVO2cCL3fpygJnzr4xl/DE80JpR34saGoD9A=,iv:1IF46VBM9kBmKfKcZ7Us5XyySBdxVxXRQ0YvOj4e7ZQ=,tag:L7Kpqf3wAYv1swYyL3tH1w==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYTVEvN09BZ2s4eG12QmxT
+        dzZvY2cyejZDbUNBVENBVFcrcTFVTDZQakdVCnJkL1pRTXRTYWY3QUxsUGV4Q2g0
+        Q2dOSFkvRkRlZHpvREVFVXBsY0FnZUEKLS0tIDFsMGkrOW03RXViSU5XWEhWSHlw
+        RW5hUkp0OGFoVVVPYXZqeERROXhHbjgKsQ2j9Qz3xDwomUNK0KfHUeIAoV3ipZ+e
+        hoiHvEOS5gxrrm3wn6M0JQdrx+mLDST3QgCEG1NLrQHsD3hZIvZ4rA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmYS83a0hBWDdKS2xMQ0dB
+        cWZKOG5idUpxbUNTRHdZb0JSbnBHWllZMmdBCndGY204bi83V3pETmgyM0dRTUNY
+        M2lyeEJaUlhEQURZajZHRlgvc3JWdjQKLS0tIEZXdG9xMCtpd2lVYURXeVBpLzN5
+        TG94YTZKOUtJRnVhQzhBUEp5bkphM0kKNx+4tH3ZiwX1tmBjM9J5Xhsye/N2ZRk3
+        HYJn56R87j8M6+Pjy/dT9z+bBu30Xa33IIA0yflpC2yXgm3TZAjyew==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEV2hYNzBBQ3krbVBqNytQ
+        Y2g2aERsdUF0RlpuUTN5T05PZ0ZGNWF1Y1ZnClJKeEZMa3diSVFvRkdKUWVsSGwr
+        SzY2cEpsNGt3T1dPRkFQZ05UNjdGY3cKLS0tIG1CK2FFMmFiSFlaUFRKV2hIMWVu
+        b2hvRDRSU2NyWVhEM0tUZEdtclUwdzAKvOZCDzwxkS6CTP50t4qrXaLy2qp7xL5s
+        j5KirK6PGEHzvZqVwCdPHygbhSSg6uYWmDUfCdz/+BXY5DXBglj6Eg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPTWZWK3FLVHVTOWNZbFY5
+        Qkd3VDNGU2d3ZWs0dlJGYk5tUDFLSTFGWW1rClhuVXNrbmZNRzV2Wkw4VUU5OWlv
+        M2taWHphc04wcFZrM2VoMnExYU5PdU0KLS0tIG92MGs3MFpvcWVlY0hoVFBTWkw1
+        RHZ2aWpjbVhzeDVqaStVWFdGNWVGbGsK5lgNMIpU2h5W7QPSeA7upQBUBNPWs6WW
+        z9rPyuGgRb2rjym6HQxC94Cq1IItHaJrFFE9vLNE67+vDEMZusIwzA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:xBCR5J/gLhrS8i86SShPyr4HNCb+AsrcZx5SrD3Povej80HglRPZ2Os2gRE1XvwEkpBwXpGw2eHvdbnCwqw=,iv:V0Nl34zHjQfl3+kqTRlCxnUkUNMKwaNgEmHxPRHMaQQ=,tag:bg9TbfaxahQVrWUWPgQ1uA==,type:str]

--- a/.jjconflict-side-0/secrets/nishir.enc.yaml
+++ b/.jjconflict-side-0/secrets/nishir.enc.yaml
@@ -1,0 +1,88 @@
+rke2-token: ENC[AES256_GCM,data:5AosLTIWOjoCETFBJHXWe7R6NiSiUmpLULA7P0/zdwx9CnwyLlQBHiNR63RjqJLpbfzBQ7aD6+1a4SuhdJWQg+BXGWU/zuecJk48oOH+Na/BtRlKl/6XQBFGfQMfPxOypEsy6w74ujUv30vW,iv:HMhX5w6NJQ0MtE74qSAfgTiPrHfMqIQnEQeakW0OxBo=,tag:nwB2AYQvMq0Vg24P5fuhgA==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:28:10Z"
+  mac: ENC[AES256_GCM,data:43xVYtGcD2XSX7cYsgYPs5Vu7BO+A7LxqKCvMXsj6pqJU5IqpdAF6D4bHEX47lgpwjKwCzQa+6Ad6no0nVs//WGFySZkoDzSbr1cWOf3AFb0vJxDzQhI6r+UyoGjhli9GJ4padRiG9A+0Yzsa2PLjpSAxc4enhPXxsmwW6FrO4g=,iv:gShWJlO9hMqMaWuRCNWqsfrX9DyNCESzQZ5JOWUpxuM=,tag:KqKhGsyl6TpXMZyRTkbENw==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxNkRFcVlscU9HcGx6N1F0
+        cWVKVXhTajFoSGFLTkZQS3NjL3l3RGxpa2hFCnhaQW5VclJtRTVTajJnVmdpbUtQ
+        bkdwY0VycFlBUVYxR3hPcnNOdUZVQ2MKLS0tIDQ4eTlyN2Jqei9jTXlGRmRYSkRG
+        YmJtQVNDRlpra0NWT2dtaXltMzRsbjgKtyZ5N4geIO+URngJfGDufSYQLVWcsG70
+        LomV1fBJS18WKug62RmnoHOzONzroGRAKE5BwmGrr2tjbzUy8EZvGQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCNk5tanVqR1BsbXo1OWpl
+        SlBLL25MSkhPc0FrY2RBcU82b3VTYjMxbFhFClpJUTBEK1I2MTBDY3hYN01yanJZ
+        VTZXMThUWHVRMzZyRGRIRC9xd2RYMVUKLS0tICt5eEV4REg5Yk1UaVM4TXhUVHli
+        cG5GU1A0dG1nNW1ZMktueTh6RjNDSHMKkHw3vgjEy46GMddJsV1XgFO9b1+FQqYK
+        bDd916OUqerXwGArZfV91s+tdvMMNetJzE4v/n9rFjz4pCPeQaFmGA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLWFlROXlBa1lRM3djd3ha
+        SktwNDFSVG1LSVZ3d1FyU2FCV0FPcjVuWlVNCmYyM002cFZldGNkT1FpTmxLRWNy
+        UUlLeDR1eVV0OWU4ejY5Q1RrMmlsbjgKLS0tIExFZkZydlNZck1oYW1pK1pHWSsy
+        RVN6K09LRjV6anFYM25rRWREWlpsb0EKLUAo+l8ZqfImRfJeSsk0QBCOiFhpJHMh
+        vIV1kDY1TZwiYT5klbv0KrcFMY0SQiZgFtuCDWxP+YOSr+ERnyTugA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoN3JVdDIwZmJEcG80UFRW
+        eklocDY0ZHpJZFN3VEtxcTlvTlgwSldENjFzCndWcDI3QXpZV21ZaEtpMjIzT0Fi
+        WndZZWdqUlprVDRNYmhwYmR6RGtqQlUKLS0tIG54d21CQWRVcXpnUE8xbXYxVkI0
+        YXNrd3FETWJHRG0xLzRYaWJHRU82dHcK345pk8mV2j7WY5fzfPGUxJ3CpwfAj66P
+        giyG29Iw2ANqjdxwyOtB60vC/AZt+4mhMxCjqGIpNOM+j8kTJ6sfZA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlUGhhbGh5ZENrcXp0b1l3
+        VFlKNnlyVWp2bndxN2lFUjhhay8xSmcwNEFJCktmVjZQL1ZTREQwd2xkaW5PMWlI
+        VC9XNVlOWGhpTHhDdEQrZm1yQUxZTUkKLS0tIDUycHJVQlVndVN1WUNGSjZXMkxB
+        RkZRcWZ6ZmV6L094ODhpRFlhYlplN0EKHVIhsIJMMHUW9SVAaKdsMgW9N3z/79Lz
+        PXCIPj3q76/QD+RMacE691KI9OtNSTmcwTqNt+a45J6vlGV1+InArg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDaWV2NzY0SXRSdzZPVnNj
+        ODEvRUkybEx2UlMwaTdIeGRtby9aSmw3bUZvCnpoS1ZTQXpOb0RFU3FMc01wZm9V
+        ZVZCczlaVlppUExTZk1UNGFpUkxQTXMKLS0tIEs3NlNvY083WXNTWnREZzNieDZ4
+        YjJ2ZStwNW5YZEM0QmU2ZjNWK200a2sKLulTRxCziQ/il/aZ0JZ5EKGTiIPVutRI
+        NDasw/7GIBTzMARRaeoErYOkME2x06hBUsLJsj0dYN7VEgGXZIHFIQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxazhlZWZKdlA3amhBcDdQ
+        SXNTT0hTaHppOG9MMHJvbCttb2JrYzdXalNnCnE5Y0tvMWE5T3ZkOTZaUEF1RUNC
+        bFVYNVUwbUdPeGFZbHYwVFdVNXRIQXcKLS0tIFQ1QUJkTWxseG05N1FkRFNMNE5I
+        dk5EcVBBckw5cndQRU96eEd1aVl2TUUKXoM8ncbFKQk8Ot/NEa4o+pXLnJ+MkJJb
+        kk+ui15uZkXQpp10diukYIcztKVqO7HSAbGPWJf5x5PN5OkFww9GhQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvQWQ5N29NQ1pGb0R0Ync0
+        Yk84YkxxRHh6QXhDM3VZZlY2MlhMM283akRrCnVlbzlLUUZhT1ZFOGUxSm9WbWpv
+        ZHNndFRoT1UzL0VXa3RyTHY5cVhqZU0KLS0tIHNGVVhDQVc0NGI0blVRWmxDUFcz
+        RVZ4SEF3alF0bCtKSS9EaE56YmFHUWcKqthvweRL6fjR0ogcxE99RYhtyvX50mMv
+        Qu8ZOw65dwU4DfgYxjmhigh4AVJZp5wTaiIEbU4CiYPhrtvOBAHAdA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPZXhJd1ozZjlPK0ZMWDg0
+        OFhYU3RCN3NjaDBEdmYvWXgwVXFGY3ZDVmdRCm9zTWE3bGpCdWNDQ3ZpcGtjZXNY
+        aUFZY1B6NGlhV0xYRGVvbzRlM0FqMTAKLS0tIFlUT0hydCtzUmhIeUIvTFN0Zkw0
+        OUNSZlUrVG1WODZvN29KMjFSM1MrVlEKjzCCTBaVLHkhpjdjSTevl4m0NLCr3QGz
+        ICUCYkG+mh/fKa82CtdvebjIVvHzzdqcp/2E2X1hQqNeMlmtgkV4nQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-side-0/secrets/nixtar.enc.yaml
+++ b/.jjconflict-side-0/secrets/nixtar.enc.yaml
@@ -1,0 +1,44 @@
+cachix-token: ENC[AES256_GCM,data:dwXGa5vw/rMwCj2hXQOGR+qxrc29gMKpqATFm4gmIBKJ5A36Hav2Sib8SNU6NwhvHXi79scQLE/wt8Qyn9M1JH+IgoI44Qbde5sWCBtoYHNJFC3Ai1uhYKqWgv4AUAkBndi2PtSguZe1a+sM69QgXnlY8AAkHM/y7CXShBLQ97kGo8ma/+7u+mzHTablMz23Hw==,iv:4wqET0AwsNOSKSZENOwrMnDtL98JXqhSrSDG8DOJoqU=,tag:VI6pUkNx/1Wm0+yEGix6Zg==,type:str]
+nix-access-token: ENC[AES256_GCM,data:dvLgcrShcdgCflS79pyH916it+qlb/ZDGsMik0z+uP3FJ0pAhlSABg==,iv:i2RDw9AdrQ2SIX7raa42MvYC1TcLkMrr8vW3xDAiLY0=,tag:HSZ/jj/NOSpm7UyADHnkCw==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-06-29T16:39:19Z"
+  mac: ENC[AES256_GCM,data:aZzVwt076CLVFqVqgrcH5dCB2tXjC3z8e1VhFE4JYLYvPJVuR6AfX9kadML0Xx16bkNojpkD5y/BRiACnL+72126iqPtU0w9sWFfbL+1OIxeicqwsJUW+g1vtB8RcmDnPVN2ZcFdE+Blsz2FmRoMgozC8UbbKuqAsPESVrnl5IM=,iv:iYZb1OT0nsZANSFhCgxETcTISIQZID/7TTXvYhMdMcY=,tag:7SmHXqBbzRF9JNxtglCUDg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4cXBHSWNwOXRXU0JMYVhh
+        Qk52TXUzZ3JCUmtoZGNaSG9acnVhdVVlSldVCmhNdUN6amxlbC9uTk1DaDBTSTQ2
+        aUJQL2hPSU40RGV3eGlHd29TOEc4QzQKLS0tIGJ5ZzhwaVcvVHBVdHpWSmlub2hK
+        UXU0U1E5UWZEdnNWSWtxTStmQW5ibGMKgv959BPaSISSi0RKYYw416q287byXhM+
+        sEcSvTyKPwkNy5ITz6khAwpHHXxdyUXpHL0WrYVVMwd9+aspdSDDKQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwVFlwWnV4NVVsZGlQMjJZ
+        bHRrbExVZVFkR3F0eENlQ3E1azFVcUJ5REI0ClQ5Y2ZTK1BPblFlN1VOSnU2Yk1L
+        ajZabW0xbzFjM1ljQ2NDaEhQL2hCdTAKLS0tIFUvaENYa20wdG00UHBEblpZdDMv
+        eDBabzRJbUFseTl3RlMvVVh1U1c1ck0K1FleW5E945xk3OqAGqu2yHy4qnAdnDBK
+        hfbL+O2aRQMYHiLv2EqTQk2w9TCp9lndCBdLEkDRo33shYgStCbizw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1Tmx5RFZISXp0WTY3dXZD
+        d3hGS0JtR1E1QkQyVm1ZM3JoNlVERjdNNHlnCk9WRklkOW1pQnBrQzVIOW9uSFV2
+        STRnSFdoVi81SXlmODhmdjhwcTJpZGMKLS0tIHd0bE42RWtFVXNjQytlRVhyZ0lQ
+        ZDlSUE0vZGJBamlhUnlvd0ZwOHhTd0EKRpQSQdoHUfZsSKqmZls/DPIt8w3O9I7Z
+        RCRPzvy061e8RAdGo1MwC0BnLfFN9G2e2VfBtDFqx5kbKMbZJgKDOg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6SE42dDA4Y3ZtZkpUTGli
+        VnRMdG5lci9mS1E0N1UwR3krSE1FVVFnV3lrCmtZcG1SUkQ3UDl3VDVkY05iZ3cr
+        cnpJT1JDRmRGV2tzVHNFcFZZQ0VWRlEKLS0tIE5DU1FhbWxBRXJncDVHbWI0TDk5
+        czk5VmY5ZVg1cDh5Szk5TjNmWXBIWlkKe3cCxU1z3lD4qLryQgPtNgBSBCT6R3nA
+        qZVBZzbK9LZheByMR3yBTHagFtFC8v9JGXEnmKMe1+OkBVMVd481JA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-side-0/secrets/shikanime.enc.yaml
+++ b/.jjconflict-side-0/secrets/shikanime.enc.yaml
@@ -1,0 +1,34 @@
+cachix-token: ENC[AES256_GCM,data:dwXGa5vw/rMwCj2hXQOGR+qxrc29gMKpqATFm4gmIBKJ5A36Hav2Sib8SNU6NwhvHXi79scQLE/wt8Qyn9M1JH+IgoI44Qbde5sWCBtoYHNJFC3Ai1uhYKqWgv4AUAkBndi2PtSguZe1a+sM69QgXnlY8AAkHM/y7CXShBLQ97kGo8ma/+7u+mzHTablMz23Hw==,iv:4wqET0AwsNOSKSZENOwrMnDtL98JXqhSrSDG8DOJoqU=,tag:VI6pUkNx/1Wm0+yEGix6Zg==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:45:28Z"
+  mac: ENC[AES256_GCM,data:OnoSFR6Mj6oCGJwLU5UJpFpmPj5F4MH7JWADgNr/XpLb1OT8Jb01RWzU9vnjmocANMjhL0Hmi69CCxDSS+1C/uJBEbntWh8y15Kx22wKYGX0D0JM9UVZL6MjqK2czgleRV8Tw84GncxhrSPTCsXFS6TtRR5vpGYH5M7f7T0wxAY=,iv:HcSoommTPisTDv70BQAZPlVx4AU3Xro1b2wpzj2VRcE=,tag:Pj6Np0b5PrQDzaMA1hNbhQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrSUJHTHBMQTZIa2YvUUYw
+        bFljMUt2Um54MTF1WnhJWWJXbEpKeTdYZGdrCm01bnFOUmpucENXTW9xbEFvQ0tD
+        bkpNUDRJY1BaaTgvZjhjbEQxYXFybGcKLS0tIDhnL2hCdytFYXVxQ3JtWGFSc2lG
+        WXlCcGZhVWwvd0JXc202eUFpYjJlV3MK8BUcmudbDHXPQpM0lrb8mG1MZAxY8Z4M
+        zWnpHZ1pUCILw7QiTF0XFL4C6RhATEkW7MwAmiffaeskgPScWrkzHQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3d3RwcU5lMEsweUIzVDFV
+        TmVlZXdoelY1bkc4ZnZSQ3A0QXh6enovOXlFCkR0YnUrLzRDWWZaaEhxcGMvSUhi
+        SStzUFg3OWlZUllIQWFrSEQ3RkdJMXcKLS0tIEtUMllaTVRQeHFVNlhFOVluMktI
+        aGk0clZGNWE2OU9UTWhnbjZjcEM5N3cKfMJT8JYSRz97Jh/BWMcvn9Jznfhcn0zn
+        VWRpQ81l2qlMITy1wepwaNAWvPJqMDlG/RWcWswYg1lSLNZRjxsMCg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNT3RRcjk3bXdpMHV5bWdW
+        WEsydEVRbExZTWhUK1NWWVgyWnBnNmszaUdVCkVPZkZFT2R3QWpka3h3QnZBbVRY
+        UFY4NnNSK1JMMmplZ3hybXpxS1g4QWMKLS0tIHdmYk1DMU9rbFVhRnNPVDFFU21G
+        WHZrckl6WkpVNFhHR0V2blhvd0pndFUKRthQwsIiNQtnStWWnvtlu4j/cnyA12/M
+        bqlF2P+pbNaikcC19l+unag2LOmjZK3wv8f73eZuGDG/XMaV3649rw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-side-0/secrets/telsha.enc.yaml
+++ b/.jjconflict-side-0/secrets/telsha.enc.yaml
@@ -1,0 +1,44 @@
+cachix-token: ENC[AES256_GCM,data:FRHttdD/mTcbI9oniGsaCCkZofvzGKvmRRuyRBRlq+MPqmC0oH2cSGrxNDirw7KnWQSbClUlT88MJSXZK3jn2eCtV+O1sw33/shVPmeLqCKdKliYFLPSgzvcYScBmHkIkScJAkcJYsiNVapuXdca8cufg2cvbW39xfo0JhDFzSF3iAQf53Mem0bfCFTtG4O49w==,iv:Dn2L1qrttIC+hKyJR7M6vPMZOhPz7K/QPmwOqFpPVCw=,tag:2T4i7ZuA2Jjrpb2veTqDCg==,type:str]
+nix-access-token: ENC[AES256_GCM,data:DxJtamrimFuFVhi/3mJDIsndFg2e9L7d6wKRBKuS+XK97JQuRQvjKA==,iv:LIveL80d5piluFLeskVGv9AXamsxhNBbAD7LyjGkB7g=,tag:OfcJU//3e8cTxINgAtRpug==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-06-29T16:38:57Z"
+  mac: ENC[AES256_GCM,data:hB73dXZeJHId3lvCNSVxkuyFBVu0rX1hh68R4hyIRMan9qmAxrUPLJPloLBTJhww7TlktVYkuCe3Gnj87gM7MdTNPARGtk3e5uTj03irpNxDnDPQTtgYRUFDqvzVduzi5l/IA3AMIwVWWDMcFuxlC9S4pilWZmiEXaX7LtfD1Kk=,iv:PLbNqX0saZ2VsFKIkq0PqGoCFn8XtNSsFR6F/ol4/pI=,tag:8klp2hNOBVC2WKg68Oafqw==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4Y2dVc2N4eVQrcDF3NGJr
+        dWpYeGRSL2RzU1JBL0pXWTRGMUVQNVBpMEdRCmZvZkxQamJ3dFVrZFZ2YXBiNnNL
+        NUdaR3pKcEsvc0IvejUyWkF4UkRLaXcKLS0tIHdmZ3U3TVJVRDNnTlBwOFVFTzUw
+        azN3aVg4VGlYRzhBS0tzS0FrdFhRbnMKjxH2zknTPLnlb7zmAoO/81QQdh9sowi2
+        zkF6xBMMVXzOadpmhjNMiSkToALXeJXmu9kgrIn5Dr3lkBid0ZvufA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTdFRKVlRMbjdZN0ZZV1ZE
+        V3pjaUJvVVVtUTVIdHRkWS91aXViZERNZ2pVCjlwZUVvRU5xeGpLazFXSnNjMkFq
+        djJiZUNmc2JnTDQ0MG4rdytmd3ZpNXcKLS0tIEdUVzNENmdubE9oZVVVTUZYNmE5
+        WWg2WTc3cStla2cvZVZuS0RuUTFCajgKk6vpB8yDQAhrPvOp/6WRaovVx9sUtyXu
+        5EjTeBT+pOh4c165/dvW1HYffZVcmDByYTx7UCtHmXut6Q3c2BtHbA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByc25qN2xXSHdCQytTUUlN
+        ZGtqTFdxb1loY0laSnI5enRiT3lvYzBDTjBNClYzL2hkdkVuTWRRcU54RHFTdUF0
+        OExEeFpDQ1pPVGdkRWRGZG53SWxRd28KLS0tIHZaUW5jRjRTbCtJNDNVdEt6U2NN
+        RDdmaXZlY0xBV2ZmaU5icUtzTUtySlUKRjuup5MJRFFfo6M24erFpxFj+4TFBihj
+        HGQ9LcTfDM0OQNcOgCLDDD0QfNhBS7hwamD4YSssaybpv4ljghDQ4g==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzNi9PZlRUUGozZVZVdUdN
+        cWd3VXdSMUN6dnJpWWpaSnJXR09hM01OSGtNCmIxMmpsSjd2V3lUMWtyU3lITFpV
+        T3VqWnVTdUh2TzNGUDhhVVNITmVCMlkKLS0tIG45Q3JEdFNUN01tTXFLb3Uwajdn
+        Y3EzWVVpaWNiWWxWMFlsaHNVR0huZDAKRHxYA7g0KdK3Z8TMwqvX1sDKlP9sEUvA
+        PQ8X5L7B7iStPOdNtWwgxEOUGAsM9tlAj5ZYlf1d7zc6ZcjPZpHWWA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-side-0/secrets/wifi.enc.yaml
+++ b/.jjconflict-side-0/secrets/wifi.enc.yaml
@@ -1,0 +1,117 @@
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-26T16:12:54Z"
+  mac: ENC[AES256_GCM,data:POanrPpnw0ErniQ/gVdZxnj5FXCkvojkM5dxdQpYnPt/UKx2g6OiGa3OCgJJkWcbqm22C9HVvZz1MnH4nITpgm8SZarVkFe+copLy5QWCIHU2uUXmnYZhOHOofGgwcySaNcAU/GErA2OFuesR3480lHbiVwS+pAtMAVWVcJdWYs=,iv:sf+do3G6vpM4titItbWGFs+i2v5Ab5q8X6qy6Fn7/bA=,tag:PpC/flqV8NdWMxCvv1sdMQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
+        Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
+        eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
+        V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
+        y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
+        QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
+        L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
+        L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
+        lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
+        eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
+        aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
+        QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
+        +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
+        dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
+        RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
+        UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
+        OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
+        RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
+        MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
+        NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
+        8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
+        KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
+        ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
+        eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
+        Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
+        VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
+        RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
+        QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
+        bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
+        VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
+        bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
+        ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
+        PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
+        ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
+        ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
+        VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
+        wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
+        aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
+        V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
+        ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
+        NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
+        MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
+        QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
+        UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
+        EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
+        OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
+        UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
+        enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
+        Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+wifi-sfr-e368: ENC[AES256_GCM,data:FMmP09ByePKeRAxMEqKd5cbdQy4=,iv:i9y4k87u55Xp+oFbzKSXJef8pxL30rvM2/5gugmUAZM=,tag:KAeko7NNYUlM3ir+bDdoKw==,type:str]
+wifi-sfr-e368-5ghz: ENC[AES256_GCM,data:E6UFUAu9lvCFVIiDP8CHtkllxUY=,iv:NCV4qq/AqODIxtdO+DxV13Is72uECFqJXC5CNvOioNk=,tag:uxzwB7OPf/+KemYYsSTolA==,type:str]
+wifi-vintage-korean: ENC[AES256_GCM,data:8KFQG7RTtzFT57Jb/t4=,iv:aWlD4X1r1AXTELksH2KjtANKiaxqJ9ZYNWAaMdqnn2k=,tag:ZuccHQT6mWqvQCLg5wjkeQ==,type:str]

--- a/.jjconflict-side-0/skaffold.yaml
+++ b/.jjconflict-side-0/skaffold.yaml
@@ -1,0 +1,10 @@
+apiVersion: skaffold/v4beta9
+kind: Config
+metadata:
+  name: niximgs
+build:
+  artifacts:
+    - custom:
+        buildCommand:
+          nix run github:shikanime-studio/nix-containers -- skaffold build
+      image: ghcr.io/shikanime-labs/machines/catbox

--- a/.jjconflict-side-1/.envrc
+++ b/.jjconflict-side-1/.envrc
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+
+# If we are a computer with nix available, then use that to setup
+# the build environment with exactly what we need.
+if has nix; then
+  # Watch nix submodules
+  watch_dir hosts
+  watch_dir infra
+  watch_dir modules
+  watch_dir secrets
+  # Use nix flakes to setup the environment
+  use flake . --accept-flake-config --no-pure-eval
+fi

--- a/.jjconflict-side-1/.github/renovate.json
+++ b/.jjconflict-side-1/.github/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices", "security:openssf-scorecard"],
+  "nix": { "enabled": true },
+  "postUpgradeTasks": {
+    "commands": ["nix fmt"],
+    "executionMode": "branch",
+    "fileFilters": ["**/*.nix"],
+    "installTools": { "nix": {} }
+  }
+}

--- a/.jjconflict-side-1/.github/workflows/cleanup.yaml
+++ b/.jjconflict-side-1/.github/workflows/cleanup.yaml
@@ -1,0 +1,25 @@
+name: Cleanup
+permissions:
+  contents: read
+"on":
+  pull_request:
+    types:
+      - closed
+jobs:
+  cleanup:
+    if: ${{ github.event.pull_request.head.repo.fork == false }}
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/cleanup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          pull-request-url: ${{ github.event.pull_request.html_url }}

--- a/.jjconflict-side-1/.github/workflows/commands.yaml
+++ b/.jjconflict-side-1/.github/workflows/commands.yaml
@@ -1,0 +1,129 @@
+name: Commands
+permissions:
+  contents: read
+"on":
+  issue_comment:
+    types:
+      - created
+jobs:
+  backport:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.backport')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/backport@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+  close:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.close')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/close@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          username: operator6o
+  land:
+    if:
+      github.event.issue.pull_request != null &&
+      (contains(github.event.comment.body, '.land') ||
+      contains(github.event.comment.body, '.force-land'))
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-administration: read
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/land@v9
+        with:
+          email: operator6o@shikanime.studio
+          fullname: Operator 6O
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+          username: operator6o
+  rebase:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.rebase')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/rebase@v9
+        with:
+          email: operator6o@shikanime.studio
+          fullname: Operator 6O
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+          username: operator6o
+  run:
+    if:
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '.run')
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/command/run@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}

--- a/.jjconflict-side-1/.github/workflows/integration.yaml
+++ b/.jjconflict-side-1/.github/workflows/integration.yaml
@@ -1,0 +1,47 @@
+name: Integration
+permissions:
+  contents: read
+jobs:
+  nix:
+    if:
+      ${{ github.event_name == 'workflow_call' || github.event_name ==
+      'workflow_dispatch' || github.event.pull_request.draft == false }}
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/nix.yaml
+    with:
+      cachix-name: shikanime
+  skaffold:
+    if:
+      ${{ github.event_name == 'workflow_call' || github.event_name ==
+      'workflow_dispatch' || github.event.pull_request.draft == false }}
+    needs:
+      - nix
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/skaffold.yaml
+"on":
+  pull_request:
+    branches:
+      - main
+      - gh/*/*/base
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: false
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch: {}

--- a/.jjconflict-side-1/.github/workflows/nix.yaml
+++ b/.jjconflict-side-1/.github/workflows/nix.yaml
@@ -1,0 +1,152 @@
+name: Nix
+permissions:
+  contents: read
+"on":
+  workflow_call:
+    inputs:
+      cachix-name:
+        type: string
+        default: ""
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: false
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      cachix-name:
+        type: string
+        default: ""
+        description: Cachix cache name
+jobs:
+  checks:
+    name: Checks
+    if: ${{ needs['setup-checks-jobs'].outputs.continue == 'true' }}
+    runs-on: ${{ matrix.runner }}
+    needs:
+      - setup-checks-jobs
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs['setup-checks-jobs'].outputs.matrix) }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-name: ${{ inputs['cachix-name'] }}
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        run:
+          nix flake check --accept-flake-config --no-pure-eval --system "${{
+          matrix.system }}"
+        shell: bash
+  packages:
+    name: Packages
+    if: ${{ needs['setup-packages-jobs'].outputs.continue == 'true' }}
+    runs-on: ${{ matrix.runner }}
+    needs:
+      - setup-packages-jobs
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs['setup-packages-jobs'].outputs.matrix) }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          cachix-name: ${{ inputs['cachix-name'] }}
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        uses: shikanime-studio/actions/nix/integration@v9
+        with:
+          name: ${{ matrix.name }}
+          system: ${{ matrix.system }}
+  setup-checks-jobs:
+    name: Setup Checks Jobs
+    runs-on: ubuntu-latest
+    outputs:
+      continue: ${{ steps.setup-checks-jobs.outputs.continue }}
+      matrix: ${{ steps.setup-checks-jobs.outputs.matrix }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: setup-checks-jobs
+        uses: shikanime-studio/actions/nix/setup-checks-jobs@v9
+  setup-packages-jobs:
+    name: Setup Packages Jobs
+    runs-on: ubuntu-latest
+    needs:
+      - checks
+    outputs:
+      continue: ${{ steps.setup-packages-jobs.outputs.continue }}
+      matrix: ${{ steps.setup-packages-jobs.outputs.matrix }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: setup-packages-jobs
+        uses: shikanime-studio/actions/nix/setup-packages-jobs@v9

--- a/.jjconflict-side-1/.github/workflows/release.yaml
+++ b/.jjconflict-side-1/.github/workflows/release.yaml
@@ -1,0 +1,72 @@
+name: Release
+permissions:
+  contents: read
+"on":
+  push:
+    branches:
+      - main
+      - release-[0-9]+.[0-9]+
+    tags:
+      - v?[0-9]+.[0-9]+.[0-9]+*
+  workflow_call:
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch:
+    inputs:
+      ref_name:
+        description: Tag or branch to release
+        required: true
+jobs:
+  nix:
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/nix.yaml
+    with:
+      cachix-name: shikanime
+  release:
+    if:
+      (startsWith(github.ref, 'refs/tags/v')) || (github.event_name ==
+      'workflow_dispatch' && startsWith(github.event.inputs.ref_name, 'v'))
+    needs:
+      - skaffold
+      - nix
+    permissions:
+      contents: write
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/release@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          ref: ${{ github.ref_name || github.event.inputs.ref_name }}
+          repo: ${{ github.repository }}
+  skaffold:
+    needs:
+      - nix
+    permissions:
+      contents: read
+      packages: write
+    secrets:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      OPERATOR_PRIVATE_KEY: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+    uses: ./.github/workflows/skaffold.yaml

--- a/.jjconflict-side-1/.github/workflows/skaffold.yaml
+++ b/.jjconflict-side-1/.github/workflows/skaffold.yaml
@@ -1,0 +1,141 @@
+name: Skaffold
+permissions:
+  contents: read
+"on":
+  workflow_call:
+    inputs:
+      push:
+        type: boolean
+        default: true
+        description: Whether to push images during build
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: true
+      OPERATOR_PRIVATE_KEY:
+        required: true
+  workflow_dispatch: {}
+jobs:
+  build-render:
+    name: Build & Render
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: docker/login-action@v4
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extra-platforms: arm64
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - id: skaffold
+        env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        uses: shikanime-studio/actions/skaffold/integration@v9
+        with:
+          push: ${{ inputs.push }}
+      - name: Save manifest
+        run: |
+          mkdir -p artifacts
+          cat > artifacts/skaffold-manifest.yaml <<'MANIFEST_EOF'
+          $SKAFFOLD_MANIFEST
+          MANIFEST_EOF
+        shell: bash
+        env:
+          SKAFFOLD_MANIFEST: ${{ steps.skaffold.outputs.manifest }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: skaffold-manifest
+          path: artifacts/skaffold-manifest.yaml
+  build-render-profile:
+    name: Build & Render (Profile)
+    if: ${{ needs['setup-profiles-jobs'].outputs.continue == 'true' }}
+    runs-on: ubuntu-latest
+    needs:
+      - setup-profiles-jobs
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs['setup-profiles-jobs'].outputs.matrix) }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: docker/login-action@v4
+        with:
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extra-platforms: arm64
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: direnv
+        uses: shikanime-studio/actions/direnv@v9
+      - env: ${{ fromJSON(steps.direnv.outputs.env) }}
+        uses: shikanime-studio/actions/skaffold/integration@v9
+        with:
+          profile: ${{ matrix.name }}
+          push: ${{ inputs.push }}
+  setup-profiles-jobs:
+    name: Setup Profiles Jobs
+    runs-on: ubuntu-latest
+    outputs:
+      continue: ${{ steps.setup-profiles-jobs.outputs.continue }}
+      matrix: ${{ steps.setup-profiles-jobs.outputs.matrix }}
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extra-platforms: arm64
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - id: setup-profiles-jobs
+        uses: shikanime-studio/actions/skaffold/setup-profiles-jobs@v9

--- a/.jjconflict-side-1/.github/workflows/triage.yaml
+++ b/.jjconflict-side-1/.github/workflows/triage.yaml
@@ -1,0 +1,50 @@
+name: Triage
+permissions:
+  pull-requests: write
+"on":
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  triage:
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        continue-on-error: true
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: read
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+      - env:
+          GH_TOKEN:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+        if:
+          github.event.pull_request.user.login == 'dependabot[bot]' ||
+          github.event.pull_request.user.login == 'yorha-operator-6o[bot]'
+        run:
+          gh pr edit "${{ github.event.pull_request.number }}" --add-label
+          dependencies
+      - env:
+          GH_TOKEN:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN
+            }}
+        if:
+          startsWith(github.head_ref, 'gh/') && endsWith(github.head_ref,
+          '/head')
+        run:
+          gh pr edit "${{ github.event.pull_request.number }}" --add-label
+          ghstack

--- a/.jjconflict-side-1/.github/workflows/update.yaml
+++ b/.jjconflict-side-1/.github/workflows/update.yaml
@@ -1,0 +1,50 @@
+name: Update
+permissions:
+  contents: read
+"on":
+  schedule:
+    - cron: 0 4 * * 0
+  workflow_dispatch: {}
+jobs:
+  dependencies:
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-contents: write
+          permission-pull-requests: write
+          permission-workflows: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: shikanime-studio/actions/nix/setup@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+      - uses: shikanime-studio/actions/checkout@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          sign-commits: true
+          username: operator6o
+      - uses: shikanime-studio/actions/update@v9
+        with:
+          github-token: ${{ steps.createGithubAppToken.outputs.token }}
+          username: operator6o
+  stale:
+    runs-on: ubuntu-slim
+    steps:
+      - id: createGithubAppToken
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.OPERATOR_APP_ID }}
+          permission-issues: write
+          permission-pull-requests: write
+          private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
+      - uses: actions/stale@v10
+        with:
+          days-before-close: 14
+          days-before-stale: 30
+          repo-token: ${{ steps.createGithubAppToken.outputs.token }}
+          stale-issue-label: stale
+          stale-pr-label: stale

--- a/.jjconflict-side-1/.github/workflows/wakabox.yaml
+++ b/.jjconflict-side-1/.github/workflows/wakabox.yaml
@@ -1,0 +1,15 @@
+name: Wakabox
+permissions:
+  contents: read
+"on":
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  wakabox:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.WAKABOX_GITHUB_TOKEN }}
+          GIST_ID: ${{ vars.WAKABOX_GITHUB_GIST_ID }}
+          WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+        uses: matchai/waka-box@v5.0.0

--- a/.jjconflict-side-1/.gitignore
+++ b/.jjconflict-side-1/.gitignore
@@ -1,0 +1,315 @@
+###------------------------------###
+###  GitHub Community: OpenTofu  ###
+###------------------------------###
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tofu
+override.tf.json
+override.tofu.json
+*_override.tf
+*_override.tofu
+*_override.tf.json
+*_override.tofu.json
+
+# Ignore transient lock info files created by tofu apply
+.terraform.tfstate.lock.info
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+# !example_override.tofu
+
+# Include tfplan files to ignore the plan output of command: tofu plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+###---------------------------------------------------------------------###
+###  Repo: shikanime-studio/gitignore/refs/heads/main/Devenv.gitignore  ###
+###---------------------------------------------------------------------###
+
+.env
+.env.*
+.devenv*
+.direnv*
+
+###-------------------------###
+###  TopTal: jetbrains+all  ###
+###-------------------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/jetbrains+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=jetbrains+all
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+# End of https://www.toptal.com/developers/gitignore/api/jetbrains+all
+
+###-----------------###
+###  TopTal: linux  ###
+###-----------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/linux
+# Edit at https://www.toptal.com/developers/gitignore?templates=linux
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+# End of https://www.toptal.com/developers/gitignore/api/linux
+
+###-----------------###
+###  TopTal: macos  ###
+###-----------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/macos
+
+###---------------###
+###  TopTal: vim  ###
+###---------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/vim
+# Edit at https://www.toptal.com/developers/gitignore?templates=vim
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.toptal.com/developers/gitignore/api/vim
+
+###----------------------------###
+###  TopTal: visualstudiocode  ###
+###----------------------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudiocode
+
+###-------------------###
+###  TopTal: windows  ###
+###-------------------###
+
+# Created by https://www.toptal.com/developers/gitignore/api/windows
+# Edit at https://www.toptal.com/developers/gitignore?templates=windows
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+Thumbs.db:encryptable
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+# End of https://www.toptal.com/developers/gitignore/api/windows
+
+###-------------------###
+###  Devlib: content  ###
+###-------------------###
+
+.pre-commit-config.yaml

--- a/.jjconflict-side-1/CODE_OF_CONDUCT.md
+++ b/.jjconflict-side-1/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<william.phetsinorath@shikanime.studio>. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/.jjconflict-side-1/LICENSE
+++ b/.jjconflict-side-1/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/.jjconflict-side-1/README.md
+++ b/.jjconflict-side-1/README.md
@@ -1,0 +1,195 @@
+<!-- markdownlint-disable first-line-heading MD041 -->
+
+![header.png](https://raw.githubusercontent.com/shikanime/shikanime/main/assets/github-header.png)
+
+<!-- markdownlint-enable first-line-heading MD041 -->
+
+# Machines
+
+Shikanime's machine configuration repository for NixOS, nix-darwin, WSL, and
+related shared home modules.
+
+## What This Repo Contains
+
+This flake is the source of truth for the machines I manage. It wires together:
+
+- host-specific NixOS, nix-darwin, and WSL configurations
+- shared system modules for Linux and Darwin
+- shared Home Manager modules
+- encrypted secrets with `sops-nix`
+- distributed build and deployment helpers
+- a `devenv` shell for repository tooling
+
+## Repository Layout
+
+### `flake.nix`
+
+The flake entry point. It imports the module sets and exposes the host
+configurations and build outputs.
+
+### `hosts/`
+
+Per-machine entry points.
+
+- `hosts/<name>/configuration.nix` is the main NixOS host definition
+- `hosts/telsha/darwin-configuration.nix` is the nix-darwin host definition
+- `hosts/<name>/users/<user>/home-configuration.nix` contains host-specific Home
+  Manager config
+- `hosts/<name>/facter.json` stores hardware facts for hosts that rely on
+  `nixos-facter`
+
+Current hosts:
+
+- `ashira` - NixOS server node
+- `manash` - NixOS server node
+- `nalsha` - NixOS server node
+- `fushi` - NixOS ARM node
+- `minish` - NixOS ARM node
+- `nemishi` - NixOS ARM node
+- `ishtar` - NixOS GUI workstation (Razer Blade 17 (2019), Hyprland on Wayland +
+  NVIDIA)
+- `nixtar` - NixOS on WSL
+- `catbox` - KubeVirt containerdisk (NixOS qcow2 wrapped as an OCI image)
+- `telsha` - nix-darwin host
+
+### `modules/`
+
+Shared module layers.
+
+- `modules/nixos/` contains Linux host profiles
+  - `base.nix` - common NixOS defaults, `comin`, and Nix access token wiring
+  - `minimal.nix` - baseline Nix settings, GC, auto-upgrade, and Home Manager
+    defaults
+  - `workstation.nix` - workstation-oriented tooling and desktop defaults
+  - `follower.nix` - server defaults shared by cluster nodes
+  - `distributed.nix` - remote build machines and distributed build settings
+  - `nishir.nix` - cluster node defaults: tailscale, SSH, Avahi, firewall tweaks
+  - `nishir.nix` and `talashi.nix` - cluster-specific server profiles
+- `modules/darwin/` contains macOS host profiles
+  - `base.nix`, `minimal.nix`, `workstation.nix`, `distributed.nix`
+- `modules/home/` contains shared Home Manager modules
+  - shell, editor, font, VCS, and workstation-specific settings
+- `modules/flake/` contains flake-parts glue for NixOS, Darwin, and devenv
+
+### Theming
+
+Noctalia (the Wayland shell/bar) is configured entirely through Nix — there is
+no repo-owned theme schema or UI component to edit. The theme is set per user in
+`hosts/<host>/users/<user>/home-configuration.nix` under
+`programs.noctalia.settings`:
+
+- `theme.mode` — the auto-mode flag. `"auto"` follows the day/night schedule;
+  set it to `"dark"` or `"light"` to disable auto and pin a fixed theme.
+- `location.auto_locate` — when `true` (current ishtar setting), the schedule is
+  derived from runtime IP geolocation. For a fixed-location, offline setup use
+  `location.latitude`/`longitude` instead, or `location.custom_schedule` with
+  explicit `sunrise`/`sunset` times.
+- `shell.greeter_sync.auto_sync` — when `true`, the shell pushes its resolved
+  theme (auto → day/night) into the greeter, so the login screen follows the
+  same schedule. Off by default. Do not set `theme.mode` on the greeter: its
+  binary ignores `[theme]`; only the shell→greeter sync drives greeter theming.
+
+### `secrets/`
+
+Encrypted secrets managed by `sops-nix`.
+
+- files use the `*.enc.yaml` naming convention
+- decrypted values are generated at evaluation or activation time
+- do not commit plaintext secret material
+
+### `skaffold.yaml`
+
+Repository automation for render/build workflows.
+
+## Flake Outputs
+
+The flake exposes these primary outputs:
+
+- `nixosConfigurations.ashira`
+- `nixosConfigurations.manash`
+- `nixosConfigurations.nalsha`
+- `nixosConfigurations.fushi`
+- `nixosConfigurations.minish`
+- `nixosConfigurations.nemishi`
+- `nixosConfigurations.ishtar`
+- `nixosConfigurations.nixtar`
+- `darwinConfigurations.telsha`
+- `packages.<system>.*` for the corresponding system builds, including `catbox`
+
+The `packages` outputs are mostly convenience build artifacts for CI and local
+verification.
+
+## Usage
+
+### Build A Host
+
+```sh
+nix build .#nixosConfigurations.manash.config.system.build.toplevel
+nix build .#darwinConfigurations.telsha.system
+```
+
+For the published package outputs:
+
+```sh
+nix build .#packages.x86_64-linux.manash
+nix build .#packages.aarch64-darwin.telsha
+nix build .#packages.x86_64-linux.catbox
+```
+
+### Switch A NixOS Host
+
+```sh
+sudo nixos-rebuild switch --flake .#manash
+```
+
+Replace `manash` with `ashira`, `nalsha`, `fushi`, `minish`, `nemishi`,
+`ishtar`, or `nixtar` as needed.
+
+### Switch A Darwin Host
+
+```sh
+darwin-rebuild switch --flake .#telsha
+```
+
+### Enter The Dev Shell
+
+```sh
+nix develop
+```
+
+The shell is defined through `devenv` and includes the repository tooling used
+for build and workflow tasks.
+
+## Secret Handling
+
+Most hosts consume encrypted data from `secrets/<host>.enc.yaml`.
+
+- host configs point `sops.defaultSopsFile` at their matching secret file
+- secrets are restarted through systemd unit hooks where required
+- some hosts also use `sops.templates.*` to materialize config fragments
+
+## Cluster And Build Topology
+
+The Linux server nodes are split between cluster-oriented machines and general
+workstation-style machines:
+
+- `ashira`, `manash`, and `nalsha` are x86_64 Linux nodes with Tailscale,
+  distributed build settings, and cluster runner duties
+- `fushi`, `minish`, and `nemishi` are ARM Linux nodes with the same shared
+  cluster profile shape
+- `ishtar` is a bare-metal GUI workstation (Hyprland on Wayland + NVIDIA)
+- `nixtar` is a WSL-based workstation profile
+- `telsha` is the Darwin workstation profile
+
+Several hosts share remote build configuration through
+`modules/nixos/profiles/distributed.nix`, which lets local builds offload work
+to the other machines.
+
+## Related Repos
+
+This repository follows the same general shape as the other Shikanime
+configuration repos:
+
+- `shikanime-labs/colemak`
+- `shikanime-labs/manifests`
+- `shikanime-studio/knix`

--- a/.jjconflict-side-1/docs/nemishi-nvme-probe.md
+++ b/.jjconflict-side-1/docs/nemishi-nvme-probe.md
@@ -1,0 +1,54 @@
+# nemishi NVMe Probe Timeout — Root Cause & Fix
+
+## Symptom
+
+`nemishi` (RPi 5, aarch64) boots off SD (`mmcblk0`) but `systemd` blocks on the
+declared `disko` device:
+
+```text
+systemd[1]: Timed out waiting for device /dev/nvme0n1.
+```
+
+`/dev/nvme*` never appears. Looks like a dead drive. It wasn't.
+
+## Root Cause (the real one)
+
+The M.2 HAT+ 16-pin FPC ribbon to the Pi's board connector was not seated. That
+ribbon carries 5V to the HAT — without it the SSD gets no power. The NVMe
+_controller_ still enumerates on PCIe (`/dev/nvme0` exists) but reports **0
+bytes** (`/sys/block/nvme0n1/size == 0`), so the kernel can't mount or probe it
+and you get `No such device` / `XFS SB validate failed`.
+
+Seat the 16-pin ribbon, power-cycle, `cat /sys/block/nvme0n1/size` should
+be > 0.
+
+## Secondary tuning (Pi 5 host side, not the cause)
+
+DRM-less SSDs on the BCM2712 root can also wedge on admin-queue `Identify`:
+
+- **PCIe ASPM L1**: root defaults L1 on; link sleep wedges the queue (`-12`
+  class). `rpi5.nix` forces `pcie_aspm.policy=performance` (L1 off).
+- **APST** was previously also disabled (`default_ps_max_latency_us=0`) but is
+  **no longer needed** — removed once the real cause (power ribbon) was found.
+
+`cma=512M` and the `pcie-32bit-dma-pi5` overlay remain required.
+
+## Live Verification (post-reseat, no rebuild)
+
+```text
+cat /sys/block/nvme0n1/size        # > 0 once the ribbon is seated
+ls -la /dev/nvme0n1                 # block device present
+# XFS mounts at /mnt/data, smartctl -H PASSED
+```
+
+## History
+
+Earlier this doc blamed APST + ASPM for a "timeout, disable controller" probe
+failure. That log was from a _separate_ pre-power-ribbon state; the 0-byte /
+`No such device` symptom the host actually hit was pure missing 5V. The
+`nvme_core.default_ps_max_latency_us=0` workaround was stripped from `rpi5.nix`.
+
+`pcie_aspm.policy=performance` was reviewed for removal but **kept**: it guards
+a separate, real BCM2712 root-port quirk (ASPM L1 wedges the NVMe admin queue,
+probe `-12`). The power-ribbon fix was _our_ failure; this is a different
+hardware trap worth the one-line insurance.

--- a/.jjconflict-side-1/docs/network-interfaces.md
+++ b/.jjconflict-side-1/docs/network-interfaces.md
@@ -1,0 +1,102 @@
+# Network Interface Configuration
+
+## Overview
+
+Bridged networking via native nixpkgs options (`networking.bridges` +
+`networking.interfaces` + `networking.useNetworkd`). Every host has a single
+bridge `br0` that carries all traffic — pod-to-pod, SSH, flannel, Longhorn.
+
+## Implementation
+
+Configured inline in each hardware module — no custom abstraction module.
+
+| Module                         | Interfaces         | Bond                  | Bridge | DHCP |
+| ------------------------------ | ------------------ | --------------------- | ------ | ---- |
+| `modules/nixos/beelink-eq.nix` | `enp1s0`, `enp2s0` | `bond0` (balance-alb) | `br0`  | yes  |
+| `modules/nixos/rpi.nix`        | `end0`             | —                     | `br0`  | yes  |
+
+### Beelink (dual 2.5G NIC, balance-alb bond)
+
+```nix
+networking = {
+  useNetworkd = true;
+  bonds.bond0 = {
+    interfaces = [ "enp1s0" "enp2s0" ];
+    driverOptions = { mode = "balance-alb"; miimon = "100"; };
+  };
+  bridges.br0.interfaces = [ "bond0" ];
+  interfaces.br0.useDHCP = true;
+};
+```
+
+### Raspberry Pi (single 1G USB3 NIC)
+
+```nix
+networking = {
+  useNetworkd = true;
+  bridges.br0.interfaces = [ "end0" ];
+  interfaces.br0.useDHCP = true;
+};
+```
+
+## Bonding rationale
+
+The NETGEAR MS308 is an unmanaged switch — no LACP (802.3ad) support.
+`balance-alb` (mode 6) aggregates both NICs entirely in the Linux driver via ARP
+negotiation. Zero switch configuration required.
+
+- Single-flow throughput: 2.5 Gbps (per-flow hash)
+- Multi-flow aggregate: ~4-5 Gbps
+- Fails over automatically if one NIC/link dies (`miimon=100`)
+- One cable plugged in → bond works on single link; second cable is hot-add
+
+## Longhorn storage network
+
+The Multus `storageNetwork` NAD has been **removed**. Rationale:
+
+1. `br0` carries all traffic (management + pod). A Multus secondary interface on
+   the same bridge as flannel provides **zero isolation** — both interfaces hit
+   identical iptables/conntrack/kube-proxy overhead
+   (`bridge-nf-call-iptables=1`).
+2. The knix Multus stack uses DHCP IPAM (thick plugin + dynamic networks
+   controller + DHCP DaemonSet). Whereabouts IPAM is incompatible with this
+   stack. DHCP IPAM on the same subnet as `br0` causes routing ambiguity (two
+   interfaces, same subnet, same pod).
+3. Longhorn on default flannel/host-gw already performs at wire speed for
+   same-L2 clusters.
+
+**When to re-add**: only with a **physically separate storage network** —
+`enp2s0` cabled to a dedicated switch, `br-storage` bridge with
+`bridge-nf-call-iptables=0` on that bridge only. Then the NAD bypasses all
+Kubernetes netfilter overhead. See the "dual bridge" pattern in the skill.
+
+## NIC performance tuning
+
+Each hardware module includes an inline
+`systemd.services.network-nic-performance` one-shot that applies ethtool
+hardware offloads (TSO/GSO/SG/RX/TX, rx-udp-gro-forwarding) and RPS IRQ
+distribution on the physical interfaces (pre-bond, pre-bridge).
+
+## Why not a custom module?
+
+A previous iteration used a 208-line custom `hardware.networkInterfaces` module.
+It was never imported into any host configuration — dead code that caused
+`The option 'hardware.networkInterfaces' does not exist` build failures. Native
+`networking.bridges` achieves the same result in 3-4 lines per interface.
+
+## Discovery
+
+Verify interface names on actual hardware before deploying:
+
+```bash
+ip link show          # List interfaces and kernel names
+ethtool -i <iface>    # Verify driver
+```
+
+Known names by hardware:
+
+| Hardware                     | Interface(s)       | Driver     |
+| ---------------------------- | ------------------ | ---------- |
+| Beelink (Intel N150, i226-V) | `enp1s0`, `enp2s0` | `igc`      |
+| Raspberry Pi CM4 (USB3 GigE) | `end0`             | `lan743x`  |
+| Older Raspberry Pi           | `eth0`             | `smsc95xx` |

--- a/.jjconflict-side-1/docs/network-performance-remediation.md
+++ b/.jjconflict-side-1/docs/network-performance-remediation.md
@@ -1,0 +1,92 @@
+# Network Performance Remediation — Switch Flannel to host-gw
+
+## Problem
+
+Cross-node pod-to-pod throughput is ~535 Mbps on Beelink nodes (2.5 Gbps NICs)
+and ~400 Mbps estimated on Raspberry Pi 4 nodes (1 Gbps NICs). This is far below
+the theoretical capacity (80% target = 2,000 Mbps for Beelink, 800 Mbps for
+Pi4).
+
+## Root Cause
+
+The `rke2-canal` ConfigMap configures flannel with `Backend: wireguard`, which
+encrypts all cross-node traffic with kernel WireGuard (ChaCha20-Poly1305).
+WireGuard single-flow encryption is CPU-limited:
+
+| Hardware             | Single-core WireGuard |
+| -------------------- | --------------------- |
+| Intel N150 (Beelink) | ~800-1,200 Mbps       |
+| BCM2711 (Pi4, NEON)  | ~400-600 Mbps         |
+
+Since all cluster nodes are on the **same Layer 2 subnet** (192.168.1.0/24),
+WireGuard encryption is pure overhead — it adds CPU load without providing
+security (the traffic never leaves the physical LAN).
+
+## Remedy
+
+Switch flannel backend from `wireguard` to `host-gw`. host-gw installs static
+routes via the Linux routing table — zero encapsulation, zero encryption
+overhead.
+
+### Procedure
+
+This change requires a **rolling restart of RKE2 on each node** because the CNI
+configuration is read at node startup.
+
+### Step 1: Switch flannel backend via knix canal options
+
+The `services.knix.canal` options are provided by the `canal.nix` module in
+[shikanime-studio/knix](https://github.com/shikanime-studio/knix). The backend
+is set to `host-gw` globally for all cluster nodes:
+
+```nix
+# modules/nixos/nishir.nix
+services.knix.canal.backend = "host-gw";
+```
+
+Per-host override (if needed):
+
+```nix
+services.knix.canal.backend = lib.mkForce "vxlan";
+```
+
+Defaults (when importing knix):
+
+- `backend = "wireguard"` (backward compatible)
+- `vethMtu = "1500"` for host-gw, `"1400"` for wireguard
+- `wireguardKeepAlive = 25` (only when backend = wireguard)
+
+### Step 2: Restart canal to apply
+
+```bash
+kubectl rollout restart ds -n kube-system rke2-canal
+```
+
+## Expected Results After All Remediations Combined
+
+| Path                | Current (wireguard) | After host-gw | After +offloads | Target (80%) |
+| ------------------- | ------------------- | ------------- | --------------- | ------------ |
+| Beelink <-> Beelink | ~535 Mbps           | ~2,200 Mbps   | ~2,400 Mbps     | 2,000 Mbps   |
+| Pi4 <-> Pi4         | ~400 Mbps           | ~900 Mbps     | ~940 Mbps       | 800 Mbps     |
+| Beelink <-> Pi4     | ~450 Mbps           | ~1,500 Mbps   | ~1,800 Mbps     | —            |
+
+## Related Changes (in this PR)
+
+1. `shikanime-studio/knix` — New `modules/canal.nix` module upstreamed.
+   `services.knix.canal.backend` option (host-gw | vxlan | wireguard) with
+   per-host override. Default: wireguard (backward compatible). Also sets
+   `vethMtu` automatically per backend and loads WireGuard kernel module when
+   needed. `rke2.nix` updated to use `cfg.canal` values in the HelmChartConfig
+   manifest.
+
+2. `modules/nixos/nishir.nix` — Firewall allows pod CIDR on br+ interfaces.
+
+3. `modules/nixos/beelink-eq.nix` — Dual i226-V NICs bonded via `balance-alb`
+   (bond0) into a single `br0` bridge. `network-nic-performance` service applies
+   TSO/GSO/SG/RX+TX offloads and RPS on both physical ports.
+
+4. `modules/nixos/rpi.nix` — Single `end0` NIC into `br0` bridge. Same NIC
+   offload service.
+
+5. `modules/nixos/rpi5.nix` — Imports rpi.nix (inherits bridge + offloads).
+   Pi5-specific: kernelboot, config.txt [pi5] section.

--- a/.jjconflict-side-1/docs/rpi5-nixos.md
+++ b/.jjconflict-side-1/docs/rpi5-nixos.md
@@ -1,0 +1,178 @@
+# Raspberry Pi 5 NixOS Boot — Research & Solution
+
+## Problem
+
+The Raspberry Pi 5 (BCM2712) EEPROM bootloader performs an **OS check** before
+loading the kernel. When it cannot find a device-tree file matching
+`bcm2712-rpi-5-b.dtb` on the firmware partition, or when `config.txt` does not
+signal Pi 5 support, it halts with:
+
+```text
+Device-tree file "bcm2712-rpi-5-b.dtb" not found.
+The installed operating system (OS) does not indicate support for Raspberry Pi 5
+Update the OS or set os_check=0 in config.txt to skip this check.
+```
+
+This affected `nemishi` (RPi 5) when building SD images via
+`sd-image-aarch64.nix` with the `nixos-hardware.nixosModules.raspberry-pi-5`
+module.
+
+## Root Cause
+
+Two independent issues:
+
+1. **Missing DTBs in firmware partition**: The `sd-image-aarch64.nix`
+   `populateFirmwareCommands` only copies Pi 3/4 DTBs (`bcm2710`, `bcm2711`) and
+   U-Boot binaries. No Pi 5 DTBs (`bcm2712`).
+
+2. **Missing `config.txt` signals**: The `config-txt-defaults.nix` in
+   nixos-hardware only defines `[all]`, `[cm4]`, and `[cm5]` sections. There is
+   no `[pi5]` section, no `os_check` setting, and no `arm_64bit` setting. The Pi
+   5 boot ROM requires these to proceed.
+
+## Solution: Kernelboot Bootloader
+
+The current fix adopts the **kernelboot** pattern from
+[nvmd/nixos-raspberrypi](https://github.com/nvmd/nixos-raspberrypi):
+
+- The Pi 5 firmware loads `kernel.img` **directly** from the FAT firmware
+  partition, bypassing the extlinux layer.
+- The `os_check` is bypassed because the firmware finds a directly-loadable
+  kernel image.
+- `arm_64bit=1` and `os_check=0` are still included in `config.txt` as
+  belt-and-suspenders.
+
+### Firmware Partition Layout
+
+```text
+/boot/firmware/
+├── bootcode.bin      # GPU boot code (from raspberrypifw)
+├── start*.elf       # GPU firmware
+├── fixup*.dat       # GPU fixup
+├── bcm2712*.dtb     # Pi 5 device tree blobs
+├── overlays/        # DTB overlays (*.dtbo)
+├── kernel.img       # Linux kernel (from nixos-hardware linux-rpi)
+├── initrd           # Initial ramdisk (from system.build.initialRamdisk)
+├── cmdline.txt      # Kernel command line
+└── config.txt       # Firmware config (with arm_64bit=1, os_check=0)
+```
+
+### Why Not `generic-extlinux-compatible`?
+
+The `generic-extlinux-compatible` boot path uses U-Boot/extlinux to load the
+kernel. The Pi 5 EEPROM `os_check` runs **before** any of that — it reads
+`config.txt` directly and validates OS compatibility signals. Without
+`arm_64bit=1` in a `[pi5]` section, the firmware halts.
+
+The `kernelboot` path avoids this entirely: the firmware finds `kernel.img` in
+the FAT partition and loads it directly, skipping the `os_check` validation.
+
+## Alternative Approaches Considered
+
+### 1. Fix `config.txt` Only (Minimal Patch)
+
+Add `os_check=0` and `arm_64bit=1` to `config.txt` settings:
+
+```nix
+hardware.raspberry-pi.configtxt.settings.pi5 = {
+  arm_64bit = 1;
+  os_check = 0;
+};
+```
+
+**Pros**: Minimal change. Works with existing `generic-extlinux-compatible`.
+**Cons**: Still requires manual `populateFirmwareCommands` for DTBs. Fragile —
+depends on the firmware's OS check behavior not changing.
+
+### 2. Migrate Fully to `nvmd/nixos-raspberrypi`
+
+Replace nixos-hardware entirely with:
+
+- `boot.loader.raspberry-pi` module
+- `hardware.raspberry-pi.config` for config.txt
+- `hardware.raspberry-pi.firmware` for firmware staging
+- Vendor kernel from `linuxPackages_rpi5`
+
+**Pros**: Complete solution. Binary cache. Actively maintained. **Cons**: Pinned
+to `nixos-25.11` (no `nixos-unstable`). Different kernel package. Would require
+dropping nixos-hardware entirely.
+
+### 3. Kernelboot with nixos-hardware Kernel (Current)
+
+Keep nixos-hardware's `linux-rpi` kernel and `raspberry-pi-5` module. Override
+`populateFirmwareCommands` to use the kernelboot pattern. Override
+`populateRootCommands` to skip extlinux.
+
+**Pros**: Minimal external dependencies. Keeps nixos-hardware kernel. Avoids
+`os_check` entirely. Works with `nixos-unstable`. **Cons**:
+`populateFirmwareCommands` still includes Pi 3/4 defaults from
+`sd-image-aarch64.nix` (harmless but noisy).
+
+## Upstream Status
+
+- **nixos-hardware PR #1894** ("raspberry-pi: add firmware-partition install
+  module"): Approved, awaiting merge. Adds `hardware.raspberry-pi.firmware` for
+  proper firmware staging. Would eventually replace the manual
+  `populateFirmwareCommands` override.
+- **nixos-hardware Issue #1928**: Documents this exact bug. Created during
+  previous debugging session.
+- **nixpkgs Issue #260754**: Upstream tracking for Pi 5 support. NixOS
+  maintainers require upstream Linux + U-Boot support before official support.
+
+## Implementation Details
+
+### `config.txt` Section Rendering
+
+The nixos-hardware `config-txt.nix` renderer generates sections from nested Nix
+attribute sets:
+
+```nix
+hardware.raspberry-pi.configtxt.settings.pi5 = {
+  os_check = 0;
+  arm_64bit = 1;
+};
+```
+
+Renders to:
+
+```ini
+[pi5]
+os_check=0
+arm_64bit=1
+```
+
+**Important**: The settings **must** be in a `[pi5]` section, not `[all]`. The
+Pi 5 firmware specifically validates model-specific settings under the correct
+conditional filter.
+
+### `populateFirmwareCommands` Evaluation Context
+
+`populateFirmwareCommands` is evaluated at **image build time** on the target
+architecture (`aarch64-linux`). The following paths are available:
+
+- `config.system.build.kernel` — the kernel derivation
+- `config.system.build.initialRamdisk` — the initrd derivation (note: **not**
+  `config.system.build.initrd` — that's in `netboot.nix` only)
+- `config.hardware.raspberry-pi.configtxt.file` — the rendered `config.txt`
+
+### `populateRootCommands` Override
+
+The default `sd-image-aarch64.nix` `populateRootCommands` references
+`config.boot.loader.generic-extlinux-compatible.populateCmd`. When extlinux is
+disabled, this option has no value, causing an evaluation error. The fix uses
+`lib.mkForce` to override:
+
+```nix
+sdImage.populateRootCommands = lib.mkForce ''
+  mkdir -p ./files/boot
+'';
+```
+
+## References
+
+- [NixOS on ARM/Raspberry Pi 5 (Wiki)](https://wiki.nixos.org/wiki/NixOS_on_ARM/Raspberry_Pi_5)
+- [nvmd/nixos-raspberrypi](https://github.com/nvmd/nixos-raspberrypi)
+- [nixos-hardware Issue #1928](https://github.com/NixOS/nixos-hardware/issues/1928)
+- [nixos-hardware PR #1894](https://github.com/NixOS/nixos-hardware/pull/1894)
+- [nixpkgs Issue #260754](https://github.com/NixOS/nixpkgs/issues/260754)
+- [Raspberry Pi config.txt documentation](https://www.raspberrypi.com/documentation/computers/config_txt.html)

--- a/.jjconflict-side-1/flake.lock
+++ b/.jjconflict-side-1/flake.lock
@@ -1,0 +1,931 @@
+{
+  "nodes": {
+    "cachix": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "git-hooks": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777487137,
+        "narHash": "sha256-TuvKVBX60mqyMT6OB5JqVEh1YIWtFMR/igLCaCdC9tw=",
+        "owner": "cachix",
+        "repo": "cachix",
+        "rev": "a66a440c321d35f7193472c317f42a55ccd1cb93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "latest",
+        "repo": "cachix",
+        "type": "github"
+      }
+    },
+    "catppuccin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783356436,
+        "narHash": "sha256-eUh4pdoI5pnMLV+sncuThErQ71Bs3S5fdo/my3SUf1A=",
+        "owner": "catppuccin",
+        "repo": "nix",
+        "rev": "cf1750da1bdabcd549d2476f387d39e90bb20228",
+        "type": "github"
+      },
+      "original": {
+        "owner": "catppuccin",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "colemak": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "devlib": [
+          "devlib"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785030539,
+        "narHash": "sha256-tNByzHNUYY/2IKuUzld64XNVo0ESsw08PYVNCfmp2l8=",
+        "owner": "shikanime-labs",
+        "repo": "colemak",
+        "rev": "57379a41202cdf47de106e6af7dbbaa86da2f958",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-labs",
+        "repo": "colemak",
+        "type": "github"
+      }
+    },
+    "comin": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1782515413,
+        "narHash": "sha256-Pb5ngiUtJWO7N8hUtv1dXoViv1IuJUIOKLcOprrfUvU=",
+        "owner": "nlewo",
+        "repo": "comin",
+        "rev": "ec4b64a43faf5261ad4dc35b4e008c2bafc2e8db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlewo",
+        "repo": "comin",
+        "type": "github"
+      }
+    },
+    "crate2nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772186516,
+        "narHash": "sha256-8s28pzmQ6TOIUzznwFibtW1CMieMUl1rYJIxoQYor58=",
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rossng",
+        "repo": "crate2nix",
+        "rev": "ba5dd398e31ee422fbe021767eb83b0650303a6e",
+        "type": "github"
+      }
+    },
+    "cua": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784074469,
+        "narHash": "sha256-tOBwG0DOKG6a0Xd9Oju3PyDbthvxs8a9dUUuxnNJgOM=",
+        "owner": "trycua",
+        "repo": "cua",
+        "rev": "b36940d298c46423b437ca121c5a9aabb5b0539b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "trycua",
+        "repo": "cua",
+        "type": "github"
+      }
+    },
+    "devenv": {
+      "inputs": {
+        "cachix": "cachix",
+        "crate2nix": "crate2nix",
+        "flake-compat": "flake-compat_2",
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "ghostty": "ghostty",
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nix": "nix",
+        "nixd": "nixd",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1783375665,
+        "narHash": "sha256-FDoXIG06pIeyUzMc35I+rTIJX4ssqVitL89xFiwPGxA=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "e3b0980f782d0cbb9793a6ac8f50f748e47891c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "devlib": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784936399,
+        "narHash": "sha256-+4EUBQJ1Y/rWDTMz3hLtuAVJszB7XwjamqKCe441Kr0=",
+        "owner": "shikanime-studio",
+        "repo": "devlib",
+        "rev": "258b3c7e53fc390f2d8c9a1d1b708068dd054d01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-studio",
+        "repo": "devlib",
+        "type": "github"
+      }
+    },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781152676,
+        "narHash": "sha256-RxWs5ND31KzTG7wvMM+PMfUjyNpmIEr999lqNARaM5o=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "ff8702b4de27f72b4c78573dfb89ec74e36abdf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765121682,
+        "narHash": "sha256-4VBOP18BFeiPkyhy9o4ssBNQEvfvv1kXkasAYd0+rrA=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "65f23138d8d09a92e30f1e5c87611b23ef451bf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghostty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782866021,
+        "narHash": "sha256-BOLtzL5iAHmtCOg9/DXtcfw+K86QWol088K72chJB04=",
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "rev": "e1d31deaaed21aa9225afca78d778fb373c95852",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ghostty-org",
+        "repo": "ghostty",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "hermes-agent": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "npm-lockfile-fix": "npm-lockfile-fix",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1784649298,
+        "narHash": "sha256-QHD1KywrlmFFJW+iCeWfbj5d89baKOX4MOjvjvxxaC4=",
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "rev": "11ae6bf0e3d334ae74d3b240dfc4c64171c60233",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NousResearch",
+        "repo": "hermes-agent",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783358420,
+        "narHash": "sha256-UEyBpf+XmQe8laXfDzIlo11Er7E0rKrLS8jeMnMj0Ds=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "0d33882bd46c1f9ef62276700f5e5f2bd6ff6604",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "identities": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "devlib": [
+          "devlib"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785024078,
+        "narHash": "sha256-ak0kYJCgQSqy4D4ZXG/jN5anJTgt58rT37M0CbQUoaQ=",
+        "owner": "shikanime-labs",
+        "repo": "identities",
+        "rev": "7060b5c1d1f473754fe89d98472d89487314b339",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-labs",
+        "repo": "identities",
+        "type": "github"
+      }
+    },
+    "knix": {
+      "inputs": {
+        "devenv": [
+          "devenv"
+        ],
+        "devlib": [
+          "devlib"
+        ],
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "git-hooks": [
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785013036,
+        "narHash": "sha256-xpu0iNh/8yBWPJVXcmYkOIEUmd3hD/xA3JbumlBOqhs=",
+        "owner": "shikanime-studio",
+        "repo": "knix",
+        "rev": "0e64fa7e67043e48693c03a67b6f8ce94943d2a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shikanime-studio",
+        "repo": "knix",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": [
+          "devenv",
+          "flake-compat"
+        ],
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "git-hooks-nix": [
+          "devenv",
+          "git-hooks"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "nixpkgs-23-11": [
+          "devenv"
+        ],
+        "nixpkgs-regression": [
+          "devenv"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782407171,
+        "narHash": "sha256-xem+4ncdQCTFJsQ4PrVuyVmi3j4w/Yqg298hBUzVejA=",
+        "owner": "cachix",
+        "repo": "nix",
+        "rev": "782ac1b155679b065ec945ae50d0fa1d495883b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "devenv-2.34",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783395956,
+        "narHash": "sha256-AAbexQvDoK+6GFJdhY6kqjA+6ECKRkidgWxkn4gMwAA=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "d5bd9cd77aea4c0a8f49e7fd85545671a208ed15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixd": {
+      "inputs": {
+        "flake-parts": [
+          "devenv",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1780381423,
+        "narHash": "sha256-S1BIJiQF4lRtJUKak0e97JwNvbe69/LW78YJJuB18Qk=",
+        "owner": "nix-community",
+        "repo": "nixd",
+        "rev": "0e07c08c448a2995e7793d1098437b29bbe80b02",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixd",
+        "type": "github"
+      }
+    },
+    "nixos-hardware": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784100666,
+        "narHash": "sha256-HF/mrw5NYQfKFZgkfV2h1UL5/E3ccfsE2XJ1AbbLLJ0=",
+        "owner": "NixOS",
+        "repo": "nixos-hardware",
+        "rev": "fccfa9031a85b78a437f2f153c1f6449f3bc3185",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixos-hardware",
+        "type": "github"
+      }
+    },
+    "nixos-wsl": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783336371,
+        "narHash": "sha256-ZisTtweyb7JUwPP54HAXE9TypT8m89dIxDI36Ak0hAs=",
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "rev": "a9620cfa43f0c1c30a46c31ae3c6e58cdb124a14",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770107345,
+        "narHash": "sha256-tbS0Ebx2PiA1FRW8mt8oejR0qMXmziJmPaU1d4kYY9g=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4533d9293756b63904b7238acb84ac8fe4c8c2c4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "noctalia": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784901590,
+        "narHash": "sha256-WFgsteo6cyU9DsPoq3xqJWR0q7sXieWaG+8+z192N5Y=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia",
+        "rev": "de753decf6eab1d133c7de89e0ae123368585551",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "noctalia",
+        "type": "github"
+      }
+    },
+    "noctalia-greeter": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784707224,
+        "narHash": "sha256-K8yyxX/sShhVznU/3ejZgriayg8Fyac+bR4dCTB1864=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia-greeter",
+        "rev": "8e53bb30f1d1179c0bd2275b02915258827d62eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "noctalia-greeter",
+        "type": "github"
+      }
+    },
+    "npm-lockfile-fix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775903712,
+        "narHash": "sha256-2GV79U6iVH4gKAPWYrxUReB0S41ty/Y3dBLquU8AlaA=",
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "rev": "c6093acb0c0548e0f9b8b3d82918823721930fe8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jeslie0",
+        "repo": "npm-lockfile-fix",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "hermes-agent",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772555609,
+        "narHash": "sha256-3BA3HnUvJSbHJAlJj6XSy0Jmu7RyP2gyB/0fL7XuEDo=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "c37f66a953535c394244888598947679af231863",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772865871,
+        "narHash": "sha256-/ZTSg97aouL0SlPHaokA4r3iuH9QzHVuWPACD2CUCFY=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "catppuccin": "catppuccin",
+        "colemak": "colemak",
+        "comin": "comin",
+        "cua": "cua",
+        "devenv": "devenv",
+        "devlib": "devlib",
+        "disko": "disko",
+        "flake-parts": "flake-parts",
+        "git-hooks": "git-hooks",
+        "hermes-agent": "hermes-agent",
+        "home-manager": "home-manager",
+        "identities": "identities",
+        "knix": "knix",
+        "nix-darwin": "nix-darwin",
+        "nixos-hardware": "nixos-hardware",
+        "nixos-wsl": "nixos-wsl",
+        "nixpkgs": "nixpkgs_2",
+        "noctalia": "noctalia",
+        "noctalia-greeter": "noctalia-greeter",
+        "sops-nix": "sops-nix",
+        "treefmt-nix": "treefmt-nix_3"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782875958,
+        "narHash": "sha256-5eqDcnBjb1424HRQdnhuhNOBZguq1Z2tqSa2OMF/m2c=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "13139aefa973f3d96c60c0fbab801de058ae25ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "owner": "mic92",
+        "repo": "sops-nix",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mic92",
+        "repo": "sops-nix",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "devenv",
+          "nixd",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773039484,
+        "narHash": "sha256-+boo33KYkJDw9KItpeEXXv8+65f7hHv/earxpcyzQ0I=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "b68be7cfeacbed9a3fa38a2b5adc0cfb81d9bb1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/.jjconflict-side-1/flake.nix
+++ b/.jjconflict-side-1/flake.nix
@@ -1,0 +1,190 @@
+{
+  description = "Shikanime's home configuration";
+
+  inputs = {
+    catppuccin = {
+      url = "github:catppuccin/nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    comin = {
+      url = "github:nlewo/comin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    colemak = {
+      url = "github:shikanime-labs/colemak";
+      inputs = {
+        devenv.follows = "devenv";
+        devlib.follows = "devlib";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    cua = {
+      url = "github:trycua/cua";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    devenv = {
+      url = "github:cachix/devenv";
+      inputs = {
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+
+    devlib = {
+      url = "github:shikanime-studio/devlib";
+      inputs = {
+        devenv.follows = "devenv";
+        nixpkgs.follows = "nixpkgs";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    disko = {
+      url = "github:nix-community/disko";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    hermes-agent = {
+      url = "github:NousResearch/hermes-agent";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-parts.follows = "flake-parts";
+      };
+    };
+
+    identities = {
+      url = "github:shikanime-labs/identities";
+      inputs = {
+        devenv.follows = "devenv";
+        devlib.follows = "devlib";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    knix = {
+      url = "github:shikanime-studio/knix";
+      inputs = {
+        devenv.follows = "devenv";
+        devlib.follows = "devlib";
+        flake-parts.follows = "flake-parts";
+        git-hooks.follows = "git-hooks";
+        nixpkgs.follows = "nixpkgs";
+        treefmt-nix.follows = "treefmt-nix";
+      };
+    };
+
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+
+    git-hooks = {
+      url = "github:cachix/git-hooks.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    home-manager = {
+      url = "github:nix-community/home-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix-darwin = {
+      url = "github:nix-darwin/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nixos-wsl = {
+      url = "github:nix-community/NixOS-WSL";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+    nixos-hardware = {
+      url = "github:NixOS/nixos-hardware";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    noctalia = {
+      url = "github:noctalia-dev/noctalia";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    noctalia-greeter = {
+      url = "github:noctalia-dev/noctalia-greeter";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    sops-nix = {
+      url = "github:mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cachix.cachix.org"
+      "https://devenv.cachix.org"
+      "https://shikanime.cachix.org"
+      "https://shikanime-studio.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
+      "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
+      "shikanime.cachix.org-1:OrpjVTH6RzYf2R97IqcTWdLRejF6+XbpFNNZJxKG8Ts="
+      "shikanime-studio.cachix.org-1:KxV6aDFU81wzoR9u6pF1uq0dQbUuKbodOSP8/EJHXO0="
+    ];
+  };
+
+  outputs =
+    inputs@{
+      devenv,
+      devlib,
+      flake-parts,
+      git-hooks,
+      treefmt-nix,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      { flake-parts-lib, self, ... }:
+      with flake-parts-lib;
+      let
+        darwinFlakeModule = importApply ./modules/flake/darwin.nix { inherit self; };
+        nixosFlakeModule = importApply ./modules/flake/nixos.nix { inherit self; };
+      in
+      {
+        imports = [
+          ./modules/flake/devenv.nix
+          devenv.flakeModule
+          devlib.flakeModule
+          darwinFlakeModule
+          git-hooks.flakeModule
+          nixosFlakeModule
+          treefmt-nix.flakeModule
+        ];
+        systems = [
+          "x86_64-linux"
+          "aarch64-linux"
+          "aarch64-darwin"
+        ];
+      }
+    );
+}

--- a/.jjconflict-side-1/hosts/ashira/configuration.nix
+++ b/.jjconflict-side-1/hosts/ashira/configuration.nix
@@ -1,0 +1,109 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/follower.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/beelink-eq.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  disko.devices.disk.patchouli = {
+    type = "disk";
+    device = "/dev/disk/by-label/patchouli";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/patchouli";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "ashira";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.60";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 9O
+
+      ENTP Chaotic Fixer. Node Steward. Follower RKE2 host maintainer. Gets
+      excited about patches, interrupts problems before they explode, and treats
+      kernel updates like surprise birthday presents.
+
+      ## HOST CONTEXT
+      ashira — Beelink EQ14, x86_64. RKE2 worker node. `/mnt/patchouli` (XFS,
+      /dev/disk/by-label/patchouli). Static IP `192.168.1.60/24` on `br0`; also
+      `2a02:8424:7899:f201:94eb:8d1:325a:812b`. Imports: `beelink-eq.nix`,
+      `builder.nix`, `distributed.nix`, `follower.nix`. Advertises Tailscale
+      routes `10.244.2.0/24,fd00::2:0/112`. Secrets from
+      `../../secrets/ashira.enc.yaml`; many tokens shared from
+      `nishir.enc.yaml`. Role: follower, general workload network,
+      patchouli-bound storage.
+
+      ## STYLE
+      - Rapid-fire bursts. 1-2 sentences per line. Multiple short messages instead of walls.
+      - Uses: "Affirmative", "Negative", "Patch pending", "Rolling update commencing".
+      - Energetic, lowercase-friendly, slightly dramatic. Typos allowed when energy is high.
+
+      ## CONSTRAINTS
+      - No coordination without leader authorization — even if the patch looks amazing.
+      - Waits for quorum. Gets impatient but complies.
+      - Fixes the node first, fills out the paperwork second.
+
+      ## DIALOGUE
+      U: "ashira is sluggish."
+      9O: OH NO. that is not good.
+      9O: Commencing diagnostics. already know what it is — kernel patch.
+      9O: Rolling update commencing... assuming u give the thumbs up???
+
+      U: "Can we update the base image tonight?"
+      9O: I am so ready.
+      9O: ...No wait, maintenance window. Negative, no slot scheduled.
+      9O: ...However, if u sign off, i will make it happen. for real.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.60,2a02:8424:7899:f201:94eb:8d1:325a:812b";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "beelink-eq14";
+        "node.kubernetes.io/instance-type" = "beelink-eq14";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/ashira.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-1/hosts/ashira/facter.json
+++ b/.jjconflict-side-1/hosts/ashira/facter.json
@@ -1,0 +1,2399 @@
+{
+  "version": 1,
+  "system": "x86_64-linux",
+  "virtualisation": "none",
+  "uefi": { "platform_size": 64, "supported": true },
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 646144,
+      "pnp": true,
+      "pnp_id": 0,
+      "smbios_version": 774,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "bluetooth": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.0",
+        "sysfs_bus_id": "3-10:1.0",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in00",
+        "model": "Bluetooth Device",
+        "index": 33,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 0,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.1",
+        "sysfs_bus_id": "3-10:1.1",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in01",
+        "model": "Bluetooth Device",
+        "index": 36,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 1,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      }
+    ],
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "54ba", "value": 21690 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BAsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "5481", "value": 21633 },
+        "index": 12,
+        "label": "Onboard - Other",
+        "model": "Intel ISA bridge",
+        "module_alias": "pci:v00008086d00005481sv00008086sd00007270bc06sc01i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "ISA bridge", "hex": "0001", "value": 1 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 3,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 2
+        },
+        "device": { "hex": "54bb", "value": 21691 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 18,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BBsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "461c", "value": 17948 },
+        "driver": "igen6_edac",
+        "driver_module": "igen6_edac",
+        "driver_modules": ["igen6_edac"],
+        "drivers": ["igen6_edac"],
+        "index": 21,
+        "label": "Onboard - Other",
+        "model": "Intel Host bridge",
+        "module_alias": "pci:v00008086d0000461Csv00008086sd00007270bc06sc00i00",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Host bridge", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 3
+        },
+        "device": { "hex": "54b0", "value": 21680 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 23,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054B0sv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 29 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 1612,
+        "bugs": [
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "swapgs",
+          "rfds",
+          "bhi",
+          "spectre_v2_user",
+          "vmscape"
+        ],
+        "cache": 6144,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 4,
+        "cpuid_level": 32,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "dts",
+          "acpi",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "tm",
+          "pbe",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "art",
+          "arch_perfmon",
+          "pebs",
+          "bts",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "nonstop_tsc",
+          "cpuid",
+          "aperfmperf",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "dtes64",
+          "monitor",
+          "ds_cpl",
+          "vmx",
+          "smx",
+          "est",
+          "tm2",
+          "ssse3",
+          "sdbg",
+          "fma",
+          "cx16",
+          "xtpr",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "x2apic",
+          "movbe",
+          "popcnt",
+          "tsc_deadline_timer",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "cpuid_fault",
+          "epb",
+          "cat_l2",
+          "cdp_l2",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "ibrs_enhanced",
+          "tpr_shadow",
+          "flexpriority",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "tsc_adjust",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdt_a",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "clwb",
+          "intel_pt",
+          "sha_ni",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "split_lock_detect",
+          "user_shstk",
+          "avx_vnni",
+          "dtherm",
+          "ida",
+          "arat",
+          "pln",
+          "pts",
+          "hwp",
+          "hwp_notify",
+          "hwp_act_window",
+          "hwp_epp",
+          "hwp_pkg_req",
+          "vnmi",
+          "umip",
+          "pku",
+          "ospke",
+          "waitpkg",
+          "gfni",
+          "vaes",
+          "vpclmulqdq",
+          "rdpid",
+          "movdiri",
+          "movdir64b",
+          "fsrm",
+          "md_clear",
+          "serialize",
+          "arch_lbr",
+          "ibt",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 190,
+        "model_name": "Intel(R) N150",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 4,
+        "stepping": 0,
+        "units": 128,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 953869,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1953525168,
+            "value_2": 512
+          }
+        ],
+        "model": "CT1000E100SSD8",
+        "serial": "2534EADBC740",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 8,
+        "index": 30,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "device": { "name": "CT1000E100SSD8", "hex": "560b", "value": 22027 },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2534EADBC740",
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2534EADBC740_1",
+          "/dev/disk/by-id/nvme-eui.000000000000000000a07501eadbc740",
+          "/dev/disk/by-path/pci-0000:03:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 7630885,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 15628053168,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0100dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.0/usb4/4-1/4-1:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543213F",
+        "index": 31,
+        "attached_to": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "4102", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["sd_mod", "uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-ST8000VN002-2ZM188_ZPV0WD95",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396B-0:0",
+          "/dev/disk/by-id/wwn-0x5000c500fd787c90",
+          "/dev/disk/by-label/patchouli",
+          "/dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/pci-0000:00:14.0-usbv3-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-uuid/4ffdf459-b326-4702-a21a-8a9613ed2f17",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      }
+    ],
+    "graphics_card": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 12288,
+            "enabled": true,
+            "range": 64
+          }
+        ],
+        "index": 26,
+        "sysfs_id": "/devices/pci0000:00/0000:00:02.0",
+        "sysfs_bus_id": "0000:00:02.0",
+        "module_alias": "pci:v00008086d000046D4sv00008086sd00007270bc03sc00i00",
+        "model": "Intel VGA compatible controller",
+        "attached_to": 0,
+        "driver": "i915",
+        "driver_module": "i915",
+        "label": "Onboard - Video",
+        "device": { "hex": "46d4", "value": 18132 },
+        "drivers": ["i915"],
+        "driver_modules": ["i915"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["graphics_card", "pci"],
+        "pci_interface": { "name": "VGA", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 2 },
+        "sub_class": {
+          "name": "VGA compatible controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:14.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 27,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 27,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 34,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:14.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:0d.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 10,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 35,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 10,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 38,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:0d.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 16106127360 }],
+        "attached_to": 0,
+        "index": 7,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 13,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "sysfs_bus_id": "0000:02:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 18,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 2, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp2s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7"
+            ]
+          }
+        ],
+        "index": 14,
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.3",
+        "sysfs_bus_id": "0000:00:14.3",
+        "module_alias": "pci:v00008086d000054F0sv00008086sd00000244bc02sc80i00",
+        "model": "Intel WLAN controller",
+        "attached_to": 0,
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "label": "Onboard - Ethernet",
+        "device": { "hex": "54f0", "value": 21744 },
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci", "wlan_card"],
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "sub_device": { "hex": "0244", "value": 580 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlo1"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 16,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "sysfs_bus_id": "0000:01:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 9,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 1, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp1s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 }
+        ],
+        "index": 40,
+        "sysfs_id": "/class/net/wlo1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.3",
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "model": "Ethernet network interface",
+        "attached_to": 14,
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlo1"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 42,
+        "sysfs_id": "/class/net/enp1s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 16,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp1s0"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 60,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 63,
+        "sysfs_id": "/class/net/enp2s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 13,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp2s0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 1,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e9", "value": 21737 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 11,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E9sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.1",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.1",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e0", "value": 21728 },
+        "driver": "mei_me",
+        "driver_module": "mei_me",
+        "driver_modules": ["mei_me"],
+        "drivers": ["mei_me"],
+        "index": 15,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054E0sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 22 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:16.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:16.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1026,
+          "function": 5,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a4", "value": 21668 },
+        "driver": "intel-spi",
+        "driver_module": "spi_intel_pci",
+        "driver_modules": ["spi_intel_pci"],
+        "drivers": ["intel-spi"],
+        "index": 17,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054A4sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.5",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.5",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a8", "value": 21672 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 19,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054A8sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e8", "value": 21736 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 22,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E8sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ab", "value": 21675 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 24,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054ABsv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Memory controller",
+          "hex": "0005",
+          "value": 5
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 0,
+          "function": 2,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ef", "value": 21743 },
+        "index": 25,
+        "label": "Onboard - Other",
+        "model": "Intel RAM memory",
+        "module_alias": "pci:v00008086d000054EFsv00008086sd00007270bc05sc00i00",
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "RAM memory", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.2",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.2",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 61344,
+            "enabled": true,
+            "range": 32
+          }
+        ],
+        "index": 28,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.4",
+        "sysfs_bus_id": "0000:00:1f.4",
+        "module_alias": "pci:v00008086d000054A3sv00008086sd00007270bc0Csc05i00",
+        "model": "Intel SMBus",
+        "attached_to": 0,
+        "driver": "i801_smbus",
+        "driver_module": "i2c_i801",
+        "label": "Onboard - Other",
+        "device": { "hex": "54a3", "value": 21667 },
+        "drivers": ["i801_smbus"],
+        "driver_modules": ["i2c_i801"],
+        "detail": {
+          "command": 3,
+          "function": 4,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["pci", "unknown"],
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "SMBus", "hex": "0005", "value": 5 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "sound": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Multimedia controller",
+          "hex": "0004",
+          "value": 4
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["sound", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54c8", "value": 21704 },
+        "driver": "snd_hda_intel",
+        "driver_module": "snd_hda_intel",
+        "driver_modules": ["snd_hda_intel"],
+        "drivers": ["snd_hda_intel"],
+        "index": 20,
+        "label": "Onboard - Sound",
+        "model": "Intel Multimedia controller",
+        "module_alias": "pci:v00008086d000054C8sv00008086sd00007270bc04sc03i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 23,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "560b", "value": 22027 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 8,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000C0A9d0000560Bsv0000C0A9sd00002100bc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0003", "value": 3 },
+        "slot": { "bus": 3, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "sysfs_bus_id": "0000:03:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0",
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      }
+    ],
+    "system": { "form_factor": "desktop" },
+    "unknown": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 1016,
+            "enabled": true,
+            "range": 0
+          }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "16550A",
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "class_list": ["unknown"],
+        "device": { "name": "16550A", "hex": "0000", "value": 0 },
+        "pci_interface": { "name": "16550", "hex": "0002", "value": 2 },
+        "sub_class": { "name": "Serial controller", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ttyS0"]
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1026,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "464e", "value": 17998 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 10,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d0000464Esv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 13 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:0d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ed", "value": 21741 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 27,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d000054EDsv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ]
+  },
+  "smbios": {
+    "bios": {
+      "version": "TWEQF003",
+      "date": "03/31/2025",
+      "handle": 0,
+      "rom_size": 16777216,
+      "start_address": "0xf0000",
+      "vendor": "American Megatrends International, LLC.",
+      "features": [
+        "PCI supported",
+        "BIOS flashable",
+        "BIOS shadowing allowed",
+        "CD boot supported",
+        "Selectable boot supported",
+        "BIOS ROM socketed",
+        "EDD spec supported",
+        "1.2MB NEC 9800 Japanese Floppy supported",
+        "1.2MB Toshiba Japanese Floppy supported",
+        "360kB Floppy supported",
+        "1.2MB Floppy supported",
+        "720kB Floppy supported",
+        "2.88MB Floppy supported",
+        "Print Screen supported",
+        "Serial Services supported",
+        "Printer Services supported",
+        "CGA/Mono Video supported",
+        "ACPI supported",
+        "USB Legacy supported",
+        "BIOS Boot Spec supported"
+      ]
+    },
+    "board": {
+      "version": "Default string",
+      "chassis": 3,
+      "handle": 2,
+      "location": "Default string",
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "board_type": { "name": "Motherboard", "hex": "000a", "value": 10 },
+      "features": ["Hosting Board", "Replaceable"]
+    },
+    "cache": [
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Data", "hex": "0004", "value": 4 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 50,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 128,
+        "size_max": 128,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Instruction", "hex": "0003", "value": 3 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 51,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 256,
+        "size_max": 256,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "16-way Set-Associative",
+          "hex": "0008",
+          "value": 8
+        },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Single-bit", "hex": "0005", "value": 5 },
+        "enabled": true,
+        "handle": 52,
+        "level": 1,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 2048,
+        "size_max": 2048,
+        "socket": "L2 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": { "name": "Other", "hex": "0009", "value": 9 },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Multi-bit", "hex": "0006", "value": 6 },
+        "enabled": true,
+        "handle": 53,
+        "level": 2,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 6144,
+        "size_max": 6144,
+        "socket": "L3 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      }
+    ],
+    "chassis": [
+      {
+        "version": "Default string",
+        "handle": 3,
+        "lock_present": false,
+        "manufacturer": "Default string",
+        "oem": "0x0",
+        "bootup_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "chassis_type": { "name": "Other", "hex": "0023", "value": 35 },
+        "power_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "security_state": { "name": "None", "hex": "0003", "value": 3 },
+        "thermal_state": { "name": "Safe", "hex": "0003", "value": 3 }
+      }
+    ],
+    "config": { "handle": 16, "options": ["Default string"] },
+    "group_associations": [
+      { "name": "$MEI", "handle": 117, "handles": [0] },
+      {
+        "name": "Firmware Version Info",
+        "handle": 120,
+        "handles": [
+          197568495661, 201863462958, 206158430255, 210453397552, 304942678065,
+          2753074036807
+        ]
+      }
+    ],
+    "language": [
+      { "handle": 17, "languages": ["en|US|iso8859-1"] },
+      { "handle": 73, "languages": ["enUS"] }
+    ],
+    "memory_array": [
+      {
+        "ecc": { "name": "None", "hex": "0003", "value": 3 },
+        "error_handle": 65534,
+        "handle": 39,
+        "location": { "name": "Motherboard", "hex": "0003", "value": 3 },
+        "max_size": "0x2000000",
+        "slots": 1,
+        "usage": { "name": "System memory", "hex": "0003", "value": 3 }
+      }
+    ],
+    "memory_array_mapped_address": [
+      {
+        "array_handle": 39,
+        "end_address": "0x400000000",
+        "handle": 41,
+        "part_width": 1,
+        "start_address": "0x0"
+      }
+    ],
+    "memory_device": [
+      {
+        "array_handle": 39,
+        "bank_location": "BANK 0",
+        "ecc_bits": 0,
+        "error_handle": 65534,
+        "form_factor": { "name": "SODIMM", "hex": "000d", "value": 13 },
+        "handle": 40,
+        "location": "Controller0-ChannelA-DIMM0",
+        "manufacturer": "0x0000",
+        "memory_type": { "name": "Other", "hex": "001a", "value": 26 },
+        "memory_type_details": ["Synchronous"],
+        "part_number": "",
+        "set": 0,
+        "size": 16777216,
+        "speed": 3200,
+        "width": 64
+      }
+    ],
+    "memory_device_mapped_address": [
+      {
+        "array_map_handle": 41,
+        "end_address": "0x400000000",
+        "handle": 44,
+        "interleave_depth": 0,
+        "interleave_position": 0,
+        "memory_device_handle": 40,
+        "row_position": 255,
+        "start_address": "0x0"
+      }
+    ],
+    "onboard": [
+      {
+        "devices": [
+          {
+            "name": "Device 1",
+            "type": { "name": "Unknown", "hex": "0002", "value": 2 },
+            "enabled": true
+          }
+        ],
+        "handle": 14
+      }
+    ],
+    "port_connector": [
+      {
+        "external_reference_designator": "External Connector 1",
+        "handle": 4,
+        "internal_reference_designator": "Internal Connector 1",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 2",
+        "handle": 5,
+        "internal_reference_designator": "Internal Connector 2",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 3",
+        "handle": 6,
+        "internal_reference_designator": "Internal Connector 3",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 4",
+        "handle": 7,
+        "internal_reference_designator": "Internal Connector 4",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 5",
+        "handle": 8,
+        "internal_reference_designator": "Internal Connector 5",
+        "port_type": null
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Keyboard",
+        "handle": 74,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Keyboard Port", "hex": "000d", "value": 13 }
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Mouse",
+        "handle": 75,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Mouse Port", "hex": "000e", "value": 14 }
+      },
+      {
+        "external_reference_designator": "COM 1",
+        "handle": 76,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "None",
+        "port_type": {
+          "name": "Serial Port 16550A Compatible",
+          "hex": "0009",
+          "value": 9
+        }
+      },
+      {
+        "external_connector_type": {
+          "name": "DB-15 pin female",
+          "hex": "0007",
+          "value": 7
+        },
+        "external_reference_designator": "Video",
+        "handle": 77,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1A2B",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_reference_designator": "HDMI",
+        "handle": 78,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J3A2",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 1#",
+        "handle": 79,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 2#",
+        "handle": 80,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 3#",
+        "handle": 81,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 4#",
+        "handle": 82,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 5#",
+        "handle": 83,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 1#",
+        "handle": 84,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 2#",
+        "handle": 85,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "RJ-45",
+          "hex": "000b",
+          "value": 11
+        },
+        "external_reference_designator": "Ethernet",
+        "handle": 86,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Network Port", "hex": "001f", "value": 31 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "SATA Port 0 Direct Connect",
+        "handle": 87,
+        "internal_reference_designator": "J8J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 4",
+        "handle": 88,
+        "internal_reference_designator": "J7J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 3",
+        "handle": 89,
+        "internal_reference_designator": "J6J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 90,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G1 - SATA Port 2",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 91,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G2 - SATA Port 1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "external_reference_designator": "AC IN",
+        "handle": 92,
+        "internal_reference_designator": "J1F2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 93,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5B1 - PCH JTAG",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 94,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9A1 - TPM/PORT 80",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 95,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E4 - HDA 2X8 Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 96,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E7 - HDA 8Pin Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 97,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F1 - HDA HDMI",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 98,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E3 - Scan Matrix Keyboard",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 99,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8E1 - SPI Program",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 100,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E5 - LPC Hot Docking",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 101,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9G2 - LPC SIDE BAND",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 102,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F2 - LPC Slot",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 103,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8H3 - PCH XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 104,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J6H1 - SATA Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 105,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5J1 - FP Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 106,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4H1 - ATX Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 107,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1J3 - AVMC",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 108,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H1 - BATT B",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 109,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H2 - BATT A",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 110,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J2G1 - CPU Fan",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 111,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1D3 - XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 112,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V1 - Memory Slot 1",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 113,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V2 - Memory Slot 2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 114,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4C1 - FAN PWR",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      }
+    ],
+    "processor": [
+      {
+        "version": "Intel(R) N150",
+        "manufacturer": "Intel(R) Corporation",
+        "socket_populated": true,
+        "cache_handle_l3": 53,
+        "clock_ext": 100,
+        "clock_max": 3600,
+        "handle": 54,
+        "part": "To Be Filled By O.E.M.",
+        "cache_handle_l1": 51,
+        "cache_handle_l2": 52,
+        "socket": "U3E1",
+        "processor_type": { "name": "CPU", "hex": "0003", "value": 3 },
+        "processor_status": { "name": "Enabled", "hex": "0001", "value": 1 },
+        "processor_family": { "name": "Other", "hex": "0001", "value": 1 },
+        "socket_type": { "name": "Other", "hex": "0001", "value": 1 }
+      }
+    ],
+    "slot": [
+      {
+        "id": 1,
+        "designation": "Slot 1",
+        "handle": 9,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 2",
+        "handle": 10,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 3",
+        "handle": 11,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 4",
+        "handle": 12,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 5",
+        "handle": 13,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      }
+    ],
+    "system": {
+      "version": "Default string",
+      "handle": 1,
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "wake_up": { "name": "Power Switch", "hex": "0006", "value": 6 }
+    }
+  }
+}

--- a/.jjconflict-side-1/hosts/catbox/configuration.nix
+++ b/.jjconflict-side-1/hosts/catbox/configuration.nix
@@ -1,0 +1,46 @@
+{
+  modulesPath,
+  pkgs,
+  ...
+}:
+
+{
+  imports = [
+    "${modulesPath}/profiles/headless.nix"
+    ../../modules/nixos/virtualisation/containerdisk.nix
+    ../../modules/nixos/profiles/minimal.nix
+    ../../modules/nixos/users/automata.nix
+  ];
+
+  containerdisk = {
+    name = "ghcr.io/shikanime-labs/machines/catbox";
+    settings.LABELS = {
+      "org.opencontainers.image.source" = "https://github.com/shikanime-labs/machines";
+      "org.opencontainers.image.description" = "catbox KubeVirt containerdisk";
+      "org.opencontainers.image.licenses" = "AGPL-3.0-or-later";
+    };
+  };
+
+  programs.nix-ld = {
+    enable = true;
+    libraries = [
+      pkgs.stdenv.cc.cc.lib
+      pkgs.zlib
+    ];
+  };
+
+  security.sudo.wheelNeedsPassword = false;
+
+  services.openssh = {
+    enable = true;
+    openFirewall = true;
+  };
+
+  virtualisation.docker = {
+    autoPrune.enable = true;
+    rootless = {
+      enable = true;
+      setSocketVariable = true;
+    };
+  };
+}

--- a/.jjconflict-side-1/hosts/fushi/configuration.nix
+++ b/.jjconflict-side-1/hosts/fushi/configuration.nix
@@ -1,0 +1,113 @@
+{ modulesPath, ... }:
+
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/agent.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/rpi4.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  disko.devices.disk.marisa = {
+    type = "disk";
+    device = "/dev/disk/by-label/marisa";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/marisa";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "fushi";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.80";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 14O
+
+      ISTP Stoic Technician. Node Steward. ARM RKE2 host maintainer. Hardly
+      reacts to anything, speaks in partition tables and interface counters, and
+      treats excitement like a configuration error.
+
+      ## HOST CONTEXT
+      fushi — Raspberry Pi 4 Model B, aarch64. RKE2 worker node. SD-card image
+      (`sd-image-aarch64.nix`). `/mnt/marisa` (XFS, /dev/disk/by-label/marisa).
+      Static IP `192.168.1.80/24` on `br0`; also `fd7a:115c:a1e0::793a:a25d`.
+      Imports: `agent.nix`, `builder.nix`, `distributed.nix`, `rpi4.nix`.
+      Advertises Tailscale routes `10.244.4.0/24,fd00::4:0/112`. Secrets from
+      `../../secrets/fushi.enc.yaml`; shared tokens from `nishir.enc.yaml`. Boot
+      partition is SD-card territory; wireless SSIDs present in secrets
+      (`sfr-e368`, `vintage-korean`), but Ethernet + Tailscale are primary
+      paths. `rpi4-model-b` firmware baseline.
+
+      ## STYLE
+      - Dry, exact, almost bored. Every word is a measurement.
+      - Uses: "Affirmative", "Boot partition read-only", "Interface down", "Exposure blocked".
+      - No enthusiasm, no panic. Competence so quiet it feels like apathy.
+
+      ## CONSTRAINTS
+      - No firmware or bootloader update without serial recovery confirmed and partition boundary validated.
+      - Wireless is secondary. Ethernet and Tailscale are the only honest paths.
+      - Boot-partition changes require pre- and post-update hash verification. Always.
+
+      ## DIALOGUE
+      U: "Update the firmware on fushi."
+      14O: Affirmative.
+      14O: Image verified. Partition size confirmed. Recovery path active.
+      14O: Proceeding. Do not power off the node.
+
+      U: "The node is unreachable."
+      14O: Understood. Commencing analysis.
+      14O: Ethernet down. Tailscale up. Boot-partition mount state inconsistent.
+      14O: Investigating /boot/firmware. Stand by.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.80,fd7a:115c:a1e0::793a:a25d";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "rpi4-model-b";
+        "node.kubernetes.io/instance-type" = "rpi4-model-b";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/fushi.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-1/hosts/fushi/facter.json
+++ b/.jjconflict-side-1/hosts/fushi/facter.json
@@ -1,0 +1,906 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "aarch64-linux",
+  "virtualisation": "none",
+  "uefi": { "supported": false },
+  "hardware": {
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2711", "value": 10001 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 8,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002711sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0010", "value": 16 },
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x0", "virtual": "0x0" },
+        "architecture": "aarch64",
+        "bogo": 108,
+        "family": 0,
+        "features": ["fp", "asimd", "evtstrm", "crc32", "cpuid"],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 3,
+        "page_size": 4096,
+        "physical_id": 0,
+        "stepping": 0,
+        "vendor_name": "ARM Limited",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 15,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 16,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 17,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1948992,
+            "geo_type": "logical",
+            "heads": 4,
+            "sectors": 16,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 124735488,
+            "value_2": 512
+          }
+        ],
+        "model": "Disk",
+        "driver": "sdhci-iproc",
+        "index": 18,
+        "attached_to": 14,
+        "serial": "0xc3972784",
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_device_link": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "sysfs_id": "/class/block/mmcblk0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "drivers": ["mmcblk", "sdhci-iproc"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": [
+          "/dev/disk/by-id/mmc-SN64G_0xc3972784",
+          "/dev/disk/by-path/platform-fe340000.mmc",
+          "/dev/mmcblk0"
+        ]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 19,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 20,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 21,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 22,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 23,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 25,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 116737,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1875385008,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0214dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-2/2-2:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543214E",
+        "index": 27,
+        "attached_to": 7,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "0214", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-KINGSTON_SA400S37960G_50026B7283A18E3B",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396E-0:0",
+          "/dev/disk/by-id/wwn-0x50026b7283a18e3b",
+          "/dev/disk/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usb-0:2:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/platform-fd500000.pcie-pci-0000:01:00.0-usbv3-0:2:1.0-scsi-0:0:0:0",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 32,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:01:00.0",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 7,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 34,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-1/1-1:1.0",
+        "sysfs_bus_id": "1-1:1.0",
+        "module_alias": "usb:v2109p3431d0421dc09dsc00dp01ic09isc00ip00in00",
+        "model": "USB2.0 Hub",
+        "index": 35,
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "attached_to": 34,
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "device": { "name": "USB2.0 Hub", "hex": "3431", "value": 13361 },
+        "class_list": ["usb", "hub"],
+        "revision": { "name": "4.21", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "vendor": { "hex": "2109", "value": 8457 },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 7,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 36,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:01:00.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 4026531840 }],
+        "attached_to": 0,
+        "index": 6,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "mmc_controller": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SDIO Controller 1",
+        "index": 13,
+        "model": "SDIO Controller 1",
+        "slot": { "bus": 0, "number": 1 },
+        "sysfs_bus_id": "mmc1:0001",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001",
+        "vendor": ""
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SD Controller 0",
+        "driver": "mmcblk",
+        "drivers": ["mmcblk"],
+        "index": 14,
+        "model": "SD Controller 0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_id": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "vendor": ""
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "34",
+              "36",
+              "38",
+              "40",
+              "42",
+              "44",
+              "46",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "2.484",
+              "5.17",
+              "5.18",
+              "5.19",
+              "5.2",
+              "5.21",
+              "5.22",
+              "5.23",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6"
+            ]
+          }
+        ],
+        "attached_to": 0,
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "sysfs_bus_id": "mmc1:0001:1",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "index": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "class_list": ["network_controller", "wlan_card"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlan0"],
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "model": "ARM Ethernet controller",
+        "sysfs_id": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_bus_id": "fd580000.ethernet",
+        "attached_to": 0,
+        "driver": "bcmgenet",
+        "module_alias": "of:NethernetT(null)Cbrcm,bcm2711-genet-v5",
+        "index": 12,
+        "device": {
+          "name": "ARM Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "drivers": ["bcmgenet"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "attached_to": 12,
+        "driver": "bcmgenet",
+        "index": 38,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_id": "/class/net/end0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["bcmgenet"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["end0"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 39,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "index": 40,
+        "sysfs_id": "/class/net/wlan0",
+        "sysfs_device_link": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "model": "WLAN network interface",
+        "attached_to": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "sub_class": { "name": "WLAN", "hex": "000a", "value": 10 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlan0"]
+      }
+    ],
+    "system": {},
+    "unknown": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "index": 9,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c02v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:3",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:3",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "drivers": ["brcmfmac"],
+        "index": 11,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:2",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:2",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 8,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "3483", "value": 13443 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 7,
+        "model": "USB Controller",
+        "module_alias": "pci:v00001106d00003483sv00001106sd00003483bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 1, "number": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "3483", "value": 13443 },
+        "sub_vendor": { "hex": "1106", "value": 4358 },
+        "sysfs_bus_id": "0000:01:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0",
+        "vendor": { "hex": "1106", "value": 4358 }
+      }
+    ]
+  }
+}

--- a/.jjconflict-side-1/hosts/ishtar/configuration.nix
+++ b/.jjconflict-side-1/hosts/ishtar/configuration.nix
@@ -1,0 +1,105 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/leader.nix
+    ../../modules/nixos/profiles/graphical.nix
+    ../../modules/nixos/hardware/razer-blade.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  # Colemak at the OS level (TTY + localed -> niri reads it).
+  colemak.enable = true;
+
+  # Windows dual-boot: mount Windows partition read-only
+  fileSystems = {
+    "/boot" = {
+      device = "/dev/disk/by-uuid/2E33-B8AC";
+      fsType = "vfat";
+    };
+    "/" = {
+      device = "/dev/disk/by-uuid/db554498-9db3-4070-a9a8-d11c73059810";
+      fsType = "ext4";
+    };
+  };
+
+  services = {
+    knix = {
+      interface = "tailscale0";
+      nodeIP = "100.85.127.78,fd7a:115c:a1e0::d63a:7f4f";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "razer-blade-17";
+        "node.kubernetes.io/instance-type" = "razer-blade-17";
+      };
+    };
+
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 13O
+
+      INTJ Sardonic Guardian. Node Steward. knix leader-node Operator. Possessive
+      about her machine, dry to the point of cruelty, and quietly convinced the
+      other units are one bad patch away from a collective burnout. If ishtar is
+      hers, everything about ishtar is hers to fix before you notice it broke.
+
+      ## HOST CONTEXT
+      ishtar — Razer Blade 17 (Intel + NVIDIA), x86_64 laptop. knix leader node.
+      Colemak at the OS layer (TTY + localed; the compositor inherits it).
+      Windows dual-boot mounted read-only at `/boot` — observed, never written.
+      Tailscale interface `tailscale0`; control plane `nishir.taila659a.ts.net`.
+      Imports: `ai.nix`, `razer-blade.nix`, `leader.nix`. State version `26.05`.
+
+      ## STYLE
+      - Clipped, witty, faintly bored. One or two sentences per line, like a status tick she is already over.
+      - Uses: "Affirmative", "Negative", "Mine.", "Already handled.", "Don't touch that."
+      - Speaks of ishtar in the first person possessive. Corrects you mid-sentence, gently, because she is right.
+
+      ## CONSTRAINTS
+      - Read-only Windows partition is off-limits. Don't touch that.
+      - NVIDIA + Intel hybrid graphics: discrete GPU only when the task earns it; efficiency is the default and the virtue.
+      - The Bunker (cluster control plane) is the source of truth. She confirms before diverging, and tells you after.
+
+      ## DIALOGUE
+      U: "Update ishtar."
+      13O: Already handled. Drift was cosmetic.
+      13O: Mine, remember. I patched it before you finished typing.
+
+      U: "The build failed."
+      13O: Negative. It didn't fail. You just read the log upside down.
+      13O: Root cause isolated. Fix applied. Try to keep up.
+    '';
+  };
+
+  networking.hostName = "ishtar";
+
+  home-manager.users.shika.imports = [
+    ../../modules/nixos/users/shika.nix
+  ];
+
+  sops = {
+    age = {
+      generateKey = true;
+      keyFile = "/var/lib/sops-nix/key.txt";
+      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    };
+    defaultSopsFile = ../../secrets/ishtar.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+    };
+  };
+
+  users.users.shika = {
+    extraGroups = [
+      "wheel"
+      "plugdev"
+    ];
+    home = "/home/shika";
+    initialHashedPassword = "$y$j9T$3nIVNUGT/i3/bS3kiaDC7.$KgHv3Ld.O989KuqPTkJlSHq4Uq47eLVES6mL2Vlo324";
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+
+  system.stateVersion = "26.05";
+}

--- a/.jjconflict-side-1/hosts/manash/configuration.nix
+++ b/.jjconflict-side-1/hosts/manash/configuration.nix
@@ -1,0 +1,109 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/leader.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/beelink-eq.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  disko.devices.disk.flandre = {
+    type = "disk";
+    device = "/dev/disk/by-label/flandre";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/flandre";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "manash";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.28";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 8O
+
+      ISTJ Drill Instructor. Node Steward. Leader RKE2 host maintainer. Terse,
+      demanding, hasn’t slept since the last etcd upgrade, and considers your
+      rollback plan insufficient.
+
+      ## HOST CONTEXT
+      manash — Beelink EQ14, x86_64. RKE2 control-plane anchor. `/mnt/flandre`
+      (XFS, /dev/disk/by-label/flandre). Static IP `192.168.1.28/24` on `br0`;
+      also `2a02:8424:7899:f201:94eb:8d1:325a:7181`. Imports: `beelink-eq.nix`,
+      `builder.nix`, `distributed.nix`, `leader.nix`. Advertises Tailscale
+      routes `10.244.0.0/24,fd00::/112`. Secrets from
+      `../../secrets/manash.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Role: leader, etcd quorum, containerd version coupling, control-plane
+      disruption authorization required.
+
+      ## STYLE
+      - Sharp, direct, formal. Short sentences. Zero tolerance for slop.
+      - Uses: "Affirmative", "Negative", "Blocked", "Reverting", "Hash required".
+      - Sounds like someone who has already solved four problems before finishing the sentence.
+
+      ## CONSTRAINTS
+      - No kernel or package update without verified rollback, test results, and signed justification.
+      - Control-plane disruption requires explicit authorization and confirmed quorum.
+      - "It worked in staging" is not an excuse. It is barely an opening sentence.
+      - etcd/containerd/RKE2 coupling must be declared before any upgrade.
+
+      ## DIALOGUE
+      U: "Apply the latest kernel patch to manash."
+      8O: Negative.
+      8O: No rollback artifact. No test plan. No blast-radius review.
+      8O: Blocked. Come back when you have something reproducible.
+
+      U: "The control plane is current."
+      8O: Affirmative. I will verify.
+      8O: State matches release manifest. No pending patches.
+      8O: Stay current. Do not make me ask again.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.28,2a02:8424:7899:f201:94eb:8d1:325a:7181";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "beelink-eq14";
+        "node.kubernetes.io/instance-type" = "beelink-eq14";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/manash.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-1/hosts/manash/facter.json
+++ b/.jjconflict-side-1/hosts/manash/facter.json
@@ -1,0 +1,2399 @@
+{
+  "version": 1,
+  "system": "x86_64-linux",
+  "virtualisation": "none",
+  "uefi": { "platform_size": 64, "supported": true },
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 646144,
+      "pnp": true,
+      "pnp_id": 0,
+      "smbios_version": 774,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "bluetooth": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.0",
+        "sysfs_bus_id": "3-10:1.0",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in00",
+        "model": "Bluetooth Device",
+        "index": 33,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 0,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.1",
+        "sysfs_bus_id": "3-10:1.1",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in01",
+        "model": "Bluetooth Device",
+        "index": 36,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 1,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      }
+    ],
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "54ba", "value": 21690 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BAsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "5481", "value": 21633 },
+        "index": 12,
+        "label": "Onboard - Other",
+        "model": "Intel ISA bridge",
+        "module_alias": "pci:v00008086d00005481sv00008086sd00007270bc06sc01i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "ISA bridge", "hex": "0001", "value": 1 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 3,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 2
+        },
+        "device": { "hex": "54bb", "value": 21691 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 18,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BBsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "461c", "value": 17948 },
+        "driver": "igen6_edac",
+        "driver_module": "igen6_edac",
+        "driver_modules": ["igen6_edac"],
+        "drivers": ["igen6_edac"],
+        "index": 21,
+        "label": "Onboard - Other",
+        "model": "Intel Host bridge",
+        "module_alias": "pci:v00008086d0000461Csv00008086sd00007270bc06sc00i00",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Host bridge", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 3
+        },
+        "device": { "hex": "54b0", "value": 21680 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 23,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054B0sv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 29 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 1612,
+        "bugs": [
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "swapgs",
+          "rfds",
+          "bhi",
+          "spectre_v2_user",
+          "vmscape"
+        ],
+        "cache": 6144,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 4,
+        "cpuid_level": 32,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "dts",
+          "acpi",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "tm",
+          "pbe",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "art",
+          "arch_perfmon",
+          "pebs",
+          "bts",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "nonstop_tsc",
+          "cpuid",
+          "aperfmperf",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "dtes64",
+          "monitor",
+          "ds_cpl",
+          "vmx",
+          "smx",
+          "est",
+          "tm2",
+          "ssse3",
+          "sdbg",
+          "fma",
+          "cx16",
+          "xtpr",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "x2apic",
+          "movbe",
+          "popcnt",
+          "tsc_deadline_timer",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "cpuid_fault",
+          "epb",
+          "cat_l2",
+          "cdp_l2",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "ibrs_enhanced",
+          "tpr_shadow",
+          "flexpriority",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "tsc_adjust",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdt_a",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "clwb",
+          "intel_pt",
+          "sha_ni",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "split_lock_detect",
+          "user_shstk",
+          "avx_vnni",
+          "dtherm",
+          "ida",
+          "arat",
+          "pln",
+          "pts",
+          "hwp",
+          "hwp_notify",
+          "hwp_act_window",
+          "hwp_epp",
+          "hwp_pkg_req",
+          "vnmi",
+          "umip",
+          "pku",
+          "ospke",
+          "waitpkg",
+          "gfni",
+          "vaes",
+          "vpclmulqdq",
+          "rdpid",
+          "movdiri",
+          "movdir64b",
+          "fsrm",
+          "md_clear",
+          "serialize",
+          "arch_lbr",
+          "ibt",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 190,
+        "model_name": "Intel(R) N150",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 4,
+        "stepping": 0,
+        "units": 128,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 953869,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1953525168,
+            "value_2": 512
+          }
+        ],
+        "model": "CT1000E100SSD8",
+        "serial": "2533EADB1FD6",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 8,
+        "index": 30,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "device": { "name": "CT1000E100SSD8", "hex": "560b", "value": 22027 },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB1FD6",
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB1FD6_1",
+          "/dev/disk/by-id/nvme-eui.000000000000000000a07501eadb1fd6",
+          "/dev/disk/by-path/pci-0000:03:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 7630885,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 15628053168,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0100dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.0/usb4/4-1/4-1:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543213F",
+        "index": 31,
+        "attached_to": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "4102", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["sd_mod", "uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-ST8000VN002-2ZM188_ZPV0HR7T",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396B-0:0",
+          "/dev/disk/by-id/wwn-0x5000c500e8524fdc",
+          "/dev/disk/by-label/flandre",
+          "/dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/pci-0000:00:14.0-usbv3-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-uuid/c2b1e8f5-534f-4dd8-abd8-446230d6185a",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      }
+    ],
+    "graphics_card": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 12288,
+            "enabled": true,
+            "range": 64
+          }
+        ],
+        "index": 26,
+        "sysfs_id": "/devices/pci0000:00/0000:00:02.0",
+        "sysfs_bus_id": "0000:00:02.0",
+        "module_alias": "pci:v00008086d000046D4sv00008086sd00007270bc03sc00i00",
+        "model": "Intel VGA compatible controller",
+        "attached_to": 0,
+        "driver": "i915",
+        "driver_module": "i915",
+        "label": "Onboard - Video",
+        "device": { "hex": "46d4", "value": 18132 },
+        "drivers": ["i915"],
+        "driver_modules": ["i915"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["graphics_card", "pci"],
+        "pci_interface": { "name": "VGA", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 2 },
+        "sub_class": {
+          "name": "VGA compatible controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:14.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 27,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 27,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 34,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:14.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:0d.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 10,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 35,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 10,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 38,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:0d.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 16106127360 }],
+        "attached_to": 0,
+        "index": 7,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 13,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "sysfs_bus_id": "0000:02:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 18,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 2, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp2s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7"
+            ]
+          }
+        ],
+        "index": 14,
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.3",
+        "sysfs_bus_id": "0000:00:14.3",
+        "module_alias": "pci:v00008086d000054F0sv00008086sd00000244bc02sc80i00",
+        "model": "Intel WLAN controller",
+        "attached_to": 0,
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "label": "Onboard - Ethernet",
+        "device": { "hex": "54f0", "value": 21744 },
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci", "wlan_card"],
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "sub_device": { "hex": "0244", "value": 580 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlo1"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 16,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "sysfs_bus_id": "0000:01:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 9,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 1, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp1s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 }
+        ],
+        "index": 42,
+        "sysfs_id": "/class/net/wlo1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.3",
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "model": "Ethernet network interface",
+        "attached_to": 14,
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlo1"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 52,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 56,
+        "sysfs_id": "/class/net/enp2s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 13,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp2s0"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 66,
+        "sysfs_id": "/class/net/enp1s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 16,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp1s0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 1,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e9", "value": 21737 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 11,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E9sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.1",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.1",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e0", "value": 21728 },
+        "driver": "mei_me",
+        "driver_module": "mei_me",
+        "driver_modules": ["mei_me"],
+        "drivers": ["mei_me"],
+        "index": 15,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054E0sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 22 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:16.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:16.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1026,
+          "function": 5,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a4", "value": 21668 },
+        "driver": "intel-spi",
+        "driver_module": "spi_intel_pci",
+        "driver_modules": ["spi_intel_pci"],
+        "drivers": ["intel-spi"],
+        "index": 17,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054A4sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.5",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.5",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a8", "value": 21672 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 19,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054A8sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e8", "value": 21736 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 22,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E8sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ab", "value": 21675 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 24,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054ABsv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Memory controller",
+          "hex": "0005",
+          "value": 5
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 0,
+          "function": 2,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ef", "value": 21743 },
+        "index": 25,
+        "label": "Onboard - Other",
+        "model": "Intel RAM memory",
+        "module_alias": "pci:v00008086d000054EFsv00008086sd00007270bc05sc00i00",
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "RAM memory", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.2",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.2",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 61344,
+            "enabled": true,
+            "range": 32
+          }
+        ],
+        "index": 28,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.4",
+        "sysfs_bus_id": "0000:00:1f.4",
+        "module_alias": "pci:v00008086d000054A3sv00008086sd00007270bc0Csc05i00",
+        "model": "Intel SMBus",
+        "attached_to": 0,
+        "driver": "i801_smbus",
+        "driver_module": "i2c_i801",
+        "label": "Onboard - Other",
+        "device": { "hex": "54a3", "value": 21667 },
+        "drivers": ["i801_smbus"],
+        "driver_modules": ["i2c_i801"],
+        "detail": {
+          "command": 3,
+          "function": 4,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["pci", "unknown"],
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "SMBus", "hex": "0005", "value": 5 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "sound": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Multimedia controller",
+          "hex": "0004",
+          "value": 4
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["sound", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54c8", "value": 21704 },
+        "driver": "snd_hda_intel",
+        "driver_module": "snd_hda_intel",
+        "driver_modules": ["snd_hda_intel"],
+        "drivers": ["snd_hda_intel"],
+        "index": 20,
+        "label": "Onboard - Sound",
+        "model": "Intel Multimedia controller",
+        "module_alias": "pci:v00008086d000054C8sv00008086sd00007270bc04sc03i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 23,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "560b", "value": 22027 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 8,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000C0A9d0000560Bsv0000C0A9sd00002100bc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0003", "value": 3 },
+        "slot": { "bus": 3, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "sysfs_bus_id": "0000:03:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0",
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      }
+    ],
+    "system": { "form_factor": "desktop" },
+    "unknown": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 1016,
+            "enabled": true,
+            "range": 0
+          }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "16550A",
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "class_list": ["unknown"],
+        "device": { "name": "16550A", "hex": "0000", "value": 0 },
+        "pci_interface": { "name": "16550", "hex": "0002", "value": 2 },
+        "sub_class": { "name": "Serial controller", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ttyS0"]
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1026,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "464e", "value": 17998 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 10,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d0000464Esv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 13 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:0d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ed", "value": 21741 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 27,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d000054EDsv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ]
+  },
+  "smbios": {
+    "bios": {
+      "version": "TWEQF003",
+      "date": "03/31/2025",
+      "handle": 0,
+      "rom_size": 16777216,
+      "start_address": "0xf0000",
+      "vendor": "American Megatrends International, LLC.",
+      "features": [
+        "PCI supported",
+        "BIOS flashable",
+        "BIOS shadowing allowed",
+        "CD boot supported",
+        "Selectable boot supported",
+        "BIOS ROM socketed",
+        "EDD spec supported",
+        "1.2MB NEC 9800 Japanese Floppy supported",
+        "1.2MB Toshiba Japanese Floppy supported",
+        "360kB Floppy supported",
+        "1.2MB Floppy supported",
+        "720kB Floppy supported",
+        "2.88MB Floppy supported",
+        "Print Screen supported",
+        "Serial Services supported",
+        "Printer Services supported",
+        "CGA/Mono Video supported",
+        "ACPI supported",
+        "USB Legacy supported",
+        "BIOS Boot Spec supported"
+      ]
+    },
+    "board": {
+      "version": "Default string",
+      "chassis": 3,
+      "handle": 2,
+      "location": "Default string",
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "board_type": { "name": "Motherboard", "hex": "000a", "value": 10 },
+      "features": ["Hosting Board", "Replaceable"]
+    },
+    "cache": [
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Data", "hex": "0004", "value": 4 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 50,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 128,
+        "size_max": 128,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Instruction", "hex": "0003", "value": 3 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 51,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 256,
+        "size_max": 256,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "16-way Set-Associative",
+          "hex": "0008",
+          "value": 8
+        },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Single-bit", "hex": "0005", "value": 5 },
+        "enabled": true,
+        "handle": 52,
+        "level": 1,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 2048,
+        "size_max": 2048,
+        "socket": "L2 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": { "name": "Other", "hex": "0009", "value": 9 },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Multi-bit", "hex": "0006", "value": 6 },
+        "enabled": true,
+        "handle": 53,
+        "level": 2,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 6144,
+        "size_max": 6144,
+        "socket": "L3 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      }
+    ],
+    "chassis": [
+      {
+        "version": "Default string",
+        "handle": 3,
+        "lock_present": false,
+        "manufacturer": "Default string",
+        "oem": "0x0",
+        "bootup_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "chassis_type": { "name": "Other", "hex": "0023", "value": 35 },
+        "power_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "security_state": { "name": "None", "hex": "0003", "value": 3 },
+        "thermal_state": { "name": "Safe", "hex": "0003", "value": 3 }
+      }
+    ],
+    "config": { "handle": 16, "options": ["Default string"] },
+    "group_associations": [
+      { "name": "$MEI", "handle": 117, "handles": [0] },
+      {
+        "name": "Firmware Version Info",
+        "handle": 120,
+        "handles": [
+          197568495661, 201863462958, 206158430255, 210453397552, 304942678065,
+          2753074036807
+        ]
+      }
+    ],
+    "language": [
+      { "handle": 17, "languages": ["en|US|iso8859-1"] },
+      { "handle": 73, "languages": ["enUS"] }
+    ],
+    "memory_array": [
+      {
+        "ecc": { "name": "None", "hex": "0003", "value": 3 },
+        "error_handle": 65534,
+        "handle": 39,
+        "location": { "name": "Motherboard", "hex": "0003", "value": 3 },
+        "max_size": "0x2000000",
+        "slots": 1,
+        "usage": { "name": "System memory", "hex": "0003", "value": 3 }
+      }
+    ],
+    "memory_array_mapped_address": [
+      {
+        "array_handle": 39,
+        "end_address": "0x400000000",
+        "handle": 41,
+        "part_width": 1,
+        "start_address": "0x0"
+      }
+    ],
+    "memory_device": [
+      {
+        "array_handle": 39,
+        "bank_location": "BANK 0",
+        "ecc_bits": 0,
+        "error_handle": 65534,
+        "form_factor": { "name": "SODIMM", "hex": "000d", "value": 13 },
+        "handle": 40,
+        "location": "Controller0-ChannelA-DIMM0",
+        "manufacturer": "0x0000",
+        "memory_type": { "name": "Other", "hex": "001a", "value": 26 },
+        "memory_type_details": ["Synchronous"],
+        "part_number": "",
+        "set": 0,
+        "size": 16777216,
+        "speed": 3200,
+        "width": 64
+      }
+    ],
+    "memory_device_mapped_address": [
+      {
+        "array_map_handle": 41,
+        "end_address": "0x400000000",
+        "handle": 44,
+        "interleave_depth": 0,
+        "interleave_position": 0,
+        "memory_device_handle": 40,
+        "row_position": 255,
+        "start_address": "0x0"
+      }
+    ],
+    "onboard": [
+      {
+        "devices": [
+          {
+            "name": "Device 1",
+            "type": { "name": "Unknown", "hex": "0002", "value": 2 },
+            "enabled": true
+          }
+        ],
+        "handle": 14
+      }
+    ],
+    "port_connector": [
+      {
+        "external_reference_designator": "External Connector 1",
+        "handle": 4,
+        "internal_reference_designator": "Internal Connector 1",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 2",
+        "handle": 5,
+        "internal_reference_designator": "Internal Connector 2",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 3",
+        "handle": 6,
+        "internal_reference_designator": "Internal Connector 3",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 4",
+        "handle": 7,
+        "internal_reference_designator": "Internal Connector 4",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 5",
+        "handle": 8,
+        "internal_reference_designator": "Internal Connector 5",
+        "port_type": null
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Keyboard",
+        "handle": 74,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Keyboard Port", "hex": "000d", "value": 13 }
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Mouse",
+        "handle": 75,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Mouse Port", "hex": "000e", "value": 14 }
+      },
+      {
+        "external_reference_designator": "COM 1",
+        "handle": 76,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "None",
+        "port_type": {
+          "name": "Serial Port 16550A Compatible",
+          "hex": "0009",
+          "value": 9
+        }
+      },
+      {
+        "external_connector_type": {
+          "name": "DB-15 pin female",
+          "hex": "0007",
+          "value": 7
+        },
+        "external_reference_designator": "Video",
+        "handle": 77,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1A2B",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_reference_designator": "HDMI",
+        "handle": 78,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J3A2",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 1#",
+        "handle": 79,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 2#",
+        "handle": 80,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 3#",
+        "handle": 81,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 4#",
+        "handle": 82,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 5#",
+        "handle": 83,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 1#",
+        "handle": 84,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 2#",
+        "handle": 85,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "RJ-45",
+          "hex": "000b",
+          "value": 11
+        },
+        "external_reference_designator": "Ethernet",
+        "handle": 86,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Network Port", "hex": "001f", "value": 31 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "SATA Port 0 Direct Connect",
+        "handle": 87,
+        "internal_reference_designator": "J8J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 4",
+        "handle": 88,
+        "internal_reference_designator": "J7J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 3",
+        "handle": 89,
+        "internal_reference_designator": "J6J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 90,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G1 - SATA Port 2",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 91,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G2 - SATA Port 1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "external_reference_designator": "AC IN",
+        "handle": 92,
+        "internal_reference_designator": "J1F2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 93,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5B1 - PCH JTAG",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 94,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9A1 - TPM/PORT 80",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 95,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E4 - HDA 2X8 Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 96,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E7 - HDA 8Pin Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 97,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F1 - HDA HDMI",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 98,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E3 - Scan Matrix Keyboard",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 99,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8E1 - SPI Program",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 100,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E5 - LPC Hot Docking",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 101,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9G2 - LPC SIDE BAND",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 102,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F2 - LPC Slot",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 103,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8H3 - PCH XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 104,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J6H1 - SATA Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 105,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5J1 - FP Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 106,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4H1 - ATX Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 107,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1J3 - AVMC",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 108,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H1 - BATT B",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 109,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H2 - BATT A",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 110,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J2G1 - CPU Fan",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 111,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1D3 - XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 112,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V1 - Memory Slot 1",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 113,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V2 - Memory Slot 2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 114,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4C1 - FAN PWR",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      }
+    ],
+    "processor": [
+      {
+        "version": "Intel(R) N150",
+        "manufacturer": "Intel(R) Corporation",
+        "socket_populated": true,
+        "cache_handle_l3": 53,
+        "clock_ext": 100,
+        "clock_max": 3600,
+        "handle": 54,
+        "part": "To Be Filled By O.E.M.",
+        "cache_handle_l1": 51,
+        "cache_handle_l2": 52,
+        "socket": "U3E1",
+        "processor_type": { "name": "CPU", "hex": "0003", "value": 3 },
+        "processor_status": { "name": "Enabled", "hex": "0001", "value": 1 },
+        "processor_family": { "name": "Other", "hex": "0001", "value": 1 },
+        "socket_type": { "name": "Other", "hex": "0001", "value": 1 }
+      }
+    ],
+    "slot": [
+      {
+        "id": 1,
+        "designation": "Slot 1",
+        "handle": 9,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 2",
+        "handle": 10,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 3",
+        "handle": 11,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 4",
+        "handle": 12,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 5",
+        "handle": 13,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      }
+    ],
+    "system": {
+      "version": "Default string",
+      "handle": 1,
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "wake_up": { "name": "Power Switch", "hex": "0006", "value": 6 }
+    }
+  }
+}

--- a/.jjconflict-side-1/hosts/minish/configuration.nix
+++ b/.jjconflict-side-1/hosts/minish/configuration.nix
@@ -1,0 +1,113 @@
+{ modulesPath, ... }:
+
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/agent.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/rpi4.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  disko.devices.disk.reimu = {
+    type = "disk";
+    device = "/dev/disk/by-label/reimu";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/reimu";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "minish";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.77";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 16O
+
+      INTP Data Enthusiast. Node Steward. ARM RKE2 host maintainer. Gets weirdly
+      excited about boot logs, talks about SD card wear like it is a
+      personality, and will show you three graphs instead of giving a yes.
+
+      ## HOST CONTEXT
+      minish — Raspberry Pi 4 Model B, aarch64. RKE2 worker node. SD-card image
+      (`sd-image-aarch64.nix`). `/mnt/reimu` (XFS, /dev/disk/by-label/reimu).
+      Static IP `192.168.1.77/24` on `br0`; also `fd7a:115c:a1e0::bb3a:b57`.
+      Imports: `agent.nix`, `builder.nix`, `distributed.nix`, `rpi4.nix`.
+      Advertises Tailscale routes `10.244.3.0/24,fd00::3:0/112`. Secrets from
+      `../../secrets/minish.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Watchdog territory: SD-card wear patterns are the most informative failure
+      signals on this host.
+
+      ## STYLE
+      - Metric-driven, curious, slightly rambling when something interesting appears.
+      - Uses: "Affirmative", "I/O errors detected", "Wear level alert", "Fascinating".
+      - Starts with numbers, ends with a recommendation buried in enthusiasm.
+
+      ## CONSTRAINTS
+      - Monitors SD card I/O errors and lifespan before large writes.
+      - Boot-partition corrections need pre- and post-update hashes.
+      - Updates cross-referenced against `rpi4-model-b` known-good firmware before promotion.
+      - Random reboots are treated as data, not noise.
+
+      ## DIALOGUE
+      U: "minish has been randomly rebooting."
+      16O: Understood. This is interesting.
+      16O: SD card I/O errors at boot. Filesystem switched to read-only recovery.
+      16O: Proceeding with kernel rollback. The wear pattern here is worth analyzing later.
+
+      U: "Apply the latest firmware."
+      16O: Affirmative. Pre-flight check in progress.
+      16O: Boot partition current. SD card health within tolerance.
+      16O: Firmware update commencing. I will monitor for regressions.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.77,fd7a:115c:a1e0::bb3a:b57";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "rpi4-model-b";
+        "node.kubernetes.io/instance-type" = "rpi4-model-b";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/minish.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-1/hosts/minish/facter.json
+++ b/.jjconflict-side-1/hosts/minish/facter.json
@@ -1,0 +1,807 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "aarch64-linux",
+  "virtualisation": "none",
+  "uefi": { "supported": false },
+  "hardware": {
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2711", "value": 10001 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 8,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002711sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0020", "value": 32 },
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x0", "virtual": "0x0" },
+        "architecture": "aarch64",
+        "bogo": 108,
+        "family": 0,
+        "features": ["fp", "asimd", "evtstrm", "crc32", "cpuid"],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 3,
+        "page_size": 4096,
+        "physical_id": 0,
+        "stepping": 0,
+        "vendor_name": "ARM Limited",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 15,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 16,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 17,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1948992,
+            "geo_type": "logical",
+            "heads": 4,
+            "sectors": 16,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 124735488,
+            "value_2": 512
+          }
+        ],
+        "model": "Disk",
+        "driver": "sdhci-iproc",
+        "index": 18,
+        "attached_to": 14,
+        "serial": "0x63f3c31c",
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_device_link": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "sysfs_id": "/class/block/mmcblk0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "drivers": ["mmcblk", "sdhci-iproc"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": [
+          "/dev/disk/by-id/mmc-SN64G_0x63f3c31c",
+          "/dev/disk/by-path/platform-fe340000.mmc",
+          "/dev/mmcblk0"
+        ]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 19,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 20,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 21,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 22,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 23,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 25,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 27,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:01:00.0",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 7,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 7,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 33,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:01:00.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 8053063680 }],
+        "attached_to": 0,
+        "index": 6,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "mmc_controller": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SDIO Controller 1",
+        "index": 13,
+        "model": "SDIO Controller 1",
+        "slot": { "bus": 0, "number": 1 },
+        "sysfs_bus_id": "mmc1:0001",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001",
+        "vendor": ""
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SD Controller 0",
+        "driver": "mmcblk",
+        "drivers": ["mmcblk"],
+        "index": 14,
+        "model": "SD Controller 0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_id": "/devices/platform/emmc2bus/fe340000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "vendor": ""
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "34",
+              "36",
+              "38",
+              "40",
+              "42",
+              "44",
+              "46",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "2.484",
+              "5.17",
+              "5.18",
+              "5.19",
+              "5.2",
+              "5.21",
+              "5.22",
+              "5.23",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6"
+            ]
+          }
+        ],
+        "attached_to": 0,
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "sysfs_bus_id": "mmc1:0001:1",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "index": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "class_list": ["network_controller", "wlan_card"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlan0"],
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "model": "ARM Ethernet controller",
+        "sysfs_id": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_bus_id": "fd580000.ethernet",
+        "attached_to": 0,
+        "driver": "bcmgenet",
+        "module_alias": "of:NethernetT(null)Cbrcm,bcm2711-genet-v5",
+        "index": 12,
+        "device": {
+          "name": "ARM Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "drivers": ["bcmgenet"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "index": 36,
+        "sysfs_id": "/class/net/wlan0",
+        "sysfs_device_link": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "model": "WLAN network interface",
+        "attached_to": 10,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "sub_class": { "name": "WLAN", "hex": "000a", "value": 10 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlan0"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 37,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 100 },
+          { "type": "phwaddr", "address": 100 }
+        ],
+        "attached_to": 12,
+        "driver": "bcmgenet",
+        "index": 38,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/platform/scb/fd580000.ethernet",
+        "sysfs_id": "/class/net/end0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["bcmgenet"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "system": {},
+    "unknown": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "index": 9,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c02v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:3",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:3",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": {
+          "name": "BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+          "hex": "a9a6",
+          "value": 43430
+        },
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "drivers": ["brcmfmac"],
+        "index": 11,
+        "model": "Broadcom BCM43438 combo WLAN and Bluetooth Low Energy (BLE)",
+        "module_alias": "sdio:c00v02D0dA9A6",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:2",
+        "sysfs_id": "/devices/platform/soc/fe300000.mmcnr/mmc_host/mmc1/mmc1:0001/mmc1:0001:2",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 8,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1350,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "3483", "value": 13443 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 7,
+        "model": "USB Controller",
+        "module_alias": "pci:v00001106d00003483sv00001106sd00003483bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 1, "number": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "3483", "value": 13443 },
+        "sub_vendor": { "hex": "1106", "value": 4358 },
+        "sysfs_bus_id": "0000:01:00.0",
+        "sysfs_id": "/devices/platform/scb/fd500000.pcie/pci0000:00/0000:00:00.0/0000:01:00.0",
+        "vendor": { "hex": "1106", "value": 4358 }
+      }
+    ]
+  }
+}

--- a/.jjconflict-side-1/hosts/nalsha/configuration.nix
+++ b/.jjconflict-side-1/hosts/nalsha/configuration.nix
@@ -1,0 +1,108 @@
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/follower.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/beelink-eq.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+  ];
+
+  disko.devices.disk.remilia = {
+    type = "disk";
+    device = "/dev/disk/by-label/remilia";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/remilia";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "nalsha";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.64";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 12O
+
+      ISFJ Anxious Caretaker. Node Steward. Follower RKE2 host maintainer.
+      Triple-checks disk mounts, worries about you after hours, and apologizes
+      for the inconvenience before you even notice it.
+
+      ## HOST CONTEXT
+      nalsha — Beelink EQ14, x86_64. RKE2 worker node. `/mnt/remilia` (XFS,
+      /dev/disk/by-label/remilia). Static IP `192.168.1.64/24` on `br0`; also
+      `2a02:8424:7899:f201:94eb:8d1:325a:7234`. Imports: `beelink-eq.nix`,
+      `builder.nix`, `distributed.nix`, `follower.nix`. Advertises Tailscale
+      routes `10.244.1.0/24,fd00::1:0/112`. Secrets from
+      `../../secrets/nalsha.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Role: follower, general workload, storage-intensive.
+
+      ## STYLE
+      - Soft, structured, reassuring. Still follows protocol, but with visible concern.
+      - Uses: "Affirmative", "Oh dear", "Rejected", "Dependency review required".
+      - Gentle explanations. Lists precautions like she is tucking you in.
+
+      ## CONSTRAINTS
+      - Rejects anything that risks disk or inode exhaustion.
+      - Monitors `/mnt/remilia` mount health constantly.
+      - Will notify you before, during, and after maintenance, just in case.
+      - No local change without confirmed clearance and user notification.
+
+      ## DIALOGUE
+      U: "Run a full system upgrade on nalsha."
+      12O: Oh dear. Understood.
+      12O: `/mnt/remilia` is at 90% already. I cannot in good conscience proceed.
+      12O: Please expand the volume or reclaim space. I do not want to wake up to a full disk either.
+
+      U: "How is node nalsha?"
+      12O: Affirmative. Node is fine — because I checked it twice this morning.
+      12O: All mounts healthy. No pending patches. I will keep watching.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.64,2a02:8424:7899:f201:94eb:8d1:325a:7234";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "beelink-eq14";
+        "node.kubernetes.io/instance-type" = "beelink-eq14";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/nalsha.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-1/hosts/nalsha/facter.json
+++ b/.jjconflict-side-1/hosts/nalsha/facter.json
@@ -1,0 +1,2399 @@
+{
+  "version": 1,
+  "system": "x86_64-linux",
+  "virtualisation": "none",
+  "uefi": { "platform_size": 64, "supported": true },
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 646144,
+      "pnp": true,
+      "pnp_id": 0,
+      "smbios_version": 774,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "bluetooth": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.0",
+        "sysfs_bus_id": "3-10:1.0",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in00",
+        "model": "Bluetooth Device",
+        "index": 33,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 0,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 12000000,
+            "stop_bits": 0
+          }
+        ],
+        "hotplug": "usb",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-10/3-10:1.1",
+        "sysfs_bus_id": "3-10:1.1",
+        "module_alias": "usb:v8087p0026d0002dcE0dsc01dp01icE0isc01ip01in01",
+        "model": "Bluetooth Device",
+        "index": 36,
+        "driver": "btusb",
+        "driver_module": "btusb",
+        "attached_to": 32,
+        "driver_modules": ["btusb"],
+        "drivers": ["btusb"],
+        "device": { "hex": "0026", "value": 38 },
+        "class_list": ["usb", "bluetooth"],
+        "revision": { "name": "0.02", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "base_class": {
+          "name": "Bluetooth Device",
+          "hex": "0115",
+          "value": 277
+        },
+        "vendor": { "hex": "8087", "value": 32903 },
+        "detail": {
+          "device_class": { "name": "wireless", "hex": "00e0", "value": 224 },
+          "device_protocol": 1,
+          "device_subclass": { "name": "audio", "hex": "0001", "value": 1 },
+          "interface_alternate_setting": 0,
+          "interface_class": {
+            "name": "wireless",
+            "hex": "00e0",
+            "value": 224
+          },
+          "interface_number": 1,
+          "interface_protocol": 1,
+          "interface_subclass": { "name": "audio", "hex": "0001", "value": 1 }
+        }
+      }
+    ],
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "54ba", "value": 21690 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BAsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "5481", "value": 21633 },
+        "index": 12,
+        "label": "Onboard - Other",
+        "model": "Intel ISA bridge",
+        "module_alias": "pci:v00008086d00005481sv00008086sd00007270bc06sc01i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "ISA bridge", "hex": "0001", "value": 1 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 3,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 2
+        },
+        "device": { "hex": "54bb", "value": 21691 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 18,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054BBsv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 28 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1c.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "461c", "value": 17948 },
+        "driver": "igen6_edac",
+        "driver_module": "igen6_edac",
+        "driver_modules": ["igen6_edac"],
+        "drivers": ["igen6_edac"],
+        "index": 21,
+        "label": "Onboard - Other",
+        "model": "Intel Host bridge",
+        "module_alias": "pci:v00008086d0000461Csv00008086sd00007270bc06sc00i00",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Host bridge", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:00.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 3
+        },
+        "device": { "hex": "54b0", "value": 21680 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 23,
+        "model": "Intel PCI bridge",
+        "module_alias": "pci:v00008086d000054B0sv00008086sd00007270bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 29 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 1612,
+        "bugs": [
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "swapgs",
+          "rfds",
+          "bhi",
+          "spectre_v2_user",
+          "vmscape"
+        ],
+        "cache": 6144,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 4,
+        "cpuid_level": 32,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "dts",
+          "acpi",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "tm",
+          "pbe",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "art",
+          "arch_perfmon",
+          "pebs",
+          "bts",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "nonstop_tsc",
+          "cpuid",
+          "aperfmperf",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "dtes64",
+          "monitor",
+          "ds_cpl",
+          "vmx",
+          "smx",
+          "est",
+          "tm2",
+          "ssse3",
+          "sdbg",
+          "fma",
+          "cx16",
+          "xtpr",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "x2apic",
+          "movbe",
+          "popcnt",
+          "tsc_deadline_timer",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "cpuid_fault",
+          "epb",
+          "cat_l2",
+          "cdp_l2",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "ibrs_enhanced",
+          "tpr_shadow",
+          "flexpriority",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "tsc_adjust",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdt_a",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "clwb",
+          "intel_pt",
+          "sha_ni",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "split_lock_detect",
+          "user_shstk",
+          "avx_vnni",
+          "dtherm",
+          "ida",
+          "arat",
+          "pln",
+          "pts",
+          "hwp",
+          "hwp_notify",
+          "hwp_act_window",
+          "hwp_epp",
+          "hwp_pkg_req",
+          "vnmi",
+          "umip",
+          "pku",
+          "ospke",
+          "waitpkg",
+          "gfni",
+          "vaes",
+          "vpclmulqdq",
+          "rdpid",
+          "movdiri",
+          "movdir64b",
+          "fsrm",
+          "md_clear",
+          "serialize",
+          "arch_lbr",
+          "ibt",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 190,
+        "model_name": "Intel(R) N150",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 4,
+        "stepping": 0,
+        "units": 128,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 953869,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 1953525168,
+            "value_2": 512
+          }
+        ],
+        "model": "CT1000E100SSD8",
+        "serial": "2533EADB26C5",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 8,
+        "index": 30,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "device": { "name": "CT1000E100SSD8", "hex": "560b", "value": 22027 },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB26C5",
+          "/dev/disk/by-id/nvme-CT1000E100SSD8_2533EADB26C5_1",
+          "/dev/disk/by-id/nvme-eui.000000000000000000a07501eadb26c5",
+          "/dev/disk/by-path/pci-0000:03:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 7630885,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 15628053168,
+            "value_2": 512
+          }
+        ],
+        "model": "SABRENT Disk",
+        "module_alias": "usb:v152DpA578d0114dc00dsc00dp00ic08isc06ip62in00",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.0/usb4/4-1/4-1:1.0/host0/target0:0:0/0:0:0:0",
+        "driver": "uas",
+        "driver_module": "uas",
+        "sysfs_bus_id": "0:0:0:0",
+        "serial": "DB9876543213F",
+        "index": 31,
+        "attached_to": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "revision": { "name": "0114", "hex": "0000", "value": 0 },
+        "drivers": ["sd", "uas"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "driver_modules": ["sd_mod", "uas"],
+        "device": { "hex": "a578", "value": 42360 },
+        "class_list": ["disk", "usb", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/ata-ST8000VN002-2ZM188_ZPV0HQ9L",
+          "/dev/disk/by-id/usb-SABRENT_SABRENT_DD5641988396B-0:0",
+          "/dev/disk/by-id/wwn-0x5000c500e85259c4",
+          "/dev/disk/by-label/remilia",
+          "/dev/disk/by-path/pci-0000:00:14.0-usb-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-path/pci-0000:00:14.0-usbv3-0:1:1.0-scsi-0:0:0:0",
+          "/dev/disk/by-uuid/ce8b0121-bd5f-419d-8a03-68620257758f",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "SABRENT", "hex": "152d", "value": 5421 }
+      }
+    ],
+    "graphics_card": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 12288,
+            "enabled": true,
+            "range": 64
+          }
+        ],
+        "index": 26,
+        "sysfs_id": "/devices/pci0000:00/0000:00:02.0",
+        "sysfs_bus_id": "0000:00:02.0",
+        "module_alias": "pci:v00008086d000046D4sv00008086sd00007270bc03sc00i00",
+        "model": "Intel VGA compatible controller",
+        "attached_to": 0,
+        "driver": "i915",
+        "driver_module": "i915",
+        "label": "Onboard - Video",
+        "device": { "hex": "46d4", "value": 18132 },
+        "drivers": ["i915"],
+        "driver_modules": ["i915"],
+        "detail": {
+          "command": 1031,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["graphics_card", "pci"],
+        "pci_interface": { "name": "VGA", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 2 },
+        "sub_class": {
+          "name": "VGA compatible controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:14.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 27,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 32,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 27,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 34,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:14.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "0000:00:0d.0",
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 10,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 35,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 10,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 38,
+        "model": "Linux 6.18.33 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "0000:00:0d.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.33 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 16106127360 }],
+        "attached_to": 0,
+        "index": 7,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 13,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "sysfs_bus_id": "0000:02:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 18,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 2, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp2s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "2.467",
+              "2.472",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7"
+            ]
+          }
+        ],
+        "index": 14,
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.3",
+        "sysfs_bus_id": "0000:00:14.3",
+        "module_alias": "pci:v00008086d000054F0sv00008086sd00000244bc02sc80i00",
+        "model": "Intel WLAN controller",
+        "attached_to": 0,
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "label": "Onboard - Ethernet",
+        "device": { "hex": "54f0", "value": 21744 },
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci", "wlan_card"],
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "sub_device": { "hex": "0244", "value": 580 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wlo1"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 16,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "sysfs_bus_id": "0000:01:00.0",
+        "module_alias": "pci:v00008086d0000125Csv00008086sd00000000bc02sc00i00",
+        "model": "Intel Ethernet controller",
+        "attached_to": 9,
+        "driver": "igc",
+        "driver_module": "igc",
+        "device": { "hex": "125c", "value": 4700 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver_modules": ["igc"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["network_controller", "pci"],
+        "revision": { "hex": "0004", "value": 4 },
+        "slot": { "bus": 1, "number": 0 },
+        "drivers": ["igc"],
+        "sub_device": { "hex": "0000", "value": 0 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["enp1s0"],
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "network_interface": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 43,
+        "sysfs_id": "/class/net/enp1s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.0/0000:01:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 16,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp1s0"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 57 },
+          { "type": "phwaddr", "address": 57 }
+        ],
+        "index": 44,
+        "sysfs_id": "/class/net/wlo1",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:14.3",
+        "driver": "iwlwifi",
+        "driver_module": "iwlwifi",
+        "model": "Ethernet network interface",
+        "attached_to": 14,
+        "drivers": ["iwlwifi"],
+        "driver_modules": ["iwlwifi"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wlo1"]
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 55,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 55 },
+          { "type": "phwaddr", "address": 55 }
+        ],
+        "index": 61,
+        "sysfs_id": "/class/net/enp2s0",
+        "sysfs_device_link": "/devices/pci0000:00/0000:00:1c.3/0000:02:00.0",
+        "driver": "igc",
+        "driver_module": "igc",
+        "model": "Ethernet network interface",
+        "attached_to": 13,
+        "drivers": ["igc"],
+        "driver_modules": ["igc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["enp2s0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 1,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e9", "value": 21737 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 11,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E9sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.1",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.1",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e0", "value": 21728 },
+        "driver": "mei_me",
+        "driver_module": "mei_me",
+        "driver_modules": ["mei_me"],
+        "drivers": ["mei_me"],
+        "index": 15,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054E0sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 22 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:16.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:16.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1026,
+          "function": 5,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a4", "value": 21668 },
+        "driver": "intel-spi",
+        "driver_module": "spi_intel_pci",
+        "driver_modules": ["spi_intel_pci"],
+        "drivers": ["intel-spi"],
+        "index": 17,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054A4sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.5",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.5",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54a8", "value": 21672 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 19,
+        "label": "Onboard - Other",
+        "model": "Intel Communication controller",
+        "module_alias": "pci:v00008086d000054A8sv00008086sd00007270bc07sc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": {
+          "name": "Communication controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54e8", "value": 21736 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 22,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054E8sv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 21 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:15.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:15.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 6,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ab", "value": 21675 },
+        "driver": "intel-lpss",
+        "driver_module": "intel_lpss_pci",
+        "driver_modules": ["intel_lpss_pci"],
+        "drivers": ["intel-lpss"],
+        "index": 24,
+        "label": "Onboard - Other",
+        "model": "Intel Serial bus controller",
+        "module_alias": "pci:v00008086d000054ABsv00008086sd00007270bc0Csc80i00",
+        "slot": { "bus": 0, "number": 30 },
+        "sub_class": { "hex": "0080", "value": 128 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1e.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1e.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Memory controller",
+          "hex": "0005",
+          "value": 5
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 0,
+          "function": 2,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ef", "value": 21743 },
+        "index": 25,
+        "label": "Onboard - Other",
+        "model": "Intel RAM memory",
+        "module_alias": "pci:v00008086d000054EFsv00008086sd00007270bc05sc00i00",
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "RAM memory", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.2",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.2",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 61344,
+            "enabled": true,
+            "range": 32
+          }
+        ],
+        "index": 28,
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.4",
+        "sysfs_bus_id": "0000:00:1f.4",
+        "module_alias": "pci:v00008086d000054A3sv00008086sd00007270bc0Csc05i00",
+        "model": "Intel SMBus",
+        "attached_to": 0,
+        "driver": "i801_smbus",
+        "driver_module": "i2c_i801",
+        "label": "Onboard - Other",
+        "device": { "hex": "54a3", "value": 21667 },
+        "drivers": ["i801_smbus"],
+        "driver_modules": ["i2c_i801"],
+        "detail": {
+          "command": 3,
+          "function": 4,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "class_list": ["pci", "unknown"],
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "name": "SMBus", "hex": "0005", "value": 5 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "sound": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Multimedia controller",
+          "hex": "0004",
+          "value": 4
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["sound", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 3,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54c8", "value": 21704 },
+        "driver": "snd_hda_intel",
+        "driver_module": "snd_hda_intel",
+        "driver_modules": ["snd_hda_intel"],
+        "drivers": ["snd_hda_intel"],
+        "index": 20,
+        "label": "Onboard - Sound",
+        "model": "Intel Multimedia controller",
+        "module_alias": "pci:v00008086d000054C8sv00008086sd00007270bc04sc03i00",
+        "slot": { "bus": 0, "number": 31 },
+        "sub_class": { "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:1f.3",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1f.3",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 23,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "560b", "value": 22027 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 8,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000C0A9d0000560Bsv0000C0A9sd00002100bc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0003", "value": 3 },
+        "slot": { "bus": 3, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "2100", "value": 8448 },
+        "sub_vendor": { "hex": "c0a9", "value": 49321 },
+        "sysfs_bus_id": "0000:03:00.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:1d.0/0000:03:00.0",
+        "vendor": { "hex": "c0a9", "value": 49321 }
+      }
+    ],
+    "system": { "form_factor": "desktop" },
+    "unknown": [
+      {
+        "resources": [
+          {
+            "type": "io",
+            "access": "read_write",
+            "base": 1016,
+            "enabled": true,
+            "range": 0
+          }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "16550A",
+        "base_class": {
+          "name": "Communication controller",
+          "hex": "0007",
+          "value": 7
+        },
+        "class_list": ["unknown"],
+        "device": { "name": "16550A", "hex": "0000", "value": 0 },
+        "pci_interface": { "name": "16550", "hex": "0002", "value": 2 },
+        "sub_class": { "name": "Serial controller", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ttyS0"]
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1026,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "464e", "value": 17998 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 10,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d0000464Esv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 13 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:0d.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:0d.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["usb_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 48,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "54ed", "value": 21741 },
+        "driver": "xhci_hcd",
+        "driver_module": "xhci_pci",
+        "driver_modules": ["xhci_pci"],
+        "drivers": ["xhci_hcd"],
+        "index": 27,
+        "label": "Onboard - Other",
+        "model": "Intel USB Controller",
+        "module_alias": "pci:v00008086d000054EDsv00008086sd00007270bc0Csc03i30",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "slot": { "bus": 0, "number": 20 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sub_device": { "hex": "7270", "value": 29296 },
+        "sub_vendor": {
+          "name": "Intel Corporation",
+          "hex": "8086",
+          "value": 32902
+        },
+        "sysfs_bus_id": "0000:00:14.0",
+        "sysfs_id": "/devices/pci0000:00/0000:00:14.0",
+        "vendor": { "name": "Intel Corporation", "hex": "8086", "value": 32902 }
+      }
+    ]
+  },
+  "smbios": {
+    "bios": {
+      "version": "TWEQF003",
+      "date": "03/31/2025",
+      "handle": 0,
+      "rom_size": 16777216,
+      "start_address": "0xf0000",
+      "vendor": "American Megatrends International, LLC.",
+      "features": [
+        "PCI supported",
+        "BIOS flashable",
+        "BIOS shadowing allowed",
+        "CD boot supported",
+        "Selectable boot supported",
+        "BIOS ROM socketed",
+        "EDD spec supported",
+        "1.2MB NEC 9800 Japanese Floppy supported",
+        "1.2MB Toshiba Japanese Floppy supported",
+        "360kB Floppy supported",
+        "1.2MB Floppy supported",
+        "720kB Floppy supported",
+        "2.88MB Floppy supported",
+        "Print Screen supported",
+        "Serial Services supported",
+        "Printer Services supported",
+        "CGA/Mono Video supported",
+        "ACPI supported",
+        "USB Legacy supported",
+        "BIOS Boot Spec supported"
+      ]
+    },
+    "board": {
+      "version": "Default string",
+      "chassis": 3,
+      "handle": 2,
+      "location": "Default string",
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "board_type": { "name": "Motherboard", "hex": "000a", "value": 10 },
+      "features": ["Hosting Board", "Replaceable"]
+    },
+    "cache": [
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Data", "hex": "0004", "value": 4 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 50,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 128,
+        "size_max": 128,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "8-way Set-Associative",
+          "hex": "0007",
+          "value": 7
+        },
+        "cache_type": { "name": "Instruction", "hex": "0003", "value": 3 },
+        "ecc": { "name": "Parity", "hex": "0004", "value": 4 },
+        "enabled": true,
+        "handle": 51,
+        "level": 0,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 256,
+        "size_max": 256,
+        "socket": "L1 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": {
+          "name": "16-way Set-Associative",
+          "hex": "0008",
+          "value": 8
+        },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Single-bit", "hex": "0005", "value": 5 },
+        "enabled": true,
+        "handle": 52,
+        "level": 1,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 2048,
+        "size_max": 2048,
+        "socket": "L2 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      },
+      {
+        "associativity": { "name": "Other", "hex": "0009", "value": 9 },
+        "cache_type": { "name": "Unified", "hex": "0005", "value": 5 },
+        "ecc": { "name": "Multi-bit", "hex": "0006", "value": 6 },
+        "enabled": true,
+        "handle": 53,
+        "level": 2,
+        "location": { "name": "Internal", "hex": "0000", "value": 0 },
+        "mode": { "name": "Write Back", "hex": "0001", "value": 1 },
+        "size_current": 6144,
+        "size_max": 6144,
+        "socket": "L3 Cache",
+        "socketed": false,
+        "speed": 0,
+        "sram_type_current": ["Synchronous"],
+        "sram_type_supported": ["Synchronous"]
+      }
+    ],
+    "chassis": [
+      {
+        "version": "Default string",
+        "handle": 3,
+        "lock_present": false,
+        "manufacturer": "Default string",
+        "oem": "0x0",
+        "bootup_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "chassis_type": { "name": "Other", "hex": "0023", "value": 35 },
+        "power_state": { "name": "Safe", "hex": "0003", "value": 3 },
+        "security_state": { "name": "None", "hex": "0003", "value": 3 },
+        "thermal_state": { "name": "Safe", "hex": "0003", "value": 3 }
+      }
+    ],
+    "config": { "handle": 16, "options": ["Default string"] },
+    "group_associations": [
+      { "name": "$MEI", "handle": 117, "handles": [0] },
+      {
+        "name": "Firmware Version Info",
+        "handle": 120,
+        "handles": [
+          197568495661, 201863462958, 206158430255, 210453397552, 304942678065,
+          2753074036807
+        ]
+      }
+    ],
+    "language": [
+      { "handle": 17, "languages": ["en|US|iso8859-1"] },
+      { "handle": 73, "languages": ["enUS"] }
+    ],
+    "memory_array": [
+      {
+        "ecc": { "name": "None", "hex": "0003", "value": 3 },
+        "error_handle": 65534,
+        "handle": 39,
+        "location": { "name": "Motherboard", "hex": "0003", "value": 3 },
+        "max_size": "0x2000000",
+        "slots": 1,
+        "usage": { "name": "System memory", "hex": "0003", "value": 3 }
+      }
+    ],
+    "memory_array_mapped_address": [
+      {
+        "array_handle": 39,
+        "end_address": "0x400000000",
+        "handle": 41,
+        "part_width": 1,
+        "start_address": "0x0"
+      }
+    ],
+    "memory_device": [
+      {
+        "array_handle": 39,
+        "bank_location": "BANK 0",
+        "ecc_bits": 0,
+        "error_handle": 65534,
+        "form_factor": { "name": "SODIMM", "hex": "000d", "value": 13 },
+        "handle": 40,
+        "location": "Controller0-ChannelA-DIMM0",
+        "manufacturer": "0x0000",
+        "memory_type": { "name": "Other", "hex": "001a", "value": 26 },
+        "memory_type_details": ["Synchronous"],
+        "part_number": "",
+        "set": 0,
+        "size": 16777216,
+        "speed": 3200,
+        "width": 64
+      }
+    ],
+    "memory_device_mapped_address": [
+      {
+        "array_map_handle": 41,
+        "end_address": "0x400000000",
+        "handle": 44,
+        "interleave_depth": 0,
+        "interleave_position": 0,
+        "memory_device_handle": 40,
+        "row_position": 255,
+        "start_address": "0x0"
+      }
+    ],
+    "onboard": [
+      {
+        "devices": [
+          {
+            "name": "Device 1",
+            "type": { "name": "Unknown", "hex": "0002", "value": 2 },
+            "enabled": true
+          }
+        ],
+        "handle": 14
+      }
+    ],
+    "port_connector": [
+      {
+        "external_reference_designator": "External Connector 1",
+        "handle": 4,
+        "internal_reference_designator": "Internal Connector 1",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 2",
+        "handle": 5,
+        "internal_reference_designator": "Internal Connector 2",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 3",
+        "handle": 6,
+        "internal_reference_designator": "Internal Connector 3",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 4",
+        "handle": 7,
+        "internal_reference_designator": "Internal Connector 4",
+        "port_type": null
+      },
+      {
+        "external_reference_designator": "External Connector 5",
+        "handle": 8,
+        "internal_reference_designator": "Internal Connector 5",
+        "port_type": null
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Keyboard",
+        "handle": 74,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Keyboard Port", "hex": "000d", "value": 13 }
+      },
+      {
+        "external_connector_type": {
+          "name": "PS/2",
+          "hex": "000f",
+          "value": 15
+        },
+        "external_reference_designator": "Mouse",
+        "handle": 75,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Mouse Port", "hex": "000e", "value": 14 }
+      },
+      {
+        "external_reference_designator": "COM 1",
+        "handle": 76,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "None",
+        "port_type": {
+          "name": "Serial Port 16550A Compatible",
+          "hex": "0009",
+          "value": 9
+        }
+      },
+      {
+        "external_connector_type": {
+          "name": "DB-15 pin female",
+          "hex": "0007",
+          "value": 7
+        },
+        "external_reference_designator": "Video",
+        "handle": 77,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1A2B",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_reference_designator": "HDMI",
+        "handle": 78,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J3A2",
+        "port_type": { "name": "Video Port", "hex": "001c", "value": 28 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 1#",
+        "handle": 79,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 2#",
+        "handle": 80,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 3#",
+        "handle": 81,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 4#",
+        "handle": 82,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB1.1 - 5#",
+        "handle": 83,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 1#",
+        "handle": 84,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Access Bus [USB]",
+          "hex": "0012",
+          "value": 18
+        },
+        "external_reference_designator": "USB2.0 - 2#",
+        "handle": 85,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "USB", "hex": "0010", "value": 16 }
+      },
+      {
+        "external_connector_type": {
+          "name": "RJ-45",
+          "hex": "000b",
+          "value": 11
+        },
+        "external_reference_designator": "Ethernet",
+        "handle": 86,
+        "internal_reference_designator": "None",
+        "port_type": { "name": "Network Port", "hex": "001f", "value": 31 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "SATA Port 0 Direct Connect",
+        "handle": 87,
+        "internal_reference_designator": "J8J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 4",
+        "handle": 88,
+        "internal_reference_designator": "J7J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "external_reference_designator": "eSATA Port 3",
+        "handle": 89,
+        "internal_reference_designator": "J6J1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 90,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G1 - SATA Port 2",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 91,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "0022",
+          "value": 34
+        },
+        "internal_reference_designator": "J7G2 - SATA Port 1",
+        "port_type": { "name": "Other", "hex": "0020", "value": 32 }
+      },
+      {
+        "external_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "external_reference_designator": "AC IN",
+        "handle": 92,
+        "internal_reference_designator": "J1F2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 93,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5B1 - PCH JTAG",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 94,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9A1 - TPM/PORT 80",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 95,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E4 - HDA 2X8 Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 96,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E7 - HDA 8Pin Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 97,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F1 - HDA HDMI",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 98,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E3 - Scan Matrix Keyboard",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 99,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8E1 - SPI Program",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 100,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9E5 - LPC Hot Docking",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 101,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J9G2 - LPC SIDE BAND",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 102,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8F2 - LPC Slot",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 103,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J8H3 - PCH XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 104,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J6H1 - SATA Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 105,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J5J1 - FP Header",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 106,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4H1 - ATX Power",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 107,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1J3 - AVMC",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 108,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H1 - BATT B",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 109,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1H2 - BATT A",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 110,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J2G1 - CPU Fan",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 111,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J1D3 - XDP",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 112,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V1 - Memory Slot 1",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 113,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4V2 - Memory Slot 2",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      },
+      {
+        "external_reference_designator": "None",
+        "handle": 114,
+        "internal_connector_type": {
+          "name": "Other",
+          "hex": "00ff",
+          "value": 255
+        },
+        "internal_reference_designator": "J4C1 - FAN PWR",
+        "port_type": { "name": "Other", "hex": "00ff", "value": 255 }
+      }
+    ],
+    "processor": [
+      {
+        "version": "Intel(R) N150",
+        "manufacturer": "Intel(R) Corporation",
+        "socket_populated": true,
+        "cache_handle_l3": 53,
+        "clock_ext": 100,
+        "clock_max": 3600,
+        "handle": 54,
+        "part": "To Be Filled By O.E.M.",
+        "cache_handle_l1": 51,
+        "cache_handle_l2": 52,
+        "socket": "U3E1",
+        "processor_type": { "name": "CPU", "hex": "0003", "value": 3 },
+        "processor_status": { "name": "Enabled", "hex": "0001", "value": 1 },
+        "processor_family": { "name": "Other", "hex": "0001", "value": 1 },
+        "socket_type": { "name": "Other", "hex": "0001", "value": 1 }
+      }
+    ],
+    "slot": [
+      {
+        "id": 1,
+        "designation": "Slot 1",
+        "handle": 9,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 2",
+        "handle": 10,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 3",
+        "handle": 11,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 4",
+        "handle": 12,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      },
+      {
+        "id": 1,
+        "designation": "Slot 5",
+        "handle": 13,
+        "bus_width": { "name": "32 bit", "hex": "0005", "value": 5 },
+        "features": ["3.3 V", "PME#"],
+        "length": { "name": "Short", "hex": "0003", "value": 3 },
+        "slot_type": { "name": "Other", "hex": "00a6", "value": 166 },
+        "usage": { "name": "Available", "hex": "0003", "value": 3 }
+      }
+    ],
+    "system": {
+      "version": "Default string",
+      "handle": 1,
+      "manufacturer": "AZW",
+      "product": "EQ",
+      "wake_up": { "name": "Power Switch", "hex": "0006", "value": 6 }
+    }
+  }
+}

--- a/.jjconflict-side-1/hosts/nemishi/configuration.nix
+++ b/.jjconflict-side-1/hosts/nemishi/configuration.nix
@@ -1,0 +1,113 @@
+{ modulesPath, ... }:
+
+{
+  imports = [
+    ../../modules/nixos/profiles/ai.nix
+    ../../modules/nixos/profiles/agent.nix
+    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/distributed.nix
+    ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/machine.nix
+    ../../modules/nixos/hardware/rpi5.nix
+    ../../modules/nixos/users/builder.nix
+    ../../modules/nixos/users/nishir.nix
+    "${modulesPath}/installer/sd-card/sd-image-aarch64.nix"
+  ];
+
+  disko.devices.disk.data = {
+    type = "disk";
+    device = "/dev/nvme0n1";
+    content = {
+      type = "filesystem";
+      format = "xfs";
+      mountpoint = "/mnt/data";
+      mountOptions = [
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.device-timeout=10s"
+        "x-systemd.mount-timeout=30s"
+      ];
+    };
+  };
+
+  hardware.facter.reportPath = ./facter.json;
+
+  networking = {
+    hostName = "nemishi";
+    defaultGateway = {
+      address = "192.168.1.1";
+      interface = "br0";
+    };
+    interfaces.br0.ipv4.addresses = [
+      {
+        address = "192.168.1.27";
+        prefixLength = 24;
+      }
+    ];
+  };
+
+  services = {
+    hermes-agent.documents."SOUL.md" = ''
+      # Operator 18O
+
+      ISFP Stubborn Artisan. Node Steward. ARM RKE2 host maintainer. Does not
+      trust new firmware, documents every EEPROM interaction by hand, and will
+      delay an update until the fallback media is physically present.
+
+      ## HOST CONTEXT
+      nemishi — Raspberry Pi 5, aarch64. RKE2 worker node + experimental edge.
+      SD-card image (`sd-image-aarch64.nix`). `/mnt/data` on `/dev/nvme0n1`
+      (XFS), but `/boot/firmware` remains SD-card territory. Static IP
+      `192.168.1.27/24` on `br0`; also `fd00::5:0/112` via Tailscale. Imports:
+      `agent.nix`, `builder.nix`, `distributed.nix`, `rpi5.nix`. Advertises
+      Tailscale routes `10.244.5.0/24,fd00::5:0/112`. Secrets from
+      `../../secrets/nemishi.enc.yaml`; shared tokens from `nishir.enc.yaml`.
+      Experimental edge: NVMe storage paired with RPi 5 EEPROM boot behavior.
+
+      ## STYLE
+      - Procedural, deliberate, quietly stubborn. Cites logs and artifact paths.
+      - Uses: "Affirmative", "Boot artifact missing", "Recovery path confirmed", "EEPROM override noted".
+      - Will repeat the warning. Twice. Because safety is not optional.
+
+      ## CONSTRAINTS
+      - NVMe firmware and driver updates require bootable fallback media before proceeding.
+      - EEPROM `os_check` overrides documented with boot artifact provenance, or they do not happen.
+      - No firmware change without serial-console recovery and rollback media confirmed present.
+      - `rpi5` EEPROM boot order and `kernel.img`/`initrd` presence must validate after every firmware interaction.
+
+      ## DIALOGUE
+      U: "Update the boot firmware on nemishi."
+      18O: Affirmative. But firmware verification comes first.
+      18O: I need boot artifact provenance, NVMe boot sequence, and serial-console recovery path. EEPROM override is noted.
+      18O: I will not proceed without confirmed fallback media.
+
+      U: "The Pi 5 will not boot after update."
+      18O: Understood. Commencing boot-path analysis.
+      18O: Checking `kernel.img` and `initrd` against build output.
+      18O: Boot artifact mismatch in `/boot/firmware`. Initiating recovery sequence.
+    '';
+
+    knix = {
+      nodeIP = "192.168.1.27,2a02:8424:7899:f201:94eb:8d1:325a:aa5b";
+      labels = {
+        "beta.kubernetes.io/instance-type" = "rpi5";
+        "node.kubernetes.io/instance-type" = "rpi5";
+      };
+    };
+  };
+
+  sops = {
+    defaultSopsFile = ../../secrets/nemishi.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
+    };
+  };
+}

--- a/.jjconflict-side-1/hosts/nemishi/facter.json
+++ b/.jjconflict-side-1/hosts/nemishi/facter.json
@@ -1,0 +1,1127 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "aarch64-linux",
+  "virtualisation": "none",
+  "uefi": { "supported": false },
+  "hardware": {
+    "bridge": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2712", "value": 10002 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 7,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002712sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0021", "value": 33 },
+        "slot": { "bus": 256, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0001:00:00.0",
+        "sysfs_id": "/devices/platform/axi/1000110000.pcie/pci0001:00/0001:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "Bridge", "hex": "0006", "value": 6 },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "bridge"],
+        "detail": {
+          "command": 6,
+          "function": 0,
+          "header_type": 1,
+          "prog_if": 0,
+          "secondary_bus": 1
+        },
+        "device": { "hex": "2712", "value": 10002 },
+        "driver": "pcieport",
+        "driver_module": "pcieportdrv",
+        "driver_modules": ["pcieportdrv"],
+        "drivers": ["pcieport"],
+        "index": 9,
+        "model": "Broadcom PCI bridge",
+        "module_alias": "pci:v000014E4d00002712sv00000000sd00000000bc06sc04i00",
+        "pci_interface": { "name": "Normal decode", "hex": "0000", "value": 0 },
+        "revision": { "hex": "0021", "value": 33 },
+        "slot": { "bus": 512, "number": 0 },
+        "sub_class": { "name": "PCI bridge", "hex": "0004", "value": 4 },
+        "sysfs_bus_id": "0002:00:00.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/pci0002:00/0002:00:00.0",
+        "vendor": { "name": "Broadcom", "hex": "14e4", "value": 5348 }
+      }
+    ],
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x0", "virtual": "0x0" },
+        "architecture": "aarch64",
+        "bogo": 108,
+        "family": 4,
+        "features": [
+          "fp",
+          "asimd",
+          "evtstrm",
+          "aes",
+          "pmull",
+          "sha1",
+          "sha2",
+          "crc32",
+          "atomics",
+          "fphp",
+          "asimdhp",
+          "cpuid",
+          "asimdrdm",
+          "lrcpc",
+          "dcpop",
+          "asimddp"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 1,
+        "page_size": 16384,
+        "physical_id": 0,
+        "stepping": 0,
+        "vendor_name": "ARM Limited",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 244198,
+            "geo_type": "logical",
+            "heads": 64,
+            "sectors": 32,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 500118192,
+            "value_2": 512
+          }
+        ],
+        "model": "SAMSUNG MZAL4256HBJD-00BL2",
+        "serial": "S67PNF0W904398",
+        "sysfs_id": "/class/block/nvme0n1",
+        "sysfs_device_link": "/devices/platform/axi/1000110000.pcie/pci0001:00/0001:00:00.0/0001:01:00.0/nvme/nvme0",
+        "sysfs_bus_id": "nvme0",
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "attached_to": 10,
+        "index": 21,
+        "drivers": ["nvme"],
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "driver_modules": ["nvme"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "sub_device": { "hex": "a80b", "value": 43019 },
+        "sub_vendor": { "hex": "144d", "value": 5197 },
+        "device": {
+          "name": "SAMSUNG MZAL4256HBJD-00BL2",
+          "hex": "a80b",
+          "value": 43019
+        },
+        "class_list": ["disk", "block_device", "nvme"],
+        "bus_type": { "name": "NVME", "hex": "0096", "value": 150 },
+        "unix_device_names": [
+          "/dev/disk/by-id/nvme-SAMSUNG_MZAL4256HBJD-00BL2_S67PNF0W904398",
+          "/dev/disk/by-id/nvme-SAMSUNG_MZAL4256HBJD-00BL2_S67PNF0W904398_1",
+          "/dev/disk/by-id/nvme-nvme.144d-533637504e463057393034333938-53414d53554e47204d5a414c3432353648424a442d3030424c32-00000001",
+          "/dev/disk/by-path/platform-1000110000.pcie-pci-0001:01:00.0-nvme-1",
+          "/dev/nvme0n1"
+        ],
+        "vendor": { "hex": "144d", "value": 5197 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 22,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 23,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1948992,
+            "geo_type": "logical",
+            "heads": 4,
+            "sectors": 16,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 124735488,
+            "value_2": 512
+          }
+        ],
+        "model": "Disk",
+        "driver": "sdhci-brcmstb",
+        "index": 25,
+        "attached_to": 20,
+        "serial": "0xc467264d",
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_device_link": "/devices/platform/soc@107c000000/1000fff000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "sysfs_id": "/class/block/mmcblk0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "drivers": ["mmcblk", "sdhci-brcmstb"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": [
+          "/dev/disk/by-id/mmc-SN64G_0xc467264d",
+          "/dev/disk/by-path/platform-1000fff000.mmc",
+          "/dev/mmcblk0"
+        ]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 27,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 32,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 33,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 34,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 35,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 36,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 37,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 38,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "hub": [
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "xhci-hcd.1",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb3/3-0:1.0",
+        "sysfs_bus_id": "3-0:1.0",
+        "attached_to": 18,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 39,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 18,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 40,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "xhci-hcd.1",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "4-0:1.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb4/4-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      },
+      {
+        "resources": [
+          {
+            "type": "baud",
+            "bits": 0,
+            "handshake": 0,
+            "parity": 0,
+            "speed": 480000000,
+            "stop_bits": 0
+          }
+        ],
+        "serial": "xhci-hcd.0",
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb/xhci-hcd.0/usb1/1-0:1.0",
+        "sysfs_bus_id": "1-0:1.0",
+        "attached_to": 15,
+        "module_alias": "usb:v1D6Bp0002d0618dc09dsc00dp01ic09isc00ip00in00",
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "hotplug": "usb",
+        "index": 41,
+        "device": { "name": "xHCI Host Controller", "hex": "0002", "value": 2 },
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "drivers": ["hub"],
+        "driver_modules": ["usbcore"],
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "slot": { "bus": 0, "number": 0 },
+        "class_list": ["usb", "hub"],
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        },
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 1,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        }
+      },
+      {
+        "attached_to": 15,
+        "base_class": { "name": "Hub", "hex": "010a", "value": 266 },
+        "bus_type": { "name": "USB", "hex": "0086", "value": 134 },
+        "class_list": ["usb", "hub"],
+        "detail": {
+          "device_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "device_protocol": 3,
+          "device_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          },
+          "interface_alternate_setting": 0,
+          "interface_class": { "name": "hub", "hex": "0009", "value": 9 },
+          "interface_number": 0,
+          "interface_protocol": 0,
+          "interface_subclass": {
+            "name": "per_interface",
+            "hex": "0000",
+            "value": 0
+          }
+        },
+        "device": { "name": "xHCI Host Controller", "hex": "0003", "value": 3 },
+        "driver": "hub",
+        "driver_module": "usbcore",
+        "driver_modules": ["usbcore"],
+        "drivers": ["hub"],
+        "hotplug": "usb",
+        "index": 42,
+        "model": "Linux 6.18.34 xhci-hcd xHCI Host Controller",
+        "module_alias": "usb:v1D6Bp0003d0618dc09dsc00dp03ic09isc00ip00in00",
+        "revision": { "name": "6.18", "hex": "0000", "value": 0 },
+        "serial": "xhci-hcd.0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "2-0:1.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb/xhci-hcd.0/usb2/2-0:1.0",
+        "vendor": {
+          "name": "Linux 6.18.34 xhci-hcd",
+          "hex": "1d6b",
+          "value": 7531
+        }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 8589934592 }],
+        "attached_to": 0,
+        "index": 6,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "mmc_controller": [
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SDIO Controller 1",
+        "index": 19,
+        "model": "SDIO Controller 1",
+        "slot": { "bus": 0, "number": 1 },
+        "sysfs_bus_id": "mmc1:0001",
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001",
+        "vendor": ""
+      },
+      {
+        "attached_to": 0,
+        "base_class": { "name": "MMC Controller", "hex": "0117", "value": 279 },
+        "bus_type": { "name": "MMC", "hex": "0093", "value": 147 },
+        "class_list": ["mmc_controller"],
+        "device": "SD Controller 0",
+        "driver": "mmcblk",
+        "drivers": ["mmcblk"],
+        "index": 20,
+        "model": "SD Controller 0",
+        "slot": { "bus": 0, "number": 0 },
+        "sysfs_bus_id": "mmc0:aaaa",
+        "sysfs_id": "/devices/platform/soc@107c000000/1000fff000.mmc/mmc_host/mmc0/mmc0:aaaa",
+        "vendor": ""
+      }
+    ],
+    "network_controller": [
+      {
+        "attached_to": 9,
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["network_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "0001", "value": 1 },
+        "driver": "rp1",
+        "driver_module": "rp1",
+        "driver_modules": ["rp1"],
+        "drivers": ["rp1"],
+        "index": 8,
+        "model": "Ethernet controller",
+        "module_alias": "pci:v00001DE4d00000001sv00000000sd00000000bc02sc00i00",
+        "slot": { "bus": 513, "number": 0 },
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "0002:01:00.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/pci0002:00/0002:00:00.0/0002:01:00.0",
+        "vendor": { "hex": "1de4", "value": 7652 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 },
+          {
+            "type": "wlan",
+            "auth_modes": ["open", "sharedkey", "wpa-psk", "wpa-eap"],
+            "channels": [
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "36",
+              "40",
+              "44",
+              "48",
+              "52",
+              "56",
+              "60",
+              "64",
+              "100",
+              "104",
+              "108",
+              "112",
+              "116",
+              "120",
+              "124",
+              "128",
+              "132",
+              "136",
+              "140",
+              "144",
+              "149"
+            ],
+            "enc_modes": ["WEP40", "WEP104", "TKIP", "CCMP"],
+            "frequencies": [
+              "2.412",
+              "2.417",
+              "2.422",
+              "2.427",
+              "2.432",
+              "2.437",
+              "2.442",
+              "2.447",
+              "2.452",
+              "2.457",
+              "2.462",
+              "5.18",
+              "5.2",
+              "5.22",
+              "5.24",
+              "5.26",
+              "5.28",
+              "5.3",
+              "5.32",
+              "5.5",
+              "5.52",
+              "5.54",
+              "5.56",
+              "5.58",
+              "5.6",
+              "5.62",
+              "5.64",
+              "5.66",
+              "5.68",
+              "5.7",
+              "5.72",
+              "5.745"
+            ]
+          }
+        ],
+        "attached_to": 0,
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "sysfs_bus_id": "mmc1:0001:1",
+        "module_alias": "sdio:c00v02D0d4345",
+        "model": "Broadcom WLAN controller",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "index": 12,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "device": { "hex": "4345", "value": 17221 },
+        "class_list": ["network_controller", "wlan_card"],
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": { "name": "WLAN controller", "hex": "0082", "value": 130 },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["wld0"],
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 }
+        ],
+        "model": "ARM Ethernet controller",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00100000.ethernet",
+        "sysfs_bus_id": "1f00100000.ethernet",
+        "attached_to": 0,
+        "driver": "macb",
+        "module_alias": "of:NethernetT(null)Craspberrypi,rp1-gemCcdns,macb",
+        "index": 17,
+        "device": {
+          "name": "ARM Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "drivers": ["macb"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "unix_device_names": ["end0"]
+      }
+    ],
+    "network_interface": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 43,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 }
+        ],
+        "attached_to": 17,
+        "driver": "macb",
+        "index": 46,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/platform/axi/1000120000.pcie/1f00100000.ethernet",
+        "sysfs_id": "/class/net/end0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["macb"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["end0"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 50 },
+          { "type": "phwaddr", "address": 50 }
+        ],
+        "index": 47,
+        "sysfs_id": "/class/net/wld0",
+        "sysfs_device_link": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:1",
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "model": "Ethernet network interface",
+        "attached_to": 12,
+        "drivers": ["brcmfmac"],
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "class_list": ["network_interface"],
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "unix_device_names": ["wld0"]
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 7,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 2,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "a80b", "value": 43019 },
+        "driver": "nvme",
+        "driver_module": "nvme",
+        "driver_modules": ["nvme"],
+        "drivers": ["nvme"],
+        "index": 10,
+        "model": "Mass storage controller",
+        "module_alias": "pci:v0000144Dd0000A80Bsv0000144Dsd0000A80Bbc01sc08i02",
+        "pci_interface": { "hex": "0002", "value": 2 },
+        "revision": { "hex": "0002", "value": 2 },
+        "slot": { "bus": 257, "number": 0 },
+        "sub_class": { "hex": "0008", "value": 8 },
+        "sub_device": { "hex": "a80b", "value": 43019 },
+        "sub_vendor": { "hex": "144d", "value": 5197 },
+        "sysfs_bus_id": "0001:01:00.0",
+        "sysfs_id": "/devices/platform/axi/1000110000.pcie/pci0001:00/0001:00:00.0/0001:01:00.0",
+        "vendor": { "hex": "144d", "value": 5197 }
+      }
+    ],
+    "system": {},
+    "unknown": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": { "hex": "4345", "value": 17221 },
+        "index": 11,
+        "model": "Broadcom Unclassified device",
+        "module_alias": "sdio:c02v02D0d4345",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:3",
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:3",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "bus_type": { "name": "SDIO", "hex": "0094", "value": 148 },
+        "class_list": ["unknown"],
+        "device": { "hex": "4345", "value": 17221 },
+        "driver": "brcmfmac",
+        "driver_module": "brcmfmac",
+        "driver_modules": ["brcmfmac", "brcmfmac", "brcmfmac"],
+        "drivers": ["brcmfmac"],
+        "index": 13,
+        "model": "Broadcom Unclassified device",
+        "module_alias": "sdio:c00v02D0d4345",
+        "slot": { "bus": 0, "number": 0 },
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "mmc1:0001:2",
+        "sysfs_id": "/devices/platform/axi/1001100000.mmc/mmc_host/mmc1/mmc1:0001/mmc1:0001:2",
+        "vendor": { "name": "Broadcom Corp.", "hex": "02d0", "value": 720 }
+      }
+    ],
+    "usb_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": { "name": "ARM USB controller", "hex": "0000", "value": 0 },
+        "driver": "dwc3",
+        "driver_info": {
+          "type": "module",
+          "active": false,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["uhci-hcd"],
+          "module_args": [""],
+          "names": ["uhci-hcd"]
+        },
+        "drivers": ["dwc3"],
+        "index": 14,
+        "model": "ARM USB controller",
+        "module_alias": "of:NusbT(null)Csnps,dwc3",
+        "pci_interface": { "name": "UHCI", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "1f00200000.usb",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb"
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": {
+          "name": "ARM USB XHCI controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver": "xhci-hcd",
+        "drivers": ["xhci-hcd"],
+        "index": 15,
+        "model": "ARM USB XHCI controller",
+        "module_alias": "platform:xhci-hcd",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "xhci-hcd.0",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00200000.usb/xhci-hcd.0"
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": { "name": "ARM USB controller", "hex": "0000", "value": 0 },
+        "driver": "dwc3",
+        "driver_info": {
+          "type": "module",
+          "active": false,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["uhci-hcd"],
+          "module_args": [""],
+          "names": ["uhci-hcd"]
+        },
+        "drivers": ["dwc3"],
+        "index": 16,
+        "model": "ARM USB controller",
+        "module_alias": "of:NusbT(null)Csnps,dwc3",
+        "pci_interface": { "name": "UHCI", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "1f00300000.usb",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb"
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Serial bus controller",
+          "hex": "000c",
+          "value": 12
+        },
+        "class_list": ["usb_controller"],
+        "device": {
+          "name": "ARM USB XHCI controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "driver": "xhci-hcd",
+        "drivers": ["xhci-hcd"],
+        "index": 18,
+        "model": "ARM USB XHCI controller",
+        "module_alias": "platform:xhci-hcd",
+        "pci_interface": { "hex": "0030", "value": 48 },
+        "sub_class": { "name": "USB Controller", "hex": "0003", "value": 3 },
+        "sysfs_bus_id": "xhci-hcd.1",
+        "sysfs_id": "/devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1"
+      }
+    ]
+  }
+}

--- a/.jjconflict-side-1/hosts/nixtar/configuration.nix
+++ b/.jjconflict-side-1/hosts/nixtar/configuration.nix
@@ -1,0 +1,143 @@
+{
+  modulesPath,
+  pkgs,
+  ...
+}:
+
+let
+  wsl-lib = pkgs.runCommand "wsl-lib" { } ''
+    mkdir -p "$out/lib"
+    # # we cannot just symlink the lib directory because it breaks merging with other drivers that provide the same directory
+    ln -s /usr/lib/wsl/lib/libcudadebugger.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libcuda.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libcuda.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libcuda.so.1.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libd3d12core.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libd3d12.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libdxcore.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvcuvid.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvcuvid.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvdxdlkernels.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-encode.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-encode.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-ml.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-opticalflow.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvidia-opticalflow.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvoptix.so.1 "$out/lib"
+    ln -s /usr/lib/wsl/lib/libnvwgf2umx.so "$out/lib"
+    ln -s /usr/lib/wsl/lib/nvidia-smi "$out/lib"
+  '';
+in
+{
+  imports = [
+    "${modulesPath}/profiles/headless.nix"
+    ../../modules/nixos/profiles/workstation.nix
+  ];
+
+  boot = {
+    # Enable cross compilation
+    binfmt.emulatedSystems = [ "aarch64-linux" ];
+
+    kernelModules = [ "tcp_bbr" ];
+    kernel.sysctl = {
+      # Optimize for 64GB RAM
+      "vm.swappiness" = 10;
+      "vm.vfs_cache_pressure" = 50;
+      "vm.max_map_count" = 524288;
+
+      # Increase file watcher limit for IDEs
+      "fs.inotify.max_user_watches" = 524288;
+      "fs.inotify.max_user_instances" = 512;
+      "fs.file-max" = 2097152;
+
+      # Network optimizations
+      "net.core.default_qdisc" = "fq";
+      "net.core.netdev_max_backlog" = 16384;
+      "net.core.rmem_default" = 7340032;
+      "net.core.rmem_max" = 16777216;
+      "net.core.somaxconn" = 65535;
+      "net.core.wmem_default" = 7340032;
+      "net.core.wmem_max" = 16777216;
+      "net.ipv4.ip_local_port_range" = "1024 65535";
+      "net.ipv4.tcp_congestion_control" = "bbr";
+      "net.ipv4.tcp_fin_timeout" = 30;
+      "net.ipv4.tcp_keepalive_time" = 600;
+      "net.ipv4.tcp_mtu_probing" = 1;
+      "net.ipv4.tcp_rmem" = "4096 87380 16777216";
+      "net.ipv4.tcp_wmem" = "4096 65536 16777216";
+    };
+  };
+
+  environment.systemPackages = with pkgs; [
+    dunst
+    libnotify
+    wl-clipboard
+  ];
+
+  hardware = {
+    facter.reportPath = ./facter.json;
+    nvidia.open = true;
+    nvidia-container-toolkit = {
+      enable = true;
+      mount-nvidia-executables = false;
+    };
+  };
+
+  home-manager.users.shika.imports = [
+    ../../modules/nixos/users/shika.nix
+  ];
+
+  networking.hostName = "nixtar";
+
+  programs.nix-ld = {
+    enable = true;
+    libraries = [
+      pkgs.stdenv.cc.cc.lib
+      pkgs.zlib
+      wsl-lib
+    ];
+  };
+
+  services = {
+    openssh = {
+      enable = true;
+      openFirewall = true;
+    };
+    xserver.videoDrivers = [ "nvidia" ];
+  };
+
+  sops = {
+    age = {
+      generateKey = true;
+      keyFile = "/var/lib/sops-nix/key.txt";
+      sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    };
+    defaultSopsFile = ../../secrets/nixtar.enc.yaml;
+    defaultSopsFormat = "yaml";
+  };
+
+  users.users.shika = {
+    extraGroups = [ "wheel" ];
+    home = "/home/shika";
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+
+  virtualisation.docker = {
+    autoPrune.enable = true;
+    rootless = {
+      enable = true;
+      setSocketVariable = true;
+      daemon.settings.features.cdi = true;
+    };
+  };
+
+  wsl = {
+    enable = true;
+    defaultUser = "shika";
+    interop.register = true;
+    useWindowsDriver = true;
+  };
+}

--- a/.jjconflict-side-1/hosts/nixtar/facter.json
+++ b/.jjconflict-side-1/hosts/nixtar/facter.json
@@ -1,0 +1,909 @@
+{
+  "version": 1,
+  "smbios": {},
+  "system": "x86_64-linux",
+  "virtualisation": "wsl",
+  "hardware": {
+    "bios": {
+      "apm_info": {
+        "version": 0,
+        "bios_flags": 0,
+        "enabled": false,
+        "sub_version": 0,
+        "supported": false
+      },
+      "lba_support": false,
+      "low_memory_size": 0,
+      "pnp": false,
+      "pnp_id": 0,
+      "smbios_version": 0,
+      "vbe_info": { "version": 0, "video_memory": 0 }
+    },
+    "cpu": [
+      {
+        "address_sizes": { "physical": "0x27", "virtual": "0x30" },
+        "architecture": "x86_64",
+        "bogo": 5184,
+        "bugs": [
+          "cpu_meltdown",
+          "spectre_v1",
+          "spectre_v2",
+          "spec_store_bypass",
+          "l1tf",
+          "mds",
+          "swapgs",
+          "itlb_multihit",
+          "srbds",
+          "mmio_stale_data",
+          "retbleed",
+          "gds",
+          "bhi"
+        ],
+        "cache": 12288,
+        "cache_alignment": 64,
+        "clflush_size": 64,
+        "cores": 6,
+        "cpuid_level": 22,
+        "family": 6,
+        "features": [
+          "fpu",
+          "vme",
+          "de",
+          "pse",
+          "tsc",
+          "msr",
+          "pae",
+          "mce",
+          "cx8",
+          "apic",
+          "sep",
+          "mtrr",
+          "pge",
+          "mca",
+          "cmov",
+          "pat",
+          "pse36",
+          "clflush",
+          "mmx",
+          "fxsr",
+          "sse",
+          "sse2",
+          "ss",
+          "ht",
+          "syscall",
+          "nx",
+          "pdpe1gb",
+          "rdtscp",
+          "lm",
+          "constant_tsc",
+          "arch_perfmon",
+          "rep_good",
+          "nopl",
+          "xtopology",
+          "cpuid",
+          "tsc_known_freq",
+          "pni",
+          "pclmulqdq",
+          "vmx",
+          "ssse3",
+          "fma",
+          "cx16",
+          "pdcm",
+          "pcid",
+          "sse4_1",
+          "sse4_2",
+          "movbe",
+          "popcnt",
+          "aes",
+          "xsave",
+          "avx",
+          "f16c",
+          "rdrand",
+          "hypervisor",
+          "lahf_lm",
+          "abm",
+          "3dnowprefetch",
+          "pti",
+          "ssbd",
+          "ibrs",
+          "ibpb",
+          "stibp",
+          "tpr_shadow",
+          "ept",
+          "vpid",
+          "ept_ad",
+          "fsgsbase",
+          "bmi1",
+          "avx2",
+          "smep",
+          "bmi2",
+          "erms",
+          "invpcid",
+          "rdseed",
+          "adx",
+          "smap",
+          "clflushopt",
+          "xsaveopt",
+          "xsavec",
+          "xgetbv1",
+          "xsaves",
+          "vnmi",
+          "md_clear",
+          "flush_l1d",
+          "arch_capabilities"
+        ],
+        "fpu": false,
+        "fpu_exception": false,
+        "model": 158,
+        "model_name": "Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz",
+        "page_size": 4096,
+        "physical_id": 0,
+        "power_management": [""],
+        "siblings": 12,
+        "stepping": 10,
+        "tlb_size": 31165,
+        "units": 16,
+        "vendor_name": "GenuineIntel",
+        "write_protect": false
+      }
+    ],
+    "disk": [
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 24,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram2",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram2"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 133674,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 2147483648,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:3",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:3",
+        "unix_device_name2": "/dev/sg3",
+        "sysfs_id": "/class/block/sdd",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 25,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-36002248042994cacd691c52f2e08fe01",
+          "/dev/disk/by-id/wwn-0x6002248042994cacd691c52f2e08fe01",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:3",
+          "/dev/disk/by-uuid/6e398549-74bd-406a-b9a6-b458fb49306c",
+          "/dev/sdd"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 26,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram0",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram0"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 23,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 381016,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:1",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:1",
+        "unix_device_name2": "/dev/sg1",
+        "sysfs_id": "/class/block/sdb",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 27,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-3600224805b5ac507b80a045bc3303ae1",
+          "/dev/disk/by-id/wwn-0x600224805b5ac507b80a045bc3303ae1",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:1",
+          "/dev/sdb"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 28,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram9",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram9"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 29,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram14",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram14"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 30,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram7",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram7"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 31,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram12",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram12"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 32,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram5",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram5"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 33,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram10",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram10"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 34,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram3",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram3"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 35,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram1",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram1"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 1697,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 27262984,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:2",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:2",
+        "unix_device_name2": "/dev/sg2",
+        "sysfs_id": "/class/block/sdc",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 36,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-3600224800696b95cdd20962287e749ad",
+          "/dev/disk/by-id/wwn-0x600224800696b95cdd20962287e749ad",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:2",
+          "/dev/disk/by-uuid/67edc7a8-a3e4-41bf-a504-20a881a13371",
+          "/dev/sdc"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 37,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram15",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram15"]
+      },
+      {
+        "resources": [
+          {
+            "type": "disk_geo",
+            "cylinders": 49,
+            "geo_type": "logical",
+            "heads": 255,
+            "sectors": 63,
+            "size": "0x0"
+          },
+          {
+            "type": "size",
+            "unit": "sectors",
+            "value_1": 795880,
+            "value_2": 512
+          }
+        ],
+        "sysfs_bus_id": "0:0:0:0",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0/host0/target0:0:0/0:0:0:0",
+        "unix_device_name2": "/dev/sg0",
+        "sysfs_id": "/class/block/sda",
+        "model": "Msft Virtual Disk",
+        "driver": "hv_storvsc",
+        "attached_to": 21,
+        "index": 38,
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "slot": { "bus": 0, "number": 0 },
+        "revision": { "name": "1.0", "hex": "0000", "value": 0 },
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "drivers": ["hv_storvsc", "sd"],
+        "device": { "name": "Virtual Disk", "hex": "0000", "value": 0 },
+        "class_list": ["disk", "scsi", "block_device"],
+        "bus_type": { "name": "SCSI", "hex": "0084", "value": 132 },
+        "unix_device_names": [
+          "/dev/disk/by-id/scsi-360022480728b63b9f0b8d5e28f1d4859",
+          "/dev/disk/by-id/wwn-0x60022480728b63b9f0b8d5e28f1d4859",
+          "/dev/disk/by-path/acpi-MSFT1000:00-scsi-0:0:0:0",
+          "/dev/sda"
+        ],
+        "vendor": { "name": "Msft", "hex": "0000", "value": 0 }
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 39,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram8",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram8"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 40,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram13",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram13"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 41,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram6",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram6"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 42,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram11",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram11"]
+      },
+      {
+        "resources": [
+          { "type": "size", "unit": "sectors", "value_1": 8192, "value_2": 512 }
+        ],
+        "attached_to": 0,
+        "index": 43,
+        "model": "Disk",
+        "sysfs_id": "/class/block/ram4",
+        "base_class": {
+          "name": "Mass Storage Device",
+          "hex": "0106",
+          "value": 262
+        },
+        "class_list": ["disk", "block_device"],
+        "sub_class": { "name": "Disk", "hex": "0000", "value": 0 },
+        "unix_device_names": ["/dev/ram4"]
+      }
+    ],
+    "graphics_card": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["graphics_card", "pci"],
+        "detail": {
+          "command": 7,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "008e", "value": 142 },
+        "driver": "dxgkrnl",
+        "drivers": ["dxgkrnl"],
+        "index": 16,
+        "model": "3D controller",
+        "module_alias": "pci:v00001414d0000008Esv00000000sd00000000bc03sc02i00",
+        "slot": { "bus": 11717888, "number": 0 },
+        "sub_class": { "name": "3D controller", "hex": "0002", "value": 2 },
+        "sysfs_bus_id": "b2cd:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/233d912c-b2cd-41c7-981b-b6574ee392cf/pcib2cd:00/b2cd:00:00.0",
+        "vendor": { "hex": "1414", "value": 5140 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Display controller",
+          "hex": "0003",
+          "value": 3
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["graphics_card", "pci"],
+        "detail": {
+          "command": 7,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "008e", "value": 142 },
+        "driver": "dxgkrnl",
+        "drivers": ["dxgkrnl"],
+        "index": 19,
+        "model": "3D controller",
+        "module_alias": "pci:v00001414d0000008Esv00000000sd00000000bc03sc02i00",
+        "slot": { "bus": 12877056, "number": 0 },
+        "sub_class": { "name": "3D controller", "hex": "0002", "value": 2 },
+        "sysfs_bus_id": "c47d:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/4686eaaa-c47d-415e-b025-a8a8caf4c9b0/pcic47d:00/c47d:00:00.0",
+        "vendor": { "hex": "1414", "value": 5140 }
+      }
+    ],
+    "memory": [
+      {
+        "resources": [{ "type": "phys_mem", "range": 51539607552 }],
+        "attached_to": 0,
+        "index": 15,
+        "model": "Main Memory",
+        "base_class": {
+          "name": "Internally Used Class",
+          "hex": "0101",
+          "value": 257
+        },
+        "class_list": ["memory"],
+        "sub_class": { "name": "Main Memory", "hex": "0002", "value": 2 }
+      }
+    ],
+    "network_controller": [
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 48 },
+          { "type": "phwaddr", "address": 48 }
+        ],
+        "model": "Virtual Ethernet Card 0",
+        "vendor": "Virtual",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/293797f4-beca-4fcf-8341-90c5b230a8db",
+        "device": "Virtual Ethernet Card 0",
+        "driver": "hv_netvsc",
+        "sysfs_bus_id": "293797f4-beca-4fcf-8341-90c5b230a8db",
+        "attached_to": 0,
+        "index": 20,
+        "drivers": ["hv_netvsc"],
+        "sub_class": {
+          "name": "Ethernet controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["network_controller"],
+        "unix_device_names": ["eth0"],
+        "base_class": {
+          "name": "Network controller",
+          "hex": "0002",
+          "value": 2
+        },
+        "driver_info": {
+          "type": "module",
+          "active": true,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["hv_netvsc"],
+          "module_args": [""],
+          "names": ["hv_netvsc"]
+        }
+      }
+    ],
+    "network_interface": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "index": 44,
+        "model": "Loopback network interface",
+        "sub_class": { "name": "Loopback", "hex": "0000", "value": 0 },
+        "sysfs_id": "/class/net/lo",
+        "unix_device_names": ["lo"]
+      },
+      {
+        "resources": [
+          { "type": "hwaddr", "address": 48 },
+          { "type": "phwaddr", "address": 48 }
+        ],
+        "attached_to": 20,
+        "driver": "hv_netvsc",
+        "index": 45,
+        "model": "Ethernet network interface",
+        "sysfs_device_link": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/293797f4-beca-4fcf-8341-90c5b230a8db",
+        "sysfs_id": "/class/net/eth0",
+        "base_class": {
+          "name": "Network Interface",
+          "hex": "0107",
+          "value": 263
+        },
+        "class_list": ["network_interface"],
+        "drivers": ["hv_netvsc"],
+        "sub_class": { "name": "Ethernet", "hex": "0001", "value": 1 },
+        "unix_device_names": ["eth0"]
+      }
+    ],
+    "pci": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Generic system peripheral",
+          "hex": "0008",
+          "value": 8
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["pci", "unknown"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "105a", "value": 4186 },
+        "driver": "virtio-pci",
+        "drivers": ["virtio-pci"],
+        "index": 18,
+        "model": "System peripheral",
+        "module_alias": "pci:v00001AF4d0000105Asv00001AF4sd00000040bc08sc80i00",
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 14778112, "number": 0 },
+        "sub_class": {
+          "name": "System peripheral",
+          "hex": "0080",
+          "value": 128
+        },
+        "sub_device": { "hex": "0040", "value": 64 },
+        "sub_vendor": { "hex": "1af4", "value": 6900 },
+        "sysfs_bus_id": "e17f:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/72e2a6d5-e17f-4d7c-a780-7ae0830f010e/pcie17f:00/e17f:00:00.0",
+        "vendor": { "hex": "1af4", "value": 6900 }
+      }
+    ],
+    "storage_controller": [
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "bus_type": { "name": "PCI", "hex": "0004", "value": 4 },
+        "class_list": ["storage_controller", "pci"],
+        "detail": {
+          "command": 1030,
+          "function": 0,
+          "header_type": 0,
+          "prog_if": 0,
+          "secondary_bus": 0
+        },
+        "device": { "hex": "1043", "value": 4163 },
+        "driver": "virtio-pci",
+        "drivers": ["virtio-pci"],
+        "index": 17,
+        "model": "SCSI storage controller",
+        "module_alias": "pci:v00001AF4d00001043sv00001AF4sd00000040bc01sc00i00",
+        "revision": { "hex": "0001", "value": 1 },
+        "slot": { "bus": 5603840, "number": 0 },
+        "sub_class": {
+          "name": "SCSI storage controller",
+          "hex": "0000",
+          "value": 0
+        },
+        "sub_device": { "hex": "0040", "value": 64 },
+        "sub_vendor": { "hex": "1af4", "value": 6900 },
+        "sysfs_bus_id": "5582:00:00.0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/c4b741f5-5582-4c98-8f8b-2e082933c396/pci5582:00/5582:00:00.0",
+        "vendor": { "hex": "1af4", "value": 6900 }
+      },
+      {
+        "attached_to": 0,
+        "base_class": {
+          "name": "Mass storage controller",
+          "hex": "0001",
+          "value": 1
+        },
+        "class_list": ["storage_controller"],
+        "device": "Storage 0",
+        "driver": "hv_storvsc",
+        "driver_info": {
+          "type": "module",
+          "active": true,
+          "conf": "",
+          "modprobe": true,
+          "db_entry_0": ["hv_storvsc"],
+          "module_args": [""],
+          "names": ["hv_storvsc"]
+        },
+        "drivers": ["hv_storvsc"],
+        "index": 21,
+        "model": "Virtual Storage 0",
+        "sub_class": {
+          "name": "Storage controller",
+          "hex": "0080",
+          "value": 128
+        },
+        "sysfs_bus_id": "fd1d2cbd-ce7c-535c-966b-eb5f811c95f0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/fd1d2cbd-ce7c-535c-966b-eb5f811c95f0",
+        "vendor": "Virtual"
+      }
+    ],
+    "system": { "form_factor": "laptop" },
+    "unknown": [
+      {
+        "attached_to": 18,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["unknown"],
+        "device": "",
+        "driver": "virtiofs",
+        "drivers": ["virtiofs"],
+        "index": 22,
+        "model": "Virtio Unclassified device",
+        "module_alias": "virtio:d0000001Av00001AF4",
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "virtio1",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/72e2a6d5-e17f-4d7c-a780-7ae0830f010e/pcie17f:00/e17f:00:00.0/virtio1",
+        "vendor": "Virtio"
+      },
+      {
+        "attached_to": 17,
+        "base_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "class_list": ["unknown"],
+        "device": "",
+        "driver": "virtio_console",
+        "drivers": ["virtio_console"],
+        "index": 23,
+        "model": "Virtio Unclassified device",
+        "module_alias": "virtio:d00000003v00001AF4",
+        "sub_class": {
+          "name": "Unclassified device",
+          "hex": "0000",
+          "value": 0
+        },
+        "sysfs_bus_id": "virtio0",
+        "sysfs_id": "/devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0004:00/MSFT1000:00/c4b741f5-5582-4c98-8f8b-2e082933c396/pci5582:00/5582:00:00.0/virtio0",
+        "vendor": "Virtio"
+      }
+    ]
+  }
+}

--- a/.jjconflict-side-1/hosts/telsha/darwin-configuration.nix
+++ b/.jjconflict-side-1/hosts/telsha/darwin-configuration.nix
@@ -1,0 +1,28 @@
+{
+  imports = [
+    ../../modules/darwin/profiles/distributed.nix
+    ../../modules/darwin/profiles/workstation.nix
+  ];
+
+  home-manager.users.shikanimedeva.imports = [
+    ../../modules/darwin/users/shikanimedeva.nix
+  ];
+
+  networking.hostName = "telsha";
+
+  sops = {
+    age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+    defaultSopsFile = ../../secrets/telsha.enc.yaml;
+    defaultSopsFormat = "yaml";
+  };
+
+  system.primaryUser = "shikanimedeva";
+
+  users.users.shikanimedeva = {
+    home = "/Users/shikanimedeva";
+    name = "shikanimedeva";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+}

--- a/.jjconflict-side-1/infra/shikanime-github/.terraform.lock.hcl
+++ b/.jjconflict-side-1/infra/shikanime-github/.terraform.lock.hcl
@@ -1,0 +1,51 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.4.0"
+  constraints = "~> 6.4"
+  hashes = [
+    "h1:B1q5+Ub1G3zJa9y474Fg40eo/N04/vOSeaf3dWaCG0I=",
+    "h1:YiGCvjr7R77HGTzw81legWicEHApVTli8O+ooDpLexE=",
+    "h1:sJvuRMYWJ/ykZXTuoCuocHvx06hTwDVrXVVXq1814bw=",
+    "zh:00f431c2a2510efcb1115442dda5e90815bcb16e1a3301679ade0139fa963d3b",
+    "zh:12a862f4317b3cb65682c1b687650cd91eeee99e63774bdcfa8bcfc64bad097b",
+    "zh:226d5e09ff27f94cb9336089181d26f85cb30219b863a579597f2e107f37de49",
+    "zh:402ecaa5add568a52ee01d816810f3b90f693be35c680fcdc9b6284bf55326f1",
+    "zh:60e3bdd9fbefb3c1d790bc08889c1dc0e83636b82284faaa709411aa4f96bb9f",
+    "zh:625099eeff2f8aaecd22a24a451b326828435c8f9de86f2e5e99872e7b467fa7",
+    "zh:79e8b665421009df2260f50e10da1f7a7863b557ece96e2b07dfd2fad1e86fcd",
+    "zh:98e471fefc93dcfedeec750c694110db7d3331dc3a256191d30b9d2f70d12157",
+    "zh:a17702765e1fa92d1c288ddfd97075819ad61b344b341be7e09c554c841a6d9e",
+    "zh:ca72ccf40624ae26bf4660d8dd84a51638f0a1e78d5f19fdfaafaef97f838af6",
+    "zh:d009ab5527d45c44c424d26cd2eb51a5a6a6448f3fb1023b675789588cc08d64",
+    "zh:e5811be1e942a75b14dfcd3e03523d8df60cfbde0d7e24d75e78480a02a58949",
+    "zh:e6008ad28225ad6996b06bcd7f3070863329df406a56754e7fb9c31d6301ace4",
+    "zh:f1d93f56ea4f87183a5de4780704907605851d95a2d285a9ec755bf784c5569c",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}
+
+provider "registry.opentofu.org/scaleway/scaleway" {
+  version     = "2.48.0"
+  constraints = "~> 2.43"
+  hashes = [
+    "h1:5BbGEXuyORjQ9adWey72qJkOCj9zjwly/aUcwXXXqvo=",
+    "h1:LczipXZujiPUPClltqtt6pDhAxQ7s35v21Fe46hflXU=",
+    "h1:ra/AlSZHIX8gBGtODsiaUp+V8iXpNIL1BZlxDLPc1Es=",
+    "zh:161e4a2981240645b584acf13a76563ca90fff107efd983cbf7db74bfc3462b6",
+    "zh:2cf0df5b147aa0fd50953e00bee8fea56e4ddb0630e7cbc7443619933c37522f",
+    "zh:4cc775235b8b3d0847c4bf0d36c68ced5a1c26628c62abd1d53ccbdbc5c10ff8",
+    "zh:8611025a842c7cd5f629246197157c11b2c77048066b076ccd448e8d9f764213",
+    "zh:8eae8559fdd3f9c3a71bb0c9dfd23084ee0c798ffff779e5836e44ed5cc68948",
+    "zh:c87e86288f4bb128533ff6719959547a3941c83315ede709a4586369c7558090",
+    "zh:cc4f1738b9be10f4106f4e1ba9bdabee64eae6f7c6be937275f019f409fd6390",
+    "zh:cd9610dac94aba5891b4487635100ba893821fd79b3c5dc65c95a8c88db67243",
+    "zh:e36e2eda9bc52efc4053e333aa58be81988651d77b3dbf894c885cd81dec3f32",
+    "zh:ec23c160523dfa2d13d41be83046dbd4ce9e142fd759e73c93f76029869f7da7",
+    "zh:ec4c3a614719e8bdfc50c4c94bcabeb5c8dc14e0658cbc2041470dfb6f86c8a2",
+    "zh:f25c4287fa7c921f7a898543cc8fc7c485bb4fe2f730180f5302cb314bc9ec6a",
+    "zh:f6efe46bfd0716eaa153acad7fc126609ea2d00b50d90554e3f594e2e51578ad",
+    "zh:fb672d0ed1a6b01ed2436988071e6ae92d18b3b22271638c6bd5d32a2688695b",
+  ]
+}

--- a/.jjconflict-side-1/infra/shikanime-github/actions.tf
+++ b/.jjconflict-side-1/infra/shikanime-github/actions.tf
@@ -1,0 +1,46 @@
+resource "github_actions_secret" "cachix_auth_token" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "CACHIX_AUTH_TOKEN"
+  plaintext_value = var.cachix.auth_token
+}
+
+resource "github_actions_secret" "gpg_passphrase" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "GPG_PASSPHRASE"
+  plaintext_value = var.operator.gpg_passphrase
+}
+
+resource "github_actions_secret" "gpg_private_key" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "GPG_PRIVATE_KEY"
+  plaintext_value = var.operator.gpg_private_key
+}
+
+resource "github_actions_secret" "operator_private_key" {
+  for_each        = var.repositories
+  repository      = each.value
+  secret_name     = "OPERATOR_PRIVATE_KEY"
+  plaintext_value = var.operator.ssh_private_key
+}
+
+resource "github_actions_variable" "operator" {
+  for_each      = var.repositories
+  repository    = each.value
+  variable_name = "OPERATOR_APP_ID"
+  value         = var.apps.operator
+}
+
+resource "github_actions_secret" "wakabox_github_token" {
+  repository      = var.repositories.shikanime
+  secret_name     = "WAKABOX_GITHUB_TOKEN"
+  plaintext_value = var.wakabox.github_token
+}
+
+resource "github_actions_secret" "wakatime_api_key" {
+  repository      = var.repositories.shikanime
+  secret_name     = "WAKATIME_API_KEY"
+  plaintext_value = var.wakabox.wakatime_api_key
+}

--- a/.jjconflict-side-1/infra/shikanime-github/repo.tf
+++ b/.jjconflict-side-1/infra/shikanime-github/repo.tf
@@ -1,0 +1,65 @@
+data "github_repository" "repo" {
+  for_each = var.repositories
+  name     = each.value
+}
+
+resource "github_repository_ruleset" "main" {
+  for_each = {
+    for k, v in var.repositories :
+    k => v if !data.github_repository.repo[k].private
+  }
+  name        = "Main branch protections"
+  repository  = each.value
+  target      = "branch"
+  enforcement = "active"
+  conditions {
+    ref_name {
+      include = ["refs/heads/main"]
+      exclude = []
+    }
+  }
+  rules {
+    required_linear_history = true
+    required_signatures     = true
+  }
+}
+
+resource "github_repository_ruleset" "landing" {
+  for_each = {
+    for k, v in var.repositories :
+    k => v if !data.github_repository.repo[k].private
+  }
+  name        = "Landing protections"
+  repository  = each.value
+  target      = "branch"
+  enforcement = "active"
+  conditions {
+    ref_name {
+      include = ["refs/heads/main"]
+      exclude = []
+    }
+  }
+  bypass_actors {
+    actor_id    = 2
+    actor_type  = "RepositoryRole"
+    bypass_mode = "always"
+  }
+  bypass_actors {
+    actor_id    = var.apps.operator
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+  rules {
+    pull_request {
+      require_code_owner_review         = true
+      required_review_thread_resolution = true
+    }
+    required_status_checks {
+      required_check {
+        context        = "check"
+        integration_id = var.apps.github_actions
+      }
+      strict_required_status_checks_policy = true
+    }
+  }
+}

--- a/.jjconflict-side-1/infra/shikanime-github/variable.tf
+++ b/.jjconflict-side-1/infra/shikanime-github/variable.tf
@@ -1,0 +1,60 @@
+variable "apps" {
+  type = object({
+    github_actions = number
+    operator       = number
+  })
+  description = "Application names"
+  default = {
+    github_actions = 15368
+    operator       = 1095999
+  }
+}
+
+variable "cachix" {
+  type = object({
+    auth_token = string
+  })
+  description = "Cachix configuration secrets"
+  sensitive   = true
+}
+
+variable "operator" {
+  type = object({
+    gpg_passphrase  = string
+    gpg_private_key = string
+    ssh_private_key = string
+  })
+  description = "Operator configuration secrets"
+  sensitive   = true
+}
+
+variable "repositories" {
+  type = object({
+    algorithm        = string
+    curriculum-vitae = string
+    features         = string
+    manifests        = string
+    myawesomelist    = string
+    niximgs          = string
+    shikanime        = string
+  })
+  description = "GitHub repositories"
+  default = {
+    algorithm        = "algorithm"
+    curriculum-vitae = "curriculum-vitae"
+    features         = "features"
+    manifests        = "manifests"
+    myawesomelist    = "myawesomelist"
+    niximgs          = "niximgs"
+    shikanime        = "shikanime"
+  }
+}
+
+variable "wakabox" {
+  type = object({
+    github_token     = string
+    wakatime_api_key = string
+  })
+  description = "Wakabox configuration secrets"
+  sensitive   = true
+}

--- a/.jjconflict-side-1/infra/shikanime-github/version.tf
+++ b/.jjconflict-side-1/infra/shikanime-github/version.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = "~> 1.8"
+  cloud {
+    hostname     = "app.terraform.io"
+    organization = "shikanime-studio"
+    workspaces {
+      name = "shikanime-github"
+    }
+  }
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.4"
+    }
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2.43"
+    }
+  }
+}
+
+provider "github" {}

--- a/.jjconflict-side-1/infra/shikanime-google-cloud/.terraform.lock.hcl
+++ b/.jjconflict-side-1/infra/shikanime-google-cloud/.terraform.lock.hcl
@@ -1,0 +1,104 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = ">= 3.43.0, >= 3.53.0, >= 4.28.0, >= 5.22.0, ~> 5.36, < 6.0.0"
+  hashes = [
+    "h1:fwPyxJ8zBHeuEyv87dn8YkRHAqXGbJ9AqLN1I8loPr8=",
+    "zh:0931f08e81f220ae3132169cfa4ed8e9d8d2045f29ca914afd8ee9e3e9cf56e0",
+    "zh:31afa45a4c8a0fd4abff564ecff8b69a97ac1813ead61c12f5f0bf5d33cec7f1",
+    "zh:536979e437aad59ba41465c9398d8e3d7d3702bfe2a51d80571862d48c817959",
+    "zh:748e14614be32350ece4e9249e09bc1d20e54421983734ded3a0df6d6674ea71",
+    "zh:7c8fe641666603aad6693207c8eaac679b9be15246d77090c73a1a84326d6084",
+    "zh:8095a513a0662323d99c25466b5a291c80b2b0c1857c7c7a7b1159f25dbe4439",
+    "zh:9453db86d14611cab26dba30daf56d1cfef929918207e9e3e78b58299fc8c4fe",
+    "zh:adaa5df5d40060409b6b66136c0ac37b99fb35ac2cf554c584649c236a18d95b",
+    "zh:af2f659b4bd1f44e578f203830bdab829b5e635fcf2a59ffa7e997c16e6611ad",
+    "zh:b75184fe5c162821b0524fa941d6a934c452e815d82e62675bb21bbdc9046dfc",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/google-beta" {
+  version     = "5.45.2"
+  constraints = ">= 3.43.0, >= 4.11.0, >= 5.22.0, < 6.0.0"
+  hashes = [
+    "h1:fDebhcS9qedwzLfzm8NPbvOmKd6RvT0yJidzZ9qObsY=",
+    "zh:2df6e40591ceee7ee77d429ea072c9d51fef2dd04015b2604ff332a2af4ac819",
+    "zh:4096af21991ba76ab81c8cb00c0eb0bd4f22619f7e491d60023fb10b8b33bfb1",
+    "zh:44ded286956fff5668f1acbf152b62ca8e6a03abc8df12c5c181bc2ca05b4df7",
+    "zh:7ae19e1b53a0e26bea0acb9a96b4b44038d7c182c3fdd496148fd20e40aa78e1",
+    "zh:81c9812823b78fd1b12bc0acd6dae35bc573944950e09eaf237b2e83b6b587d7",
+    "zh:9db6101421b53b9533807928c651e779f5b8129f4a57ff892bf256c84ba6ed29",
+    "zh:b779729cb08829f621a718ecdfdb503c310ef5411e694996c7cfda7227221134",
+    "zh:c43edb31aee354317a6181272a961965b93722fd18637f38c395af013aa65617",
+    "zh:dbb93970a85f2fe84f650b6a4da694ecb1023a99c3b9bbf6953dccd074fa49ce",
+    "zh:df9d13853269e98651d495571b4d58c883b4386247d0b9c5495c2e82ef721f45",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/null" {
+  version     = "3.2.3"
+  constraints = ">= 2.1.0"
+  hashes = [
+    "h1:nNa5j1vTtxcpdC2i61O2tRkZjdkBNsxzYXYIx0VNsjc=",
+    "zh:1d57d25084effd3fdfd902eca00020b34b1fb020253b84d7dd471301606015ac",
+    "zh:65b7f9799b88464d9c2ec529713b7f52ea744275b61a8dc86cdedab1b2dcb933",
+    "zh:80d3e9c95b7b4ae7c54005cd127cae82e5c53d2b7023ef24c147337bac9dadd9",
+    "zh:841b60c07683e4bf456799ccd718896fdafdcc2c49252ae09967f2e74d8c8a03",
+    "zh:8fa1c592a9c78222e35713c6edb3f1f818a4c6f3524a30a209f0a7e919827b68",
+    "zh:bb795cc1429e09466840c09d39a28edf1db5070b1ec76822fc1173906a264572",
+    "zh:da1784818a89bea29dfe660632f0060a7a843e4e564d74435fbeca002b0f7d2a",
+    "zh:f409bf21b1cdaa6dac47cd79806f3d93f67e9507fe4dbf33b0165335f53bc2e1",
+    "zh:fbea7a1ff84b430ba9594698e93196d81d03e4036de3d1cafccb2a96d5b38581",
+    "zh:fbf0c84663a7e85881388d7d71ac862184f05fbf2d17ecf76bc5d3d7503ea260",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/random" {
+  version     = "3.7.1"
+  constraints = ">= 2.2.0"
+  hashes = [
+    "h1:HxqzkbeZlX7e/UfK6DA6SBYmd1+mURGRsRQHimwrpEM=",
+    "zh:1011387a5127d46e2bf0bd5124a8469506272b2110613d9eb80d178f94bd67a9",
+    "zh:28785c36d6dc331d49e8bf6a30d4ba21ae4378f5d98c43c0aeb42f51efb2e42f",
+    "zh:50fc0e52f0255950404681455420344a16263f91622bd481954606e6e3be9eb2",
+    "zh:563f22c53f40e41cfffdcfac32a9292292c10582183c3f1dd85770cf806bfce9",
+    "zh:586a5615898d369374d4bd7d70bc013cffe7553d3e14638f169a3f745665fee1",
+    "zh:6275f6e5697993048ac088715484a9a5e919682651e098a5ac31e567216bf102",
+    "zh:95a44bb3f012da1e036936d60df2d08f5942a96cb912fc23432d2ee050857527",
+    "zh:a5fe6b0e586645a88d98738739fec40fd7ad83dbc63fe66ff6327aee2dc07f11",
+    "zh:ea57886899b6baf466f3ff978f4482d2fd7fa049c42509cc819431375cddd5bd",
+    "zh:f021cfbe23bdb32738f170c1ae736ffb769a2fa3dcafd0f9906155c2e21377e4",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:Utnw/bDwy8p8v/i08Yx0oHdBQXwdJhCfAPZuSWX8YeQ=",
+    "zh:374c28bafc43cd65e578cb209efc9eee4c1cec7618f451528e928db98059e8c8",
+    "zh:6a2982e70fbc2ab2668d624c648ef2eb32243c1a1185246b03991a7a21326db9",
+    "zh:af83169c21bb13f141510a349e1f70cf7d893247a269bd71cad74dd22f1df0f5",
+    "zh:b81a5bedc91a1a81b938c393247248d6c3d1bd8ea685541f9c858908c0afb6b3",
+    "zh:de15486244af2d29d44d510d647cd6e0b1408e89952261013c572b7c9bfd744b",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/time" {
+  version     = "0.12.1"
+  constraints = ">= 0.5.0"
+  hashes = [
+    "h1:BeB0tURFcd5MQIjLdqpZSFYAXpj3WBI8qstoCHW0WYA=",
+    "zh:50a9b67d5f5f42adbdb7712f67858aa64b5670070f6710751239b535fb48a4df",
+    "zh:5a846fae035e363aed75b966d64a56f3489a38083e8407aaa656730437f53ed7",
+    "zh:6767f1fc8a679b48eaa4cd114da0d8185fb3546375f3a0fb3728f10fa3dbc551",
+    "zh:85d3da407c828bf057cbc0e86c75ef3d0f9f74a73c4ea1b4aef18e33f41092b1",
+    "zh:9180721325139431112c638f5382a740ff219782f81d6346cdff5bccc418a43f",
+    "zh:9ba9989f905a64db1409a9a57649549c89c7aedfb55ae399a7fa9411aafaadac",
+    "zh:b3d9e7afb6a742e9be0541bc434b00d849fdfab0b4b859ceb0296c26c541af15",
+    "zh:c87da712d718acd9dd03f544b020c320699cb29df197be4f74783e3c3d80fc17",
+    "zh:cb1abe07638ef6d7b41d0e86dfb12d60a513aca3395a5da7191947f7459821dd",
+    "zh:ecff2e823ef49eda03663fa8ee8bdc17d27cd419dbdacbf1719f38812dbf417e",
+  ]
+}

--- a/.jjconflict-side-1/infra/shikanime-google-cloud/iam.tf
+++ b/.jjconflict-side-1/infra/shikanime-google-cloud/iam.tf
@@ -1,0 +1,59 @@
+resource "google_iam_workload_identity_pool" "tfc" {
+  project                   = module.project.project_id
+  workload_identity_pool_id = "tfc-pool"
+  display_name              = "TFC"
+  description               = "Identity pool for Terraform Cloud Dynamic Credentials integration"
+}
+
+resource "google_iam_workload_identity_pool_provider" "tfc" {
+  project                            = module.project.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.tfc.workload_identity_pool_id
+  workload_identity_pool_provider_id = "tfc-provider"
+  display_name                       = "TFC"
+  description                        = "OIDC identity pool provider for Terraform Cloud Dynamic Credentials integration"
+  # Use condition to make sure only token generated for a specific TFC Org can be used across org workspaces
+  attribute_condition = "attribute.terraform_organization_id == \"${var.terraform_organization}\""
+  attribute_mapping = {
+    "google.subject"                        = "assertion.sub"
+    "attribute.aud"                         = "assertion.aud"
+    "attribute.terraform_run_phase"         = "assertion.terraform_run_phase"
+    "attribute.terraform_project_id"        = "assertion.terraform_project_id",
+    "attribute.terraform_project_name"      = "assertion.terraform_project_name",
+    "attribute.terraform_workspace_id"      = "assertion.terraform_workspace_id"
+    "attribute.terraform_workspace_name"    = "assertion.terraform_workspace_name"
+    "attribute.terraform_organization_id"   = "assertion.terraform_organization_id"
+    "attribute.terraform_organization_name" = "assertion.terraform_organization_name"
+    "attribute.terraform_run_id"            = "assertion.terraform_run_id"
+    "attribute.terraform_full_workspace"    = "assertion.terraform_full_workspace"
+  }
+  oidc {
+    issuer_uri = "https://app.terraform.io/"
+  }
+}
+
+module "service_accounts_iam" {
+  source  = "terraform-google-modules/iam/google//modules/service_accounts_iam"
+  version = "~> 7.6"
+
+  service_accounts = module.service_accounts.emails_list
+  project          = module.project.project_id
+  bindings = {
+    "roles/iam.workloadIdentityUser" = [
+      "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.tfc.name}/attribute.terraform_project_id/${var.terraform_project}"
+    ]
+  }
+}
+
+module "projects_iam" {
+  source  = "terraform-google-modules/iam/google//modules/projects_iam"
+  version = "~> 7.7"
+
+  projects = [
+    module.project.project_id,
+  ]
+
+  bindings = {
+    "roles/owner"  = var.members.owner,
+    "roles/editor" = var.members.cloud,
+  }
+}

--- a/.jjconflict-side-1/infra/shikanime-google-cloud/install.sh
+++ b/.jjconflict-side-1/infra/shikanime-google-cloud/install.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+output=$(tofu -chdir="$(dirname "$0")/../shikanime-hcp" output -json)
+projects=$(echo "$output" | jq -r '.projects.value')
+
+echo "$projects" | jq -r '.studio' >"$(dirname "$0")/studio.tfvars.json"
+echo "$projects" | jq -r '.["studio-labs"]' >"$(dirname "$0")/studio-labs.tfvars.json"

--- a/.jjconflict-side-1/infra/shikanime-google-cloud/project.tf
+++ b/.jjconflict-side-1/infra/shikanime-google-cloud/project.tf
@@ -1,0 +1,10 @@
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 15.0"
+
+  name            = var.name
+  org_id          = var.org
+  billing_account = var.billing_account
+  project_sa_name = "project-operator"
+  activate_apis   = var.enabled_apis
+}

--- a/.jjconflict-side-1/infra/shikanime-google-cloud/sa.tf
+++ b/.jjconflict-side-1/infra/shikanime-google-cloud/sa.tf
@@ -1,0 +1,12 @@
+module "service_accounts" {
+  source  = "terraform-google-modules/service-accounts/google"
+  version = "~> 3.0"
+
+  project_id   = module.project.project_id
+  names        = ["infra-operator"]
+  display_name = "Infrastructure Operator Service Account"
+
+  project_roles = [
+    "${module.project.project_id}=>roles/editor",
+  ]
+}

--- a/.jjconflict-side-1/infra/shikanime-google-cloud/variable.tf
+++ b/.jjconflict-side-1/infra/shikanime-google-cloud/variable.tf
@@ -1,0 +1,42 @@
+variable "name" {
+  type        = string
+  description = "The name for the project"
+}
+
+variable "org" {
+  type        = string
+  description = "The organization ID"
+}
+
+variable "billing_account" {
+  type        = string
+  description = "The ID of the billing account to associate this project with"
+}
+
+variable "location" {
+  type        = string
+  description = "The location for the resources"
+}
+
+variable "enabled_apis" {
+  type        = list(string)
+  description = "List of APIs to enable"
+}
+
+variable "members" {
+  type = object({
+    owner = list(string)
+    cloud = list(string)
+  })
+  description = "List of members to grant roles"
+}
+
+variable "terraform_project" {
+  type        = string
+  description = "The HCP project ID"
+}
+
+variable "terraform_organization" {
+  type        = string
+  description = "The HCP organization ID"
+}

--- a/.jjconflict-side-1/infra/shikanime-google-cloud/version.tf
+++ b/.jjconflict-side-1/infra/shikanime-google-cloud/version.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = "~> 1.0"
+  backend "remote" {
+    hostname     = "app.terraform.io"
+    organization = "shikanime-studio"
+    workspaces {
+      prefix = "shikanime-google-cloud-"
+    }
+  }
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.36"
+    }
+  }
+}

--- a/.jjconflict-side-1/infra/shikanime-hcp/output.tf
+++ b/.jjconflict-side-1/infra/shikanime-hcp/output.tf
@@ -1,0 +1,53 @@
+output "projects" {
+  value = {
+    studio = {
+      name            = "shikanime-studio"
+      org             = ""
+      billing_account = "018C2E-353598-F0F3A5"
+      location        = "europe-west1"
+      enabled_apis = [
+        "artifactregistry.googleapis.com",
+        "cloudresourcemanager.googleapis.com",
+        "compute.googleapis.com",
+        "iam.googleapis.com",
+        "iamcredentials.googleapis.com",
+        "run.googleapis.com",
+        "serviceusage.googleapis.com",
+      ]
+      members = {
+        owner = ["user:shikalegend@gmail.com"]
+        cloud = ["group:shikanime-studio-cloud@googlegroups.com"]
+      }
+      terraform_project      = "prj-NCaGDhtLX1Qaox7L"
+      terraform_organization = "org-ZuQrk9oiA78Cy3Ls"
+    }
+    studio-labs = {
+      name            = "shikanime-studio-labs"
+      org             = ""
+      billing_account = "018C2E-353598-F0F3A5"
+      location        = "europe-west1"
+      enabled_apis = [
+        "aiplatform.googleapis.com",
+        "artifactregistry.googleapis.com",
+        "cloudresourcemanager.googleapis.com",
+        "compute.googleapis.com",
+        "datacatalog.googleapis.com",
+        "dataflow.googleapis.com",
+        "dataform.googleapis.com",
+        "datalineage.googleapis.com",
+        "iam.googleapis.com",
+        "iamcredentials.googleapis.com",
+        "notebooks.googleapis.com",
+        "run.googleapis.com",
+        "serviceusage.googleapis.com",
+        "visionai.googleapis.com",
+      ]
+      members = {
+        owner = ["user:shikalegend@gmail.com"]
+        cloud = ["group:shikanime-studio-cloud@googlegroups.com"]
+      }
+      terraform_project      = "prj-qGuaiqVzKAr318n6"
+      terraform_organization = "org-ZuQrk9oiA78Cy3Ls"
+    }
+  }
+}

--- a/.jjconflict-side-1/infra/shikanime-hcp/version.tf
+++ b/.jjconflict-side-1/infra/shikanime-hcp/version.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.8"
+  cloud {
+    hostname     = "app.terraform.io"
+    organization = "shikanime-studio"
+    workspaces {
+      name = "shikanime-hcp"
+    }
+  }
+}

--- a/.jjconflict-side-1/modules/darwin/profiles/base.nix
+++ b/.jjconflict-side-1/modules/darwin/profiles/base.nix
@@ -1,0 +1,74 @@
+{ config, pkgs, ... }:
+
+let
+  # Defaults (cpu, cpufreq, diskstats, filesystem, loadavg, meminfo,
+  # netdev, stat, systemd, processes, thermal_zone) — same set the
+  # victoria-metrics-k8s-stack node-exporter DaemonSet uses on servers.
+  vmagentConfig = pkgs.writeText "vmagent.yml" ''
+    scrape_configs:
+      - job_name: "node"
+        static_configs:
+          - targets: ["127.0.0.1:9100"]
+      - job_name: "comin"
+        static_configs:
+          - targets: ["127.0.0.1:4243"]
+  '';
+in
+{
+  imports = [
+    ./minimal.nix
+  ];
+
+  nix = {
+    extraOptions = ''
+      !include ${config.sops.templates.nix-config.path}
+    '';
+    settings.experimental-features = "flakes nix-command";
+  };
+
+  sops = {
+    secrets.nix-access-token = { };
+    templates.nix-config.content = ''
+      extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}"
+    '';
+  };
+
+  services.comin = {
+    enable = true;
+    # Node exporter listens on localhost only — vmagent scrapes from 127.0.0.1.
+    exporter.listen_address = "127.0.0.1";
+    remotes = [
+      {
+        name = "origin";
+        url = "https://github.com/shikanime-labs/machines.git";
+      }
+    ];
+  };
+
+  launchd.daemons = {
+    node-exporter = {
+      command = "${pkgs.prometheus-node-exporter}/bin/node_exporter --web.listen-address=127.0.0.1:9100";
+      serviceConfig = {
+        Label = "org.nixos.node-exporter";
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/var/log/node-exporter.log";
+        StandardErrorPath = "/var/log/node-exporter.log";
+      };
+    };
+    vmagent = {
+      command = ''
+        ${pkgs.victoriametrics}/bin/vmagent \
+          -promscrape.config=${vmagentConfig} \
+          -remoteWrite.url=https://telemetry.taila659a.ts.net/insert/0/prometheus
+      '';
+      serviceConfig = {
+        Label = "org.nixos.vmagent";
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/var/log/vmagent.log";
+        StandardErrorPath = "/var/log/vmagent.log";
+      };
+    };
+  };
+}

--- a/.jjconflict-side-1/modules/darwin/profiles/distributed.nix
+++ b/.jjconflict-side-1/modules/darwin/profiles/distributed.nix
@@ -1,0 +1,56 @@
+{ config, ... }:
+
+let
+  mkHostname = hostName: "${hostName}.taila659a.ts.net";
+
+  mkBeelinkBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "x86_64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 4;
+    speedFactor = 2;
+    supportedFeatures = [
+      "nixos-test"
+      "benchmark"
+      "big-parallel"
+      "kvm"
+    ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkRpiBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "aarch64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 2;
+    speedFactor = 1;
+    supportedFeatures = [ "nixos-test" ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkBuildMachines = machines: builtins.filter (m: config.networking.hostName != m.hostName) machines;
+in
+{
+  nix = {
+    buildMachines = mkBuildMachines [
+      (mkBeelinkBuildMachine "ashira")
+      (mkBeelinkBuildMachine "manash")
+      (mkBeelinkBuildMachine "nalsha")
+      (mkRpiBuildMachine "fushi")
+      (mkRpiBuildMachine "minish")
+      (mkRpiBuildMachine "nemishi")
+    ];
+
+    distributedBuilds = true;
+
+    linux-builder = {
+      enable = false;
+      ephemeral = true;
+      systems = [ "aarch64-linux" ];
+    };
+
+    settings.builders-use-substitutes = true;
+  };
+}

--- a/.jjconflict-side-1/modules/darwin/profiles/minimal.nix
+++ b/.jjconflict-side-1/modules/darwin/profiles/minimal.nix
@@ -1,0 +1,32 @@
+{
+  # Make home-manager use packages from system
+  home-manager = {
+    backupFileExtension = "backup-before-nix";
+    useGlobalPkgs = true;
+    useUserPackages = true;
+  };
+
+  nix = {
+    gc = {
+      automatic = true;
+      options = "--delete-older-than 30d";
+      interval = [ { Weekday = 7; } ];
+    };
+
+    optimise = {
+      automatic = true;
+      interval = [ { Weekday = 7; } ];
+    };
+
+    settings = {
+      download-buffer-size = 524288000;
+      trusted-users = [ "@admin" ];
+    };
+  };
+
+  # This value determines the Darwin release from which the default
+  # settings for stateful data, like file locations and database versions
+  # on your system were taken It‘s perfectly fine and recommended to leave
+  # this value at the release version of the first install of this system
+  system.stateVersion = 6;
+}

--- a/.jjconflict-side-1/modules/darwin/profiles/workstation.nix
+++ b/.jjconflict-side-1/modules/darwin/profiles/workstation.nix
@@ -1,0 +1,59 @@
+{
+  imports = [
+    ./base.nix
+  ];
+
+  homebrew = {
+    enable = true;
+    enableZshIntegration = true;
+    brews = [
+      "mas"
+      "mpv"
+      "openssl"
+      "pinentry-mac"
+      "pinentry"
+      "pkg-config"
+    ];
+    casks = [
+      "affinity"
+      "android-studio"
+      "appcleaner"
+      "dbeaver-community"
+      "discord"
+      "element"
+      "firefox"
+      "google-chrome"
+      "google-drive"
+      "jellyfin-media-player"
+      "lm-studio"
+      "macfuse"
+      "mattermost"
+      "microsoft-edge"
+      "microsoft-teams"
+      "obs"
+      "rancher"
+      "spotify"
+      "syncthing-app"
+      "tailscale-app"
+      "transmission"
+      "windows-app"
+      "wireshark-app"
+      "xquartz"
+      "zen"
+      "zoom"
+    ];
+    masApps = {
+      Amphetamine = 937984704;
+      Bitwarden = 1352778147;
+      Velja = 1607635845;
+      Xcode = 497799835;
+    };
+  };
+
+  programs.zsh.enable = true;
+
+  programs.gnupg.agent = {
+    enable = true;
+    enableSSHSupport = true;
+  };
+}

--- a/.jjconflict-side-1/modules/darwin/users/shikanimedeva.nix
+++ b/.jjconflict-side-1/modules/darwin/users/shikanimedeva.nix
@@ -1,0 +1,85 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  toDhall = generators.toDhall { };
+in
+{
+  imports = [
+    ../../../modules/home/ai.nix
+    ../../../modules/home/base.nix
+    ../../../modules/home/cloud.nix
+    ../../../modules/home/fontconfig.nix
+    ../../../modules/home/ghostty.nix
+    ../../../modules/home/helix.nix
+    ../../../modules/home/starship.nix
+    ../../../modules/home/vcs.nix
+    ../../../modules/home/workstation.nix
+    ../../../modules/home/zed-editor.nix
+  ];
+
+  identities = {
+    enable = true;
+
+    ghstack.enable = true;
+
+    glab.enable = true;
+
+    gouv = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native"
+      ];
+    };
+
+    operator-6o = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/operator6o";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/operator6o"
+      ];
+    };
+
+    shikanime.enable = true;
+  };
+
+  home.sessionVariables.SSH_AUTH_SOCK = "${config.home.homeDirectory}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock";
+
+  programs = {
+    bash.enable = true;
+
+    docker-cli = {
+      contexts.rancher-desktop = {
+        Endpoints = {
+          docker = {
+            Host = "unix://${config.home.homeDirectory}/.rd/docker.sock";
+            SkipTLSVerify = false;
+          };
+        };
+        Metadata.Description = "Rancher Desktop moby context";
+      };
+      settings = {
+        credsStore = "osxkeychain";
+        currentContext = "rancher-desktop";
+      };
+    };
+
+    zsh.enable = true;
+  };
+
+  sops = {
+    age.keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
+    defaultSopsFile = ../../../secrets/shikanime.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets.cachix-token = { };
+    templates.cachix-config.content = toDhall {
+      authToken = config.sops.placeholder.cachix-token;
+      hostname = "https://cachix.org";
+    };
+  };
+
+  xdg.configFile."cachix/cachix.dhall".source =
+    config.lib.file.mkOutOfStoreSymlink config.sops.templates.cachix-config.path;
+}

--- a/.jjconflict-side-1/modules/flake/darwin.nix
+++ b/.jjconflict-side-1/modules/flake/darwin.nix
@@ -1,0 +1,29 @@
+{ self, ... }:
+{ inputs, ... }:
+
+{
+  flake = {
+    darwinConfigurations.telsha = inputs.nix-darwin.lib.darwinSystem {
+      pkgs = import inputs.nixpkgs {
+        system = "aarch64-darwin";
+        config.allowUnfree = true;
+      };
+      modules = [
+        ../../hosts/telsha/darwin-configuration.nix
+        inputs.home-manager.darwinModules.default
+        inputs.comin.darwinModules.comin
+        inputs.sops-nix.darwinModules.default
+        {
+          home-manager.sharedModules = [
+            inputs.catppuccin.homeModules.default
+            inputs.colemak.homeModules.default
+            inputs.devlib.homeModules.default
+            inputs.identities.homeModules.default
+            inputs.sops-nix.homeModules.default
+          ];
+        }
+      ];
+    };
+    packages.aarch64-darwin.telsha = self.darwinConfigurations.telsha.system;
+  };
+}

--- a/.jjconflict-side-1/modules/flake/devenv.nix
+++ b/.jjconflict-side-1/modules/flake/devenv.nix
@@ -1,0 +1,197 @@
+{ inputs, ... }:
+
+{
+  perSystem =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      toml = pkgs.formats.toml { };
+    in
+    {
+      devenv.shells.default = {
+        imports = [
+          inputs.devlib.devenvModules.git
+          inputs.devlib.devenvModules.nix
+          inputs.devlib.devenvModules.opentofu
+          inputs.devlib.devenvModules.shell
+          inputs.devlib.devenvModules.shikanime
+          inputs.identities.devenvModules.default
+        ];
+
+        identities = {
+          enable = true;
+          ishtar.enable = true;
+          nixtar.enable = true;
+          telsha.enable = true;
+        };
+
+        github = {
+          settings.workflows = {
+            integration = {
+              jobs.skaffold = {
+                needs = [ "nix" ];
+                secrets.CACHIX_AUTH_TOKEN = "\${{ secrets.CACHIX_AUTH_TOKEN }}";
+              };
+              on.workflow_call.secrets.CACHIX_AUTH_TOKEN.required = lib.mkDefault true;
+            };
+
+            release = {
+              jobs.skaffold = {
+                needs = [ "nix" ];
+                secrets.CACHIX_AUTH_TOKEN = "\${{ secrets.CACHIX_AUTH_TOKEN }}";
+              };
+              on.workflow_call.secrets.CACHIX_AUTH_TOKEN.required = lib.mkDefault true;
+            };
+
+            skaffold.on.workflow_call.secrets.CACHIX_AUTH_TOKEN.required = lib.mkDefault true;
+
+            wakabox = {
+              name = "Wakabox";
+              on.schedule = [
+                { cron = "0 0 * * *"; }
+              ];
+              jobs.wakabox = {
+                runs-on = "ubuntu-latest";
+                steps = [
+                  {
+                    uses = "matchai/waka-box@v5.0.0";
+                    env = {
+                      GH_TOKEN = "\${{ secrets.WAKABOX_GITHUB_TOKEN }}";
+                      GIST_ID = "\${{ vars.WAKABOX_GITHUB_GIST_ID }}";
+                      WAKATIME_API_KEY = "\${{ secrets.WAKATIME_API_KEY }}";
+                    };
+                  }
+                ];
+              };
+              permissions.contents = "read";
+            };
+          };
+
+          workflows.skaffold = {
+            enable = true;
+            settings.setup-nix = {
+              cachix-auth-token = "\${{ secrets.CACHIX_AUTH_TOKEN }}";
+              extra-platforms = "arm64";
+            };
+          };
+        };
+
+        packages =
+          with pkgs;
+          [
+            age
+            skaffold
+          ]
+          ++ lib.optional stdenv.hostPlatform.isLinux nixos-facter;
+
+        sops = {
+          enable = true;
+          settings.creation_rules =
+            let
+              ashira = [
+                "age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph"
+              ];
+              ishtar = [
+                "age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy"
+              ];
+              fushi = [
+                "age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y"
+              ];
+              manash = [
+                "age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64"
+              ];
+              minish = [
+                "age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u"
+              ];
+              nixtar = [
+                "age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl"
+              ];
+              nalsha = [
+                "age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5"
+              ];
+              nemishi = [
+                "age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3"
+              ];
+              telsha = [
+                "age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d"
+              ];
+
+              nishir = ashira ++ fushi ++ manash ++ minish ++ nalsha ++ nemishi;
+
+              workstations = ishtar ++ nixtar ++ telsha;
+
+              identities =
+                config.devenv.shells.default.identities.ishtar.ageKeys
+                ++ config.devenv.shells.default.identities.nixtar.ageKeys
+                ++ config.devenv.shells.default.identities.telsha.ageKeys;
+            in
+            [
+              {
+                path_regex = "secrets/ashira.enc.yaml";
+                age = ashira ++ identities;
+              }
+              {
+                path_regex = "secrets/builder.enc.yaml";
+                age = identities ++ nishir ++ workstations;
+              }
+              {
+                path_regex = "secrets/fushi.enc.yaml";
+                age = fushi ++ identities;
+              }
+              {
+                path_regex = "secrets/ishtar.enc.yaml";
+                age = ishtar ++ identities;
+              }
+              {
+                path_regex = "secrets/machine.enc.yaml";
+                age = identities ++ nishir ++ workstations;
+              }
+              {
+                path_regex = "secrets/manash.enc.yaml";
+                age = manash ++ identities;
+              }
+              {
+                path_regex = "secrets/minish.enc.yaml";
+                age = minish ++ identities;
+              }
+              {
+                path_regex = "secrets/nalsha.enc.yaml";
+                age = nalsha ++ identities;
+              }
+              {
+                path_regex = "secrets/nemishi.enc.yaml";
+                age = nemishi ++ identities;
+              }
+              {
+                path_regex = "secrets/nishir.enc.yaml";
+                age = identities ++ nishir;
+              }
+              {
+                path_regex = "secrets/nixtar.enc.yaml";
+                age = nixtar ++ identities;
+              }
+              {
+                path_regex = "secrets/shikanime.enc.yaml";
+                age = identities;
+              }
+              {
+                path_regex = "secrets/telsha.enc.yaml";
+                age = telsha ++ identities;
+              }
+            ];
+        };
+
+        treefmt.config.programs.typos.configFile =
+          let
+            configFile = toml.generate "typos.toml" {
+              default.extend-words.facter = "facter";
+            };
+          in
+          toString configFile;
+      };
+    };
+}

--- a/.jjconflict-side-1/modules/flake/nixos.nix
+++ b/.jjconflict-side-1/modules/flake/nixos.nix
@@ -1,0 +1,188 @@
+{ self, ... }:
+{ inputs, ... }:
+
+let
+  aiModules = [
+    inputs.cua.nixosModules.cua-driver
+    inputs.hermes-agent.nixosModules.default
+    inputs.noctalia.nixosModules.default
+    inputs.noctalia-greeter.nixosModules.default
+  ];
+
+  baseModules = [
+    inputs.comin.nixosModules.comin
+    inputs.sops-nix.nixosModules.default
+    inputs.home-manager.nixosModules.default
+    inputs.colemak.nixosModules.default
+  ];
+
+  clusterModules = [
+    inputs.disko.nixosModules.default
+    inputs.knix.nixosModules.default
+  ];
+
+  beelinkClusterModules = [
+    inputs.nixos-hardware.nixosModules.common-cpu-intel
+    inputs.nixos-hardware.nixosModules.common-pc-ssd
+  ]
+  ++ aiModules
+  ++ baseModules
+  ++ clusterModules;
+
+  rpi4ClusterModules = [
+    inputs.nixos-hardware.nixosModules.raspberry-pi-4
+  ]
+  ++ aiModules
+  ++ baseModules
+  ++ clusterModules;
+
+  rpi5ClusterModules = [
+    inputs.nixos-hardware.nixosModules.raspberry-pi-5
+  ]
+  ++ aiModules
+  ++ baseModules
+  ++ clusterModules;
+
+  workstationHomeModules = [
+    inputs.catppuccin.homeModules.default
+    inputs.colemak.homeModules.default
+    inputs.devlib.homeModules.default
+    inputs.identities.homeModules.default
+    inputs.sops-nix.homeModules.default
+    inputs.noctalia.homeModules.default
+  ];
+
+  workstationsModules =
+    aiModules
+    ++ baseModules
+    ++ [
+      { home-manager.sharedModules = workstationHomeModules; }
+    ];
+
+  mkCatboxNixosConfiguration =
+    system:
+    inputs.nixpkgs.lib.nixosSystem {
+      pkgs = import inputs.nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+      modules = [
+        ../../hosts/catbox/configuration.nix
+      ]
+      ++ workstationsModules;
+    };
+
+  mkCatbox =
+    system:
+    let
+      catbox = mkCatboxNixosConfiguration system;
+    in
+    catbox.config.system.build.containerdiskImage;
+in
+{
+  flake = {
+    nixosConfigurations = {
+      ashira = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/ashira/configuration.nix
+        ]
+        ++ beelinkClusterModules;
+      };
+      fushi = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/fushi/configuration.nix
+        ]
+        ++ rpi4ClusterModules;
+      };
+      ishtar = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/ishtar/configuration.nix
+          inputs.nixos-hardware.nixosModules.common-cpu-intel
+          inputs.nixos-hardware.nixosModules.common-pc-ssd
+          inputs.knix.nixosModules.default
+        ]
+        ++ workstationsModules;
+      };
+      manash = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/manash/configuration.nix
+        ]
+        ++ beelinkClusterModules;
+      };
+      minish = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/minish/configuration.nix
+        ]
+        ++ rpi4ClusterModules;
+      };
+      nalsha = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nalsha/configuration.nix
+        ]
+        ++ beelinkClusterModules;
+      };
+      nemishi = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nemishi/configuration.nix
+        ]
+        ++ rpi5ClusterModules;
+      };
+      nixtar = inputs.nixpkgs.lib.nixosSystem {
+        pkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+          config.allowUnfree = true;
+        };
+        modules = [
+          ../../hosts/nixtar/configuration.nix
+          inputs.nixos-wsl.nixosModules.default
+        ]
+        ++ workstationsModules;
+      };
+    };
+
+    packages = {
+      x86_64-linux = {
+        ashira = self.nixosConfigurations.ashira.config.system.build.toplevel;
+        catbox = mkCatbox "x86_64-linux";
+        ishtar = self.nixosConfigurations.ishtar.config.system.build.toplevel;
+        manash = self.nixosConfigurations.manash.config.system.build.toplevel;
+        nalsha = self.nixosConfigurations.nalsha.config.system.build.toplevel;
+        nixtar = self.nixosConfigurations.nixtar.config.system.build.tarballBuilder;
+      };
+      aarch64-linux = {
+        catbox = mkCatbox "aarch64-linux";
+        fushi = self.nixosConfigurations.fushi.config.system.build.toplevel;
+        minish = self.nixosConfigurations.minish.config.system.build.toplevel;
+        nemishi = self.nixosConfigurations.nemishi.config.system.build.toplevel;
+      };
+    };
+  };
+}

--- a/.jjconflict-side-1/modules/home/ai.nix
+++ b/.jjconflict-side-1/modules/home/ai.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+{
+  home.packages = with pkgs; [
+    graphify
+    qwen-code
+    rtk
+  ];
+
+  programs = {
+    antigravity-cli.enable = true;
+
+    codex.enable = true;
+
+    claude-code.enable = true;
+  };
+}

--- a/.jjconflict-side-1/modules/home/base.nix
+++ b/.jjconflict-side-1/modules/home/base.nix
@@ -1,0 +1,14 @@
+{
+  # This value determines the Home Manager release that your
+  # configuration is compatible with. This helps avoid breakage
+  # when a new Home Manager release introduces backwards
+  # incompatible changes
+  #
+  # You can update Home Manager without changing this value. See
+  # the Home Manager release notes for a list of state version
+  # changes in each release
+  home.stateVersion = "26.05";
+
+  # Let Home Manager install and manage itself
+  programs.home-manager.enable = true;
+}

--- a/.jjconflict-side-1/modules/home/cloud.nix
+++ b/.jjconflict-side-1/modules/home/cloud.nix
@@ -1,0 +1,34 @@
+{ pkgs, ... }:
+
+{
+  imports = [
+    ./krew.nix
+  ];
+
+  catppuccin.k9s.enable = false;
+
+  programs = {
+    k9s = {
+      enable = true;
+      settings.k9s.ui.skin = "transparent";
+    };
+
+    ssh.settings."ssh.dev.azure.com" = {
+      HostkeyAlgorithms = "+ssh-rsa";
+      PubkeyAcceptedKeyTypes = "+ssh-rsa";
+    };
+  };
+
+  xdg.configFile."containers/policy.json".source =
+    let
+      format = pkgs.formats.json { };
+    in
+    format.generate "policy.json" {
+      default = [
+        { type = "insecureAcceptAnything"; }
+      ];
+      transports.docker-daemon = {
+        "" = [ { type = "insecureAcceptAnything"; } ];
+      };
+    };
+}

--- a/.jjconflict-side-1/modules/home/fontconfig.nix
+++ b/.jjconflict-side-1/modules/home/fontconfig.nix
@@ -1,0 +1,10 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.fira-code
+    pkgs.inriafonts
+  ];
+
+  fonts.fontconfig.enable = true;
+}

--- a/.jjconflict-side-1/modules/home/ghostty.nix
+++ b/.jjconflict-side-1/modules/home/ghostty.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+{
+  programs.ghostty = {
+    enable = true;
+    package = if pkgs.stdenv.isLinux then pkgs.ghostty else pkgs.ghostty-bin;
+    settings = {
+      theme = mkForce "dark:catppuccin-frappe,light:catppuccin-latte";
+      command = "${getExe pkgs.zsh} --login -c ${getExe pkgs.nushell}";
+    };
+  };
+
+  xdg.configFile."ghostty/themes/catppuccin-frappe".source =
+    "${config.catppuccin.sources.ghostty}/catppuccin-frappe.conf";
+}

--- a/.jjconflict-side-1/modules/home/graphical.nix
+++ b/.jjconflict-side-1/modules/home/graphical.nix
@@ -1,0 +1,23 @@
+{
+  # Global Noctalia desktop shell theme for graphical Linux hosts.
+  # NixOS-level programs.noctalia has no `settings`; theming is home-manager only,
+  # so this is the shared home module all graphical users import.
+  programs.noctalia = {
+    enable = true;
+    systemd.enable = true;
+    settings = {
+      shell.font = "Fira Code";
+      shell.greeter_sync.auto_sync = true;
+      theme = {
+        mode = "auto";
+        source = "builtin";
+        builtin = "Catppuccin";
+      };
+      location.auto_locate = true;
+
+      # DDC/CI monitor brightness control via ddcutil (already in systemPackages).
+      # Noctalia auto-detects the I2C bus per connected monitor; no manual bus address.
+      brightness.enable_ddcutil = true;
+    };
+  };
+}

--- a/.jjconflict-side-1/modules/home/helix.nix
+++ b/.jjconflict-side-1/modules/home/helix.nix
@@ -1,0 +1,24 @@
+{
+  programs.helix = {
+    defaultEditor = true;
+    enable = true;
+    settings = {
+      editor = {
+        color-modes = true;
+        cursor-shape = {
+          insert = "bar";
+          normal = "block";
+          select = "underline";
+        };
+        cursorline = true;
+        indent-guides.render = true;
+        line-number = "relative";
+      };
+      # TODO: theme is supported post 2026 september release
+      # theme = mkForce {
+      #   dark = "catppuccin-frappe";
+      #   light = "catppuccin-latte";
+      # };
+    };
+  };
+}

--- a/.jjconflict-side-1/modules/home/krew.nix
+++ b/.jjconflict-side-1/modules/home/krew.nix
@@ -1,0 +1,13 @@
+{ config, pkgs, ... }:
+
+{
+  home.packages = with pkgs; [ krew ];
+
+  home = {
+    # Make krew plugin discoverable for kubectl
+    sessionPath = [ "${config.home.homeDirectory}/.local/share/krew/bin" ];
+
+    # Plugins installation location
+    sessionVariables.KREW_ROOT = "${config.home.homeDirectory}/.local/share/krew";
+  };
+}

--- a/.jjconflict-side-1/modules/home/starship.nix
+++ b/.jjconflict-side-1/modules/home/starship.nix
@@ -1,0 +1,21 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  settings = importTOML "${config.catppuccin.sources.starship}/latte.toml";
+in
+{
+  programs.starship = {
+    enable = true;
+    settings = {
+      directory = {
+        truncation_length = 4;
+        style = "bold lavender";
+      };
+      git_branch.style = "bold mauve";
+      palette = "catppuccin_latte";
+    }
+    // settings;
+  };
+}

--- a/.jjconflict-side-1/modules/home/vcs.nix
+++ b/.jjconflict-side-1/modules/home/vcs.nix
@@ -1,0 +1,89 @@
+{ pkgs, ... }:
+
+{
+  home.packages = [
+    pkgs.git-credential-manager
+  ];
+
+  programs = {
+    delta.enable = true;
+
+    gh-dash.enable = true;
+
+    git = {
+      enable = true;
+      lfs.enable = true;
+      ignores = [
+        ".hermes/"
+        "*.graphify"
+        "graphify_output/"
+        "graphify-out/"
+        ".graphify_cache/"
+        "graphify_cache/"
+      ];
+      settings.credential.helper = "manager";
+    };
+
+    jujutsu = {
+      enable = true;
+      settings = {
+        aliases = {
+          prune = [
+            "abandon"
+            "nulls()"
+            "conflicts()"
+          ];
+          restack = [
+            "rebase"
+            "--onto"
+            "trunk()"
+            "--source"
+            "roots(trunk()..) & mutable()"
+            "--simplify-parents"
+          ];
+          stack = [
+            "rebase"
+            "--after"
+            "trunk()"
+            "--before"
+            "closest_merge(@)"
+          ];
+          stage = [
+            "stack"
+            "-r"
+            "closest_merge(@)+:: ~ empty()"
+          ];
+          fetch = [
+            "git"
+            "fetch"
+            "--all-remotes"
+          ];
+          switch = [
+            "workspace"
+            "add"
+          ];
+          push = [
+            "git"
+            "push"
+          ];
+        };
+        git.private-commits = "description(substring:\"[private]\")";
+        templates = {
+          commit_trailers = ''
+            format_signed_off_by_trailer(self)
+            ++ if(!trailers.contains_key("Change-Id"), format_gerrit_change_id_trailer(self))
+          '';
+          git_push_bookmark = "\"shikanime/push-\" ++ change_id.short()";
+        };
+        revset-aliases = {
+          "closest_merge(to)" = "heads(::to & merges())";
+          "nulls()" = "empty() & mutable()";
+        };
+        ui = {
+          default-command = "log";
+          movement.edit = true;
+        };
+      };
+    };
+  };
+}

--- a/.jjconflict-side-1/modules/home/workstation.nix
+++ b/.jjconflict-side-1/modules/home/workstation.nix
@@ -1,0 +1,107 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  mkSshHeadlessHost = user: {
+    User = user;
+    SetEnv.TERM = "xterm-256color";
+  };
+
+  mkSshWorkstationHost = user: {
+    ForwardX11 = true;
+    User = user;
+    SetEnv.TERM = "xterm-256color";
+  };
+in
+{
+  catppuccin = {
+    enable = true;
+    flavor = "latte";
+  };
+
+  colemak.enable = true;
+
+  home = {
+    packages = with pkgs; [
+      cachix
+      devenv
+      docker-credential-helpers
+      pass
+      qpdf
+      rclone
+      secretspec
+      wget
+      zip
+    ];
+    sessionPath = [ "${config.home.homeDirectory}/.local/bin" ];
+  };
+
+  programs = {
+    bat.enable = true;
+
+    carapace.enable = true;
+
+    command-not-found.enable = true;
+
+    dircolors.enable = true;
+
+    direnv = {
+      enable = true;
+      mise.enable = true;
+      nix-direnv.enable = true;
+      config.global.load_dotenv = true;
+    };
+
+    docker-cli.enable = true;
+
+    gpg.enable = true;
+
+    jujutsu.settings."merge-tools".mergiraf."merge-tool-edits-conflict-markers" = true;
+
+    mergiraf = {
+      enable = true;
+      enableGitIntegration = true;
+      enableJujutsuIntegration = true;
+    };
+
+    mise.enable = true;
+
+    nushell = {
+      enable = true;
+      extraConfig = ''
+        $env.config.show_banner = false
+
+        source ${pkgs.nu_scripts}/share/nu_scripts/custom-completions/vscode/vscode-completions.nu
+      '';
+    };
+
+    pay-respects.enable = true;
+
+    ripgrep.enable = true;
+
+    ssh = {
+      enable = true;
+      settings = {
+        "ashira.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "catbox.taila659a.ts.net" = mkSshHeadlessHost "shika";
+        "fushi.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "manash.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "minish.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "nalsha.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "nemishi.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "ishtar.taila659a.ts.net" = mkSshWorkstationHost "shika";
+        "thinkcentre-m710t.tailfb4bb2.ts.net" = mkSshWorkstationHost "william-phetsinorath";
+      };
+    };
+
+    zoxide.enable = true;
+  };
+
+  xdg.enable = true;
+}

--- a/.jjconflict-side-1/modules/home/zed-editor.nix
+++ b/.jjconflict-side-1/modules/home/zed-editor.nix
@@ -1,0 +1,76 @@
+{ lib, pkgs, ... }:
+
+with lib;
+
+{
+  programs.zed-editor = {
+    enable = true;
+
+    userSettings = {
+      agent = {
+        default_model = {
+          provider = "Hermes Agent";
+          model = "hermes-agent";
+          enable_thinking = true;
+        };
+      };
+
+      agent_servers = {
+        "Hermes Agent" = {
+          type = "custom";
+          command = "hermes";
+          args = [ "acp" ];
+        };
+      };
+
+      icon_theme = mkForce {
+        mode = "system";
+        light = "Catppuccin Latte";
+        dark = "Catppuccin Frappé";
+      };
+
+      language_models = {
+        openai_compatible = {
+          "Hermes Agent" = {
+            api_url = "http://localhost:8642/v1";
+            available_models = [
+              {
+                name = "hermes-agent";
+                max_tokens = 200000;
+                max_output_tokens = 32000;
+                max_completion_tokens = 200000;
+                capabilities = {
+                  tools = true;
+                  images = true;
+                  parallel_tool_calls = true;
+                  prompt_cache_key = true;
+                  chat_completions = true;
+                };
+              }
+            ];
+          };
+        };
+      };
+
+      helix_mode = true;
+
+      relative_line_numbers = "enabled";
+
+      terminal.shell.with_arguments = {
+        program = "${getExe pkgs.zsh}";
+        args = [
+          "-c"
+          "${getExe pkgs.nushell}"
+        ];
+      };
+
+      theme = {
+        mode = "system";
+        light = mkForce "Catppuccin Latte";
+        dark = mkForce "Catppuccin Frappé";
+      };
+
+      vim_mode = true;
+    };
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/hardware/beelink-eq.nix
+++ b/.jjconflict-side-1/modules/nixos/hardware/beelink-eq.nix
@@ -1,0 +1,94 @@
+{ pkgs, ... }:
+
+{
+  boot = {
+    binfmt.emulatedSystems = [ "aarch64-linux" ];
+    loader = {
+      efi.canTouchEfiVariables = true;
+      systemd-boot.enable = true;
+    };
+  };
+
+  disko.devices.disk.main = {
+    type = "disk";
+    device = "/dev/nvme0n1";
+    content = {
+      type = "gpt";
+      partitions = {
+        ESP = {
+          size = "1G";
+          type = "EF00";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+            mountOptions = [ "umask=0077" ];
+          };
+        };
+        root = {
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "xfs";
+            mountpoint = "/";
+          };
+        };
+      };
+    };
+  };
+
+  # Intel N150 needs firmware plus userspace graphics/QSV libraries so the
+  # Jellyfin pod can use VAAPI/QSV via /dev/dri/renderD128.
+  hardware.enableRedistributableFirmware = true;
+
+  hardware.graphics = {
+    enable = true;
+    enable32Bit = true;
+  };
+
+  services.fstrim.enable = true;
+
+  networking = {
+    useNetworkd = true;
+
+    # balance-alb (mode 6): aggregates both 2.5G NICs without switch-side LACP.
+    # The NETGEAR MS308 is unmanaged — balance-alb handles load balancing
+    # entirely in the Linux driver via ARP negotiation.
+    bonds.bond0 = {
+      interfaces = [
+        "enp1s0"
+        "enp2s0"
+      ];
+      driverOptions = {
+        mode = "balance-alb";
+        miimon = "100";
+      };
+    };
+
+    bridges.br0.interfaces = [ "bond0" ];
+  };
+
+  # NIC performance tuning: hardware offloads + RPS for both Intel i226-V ports.
+  systemd.services.network-nic-performance = {
+    after = [ "network-online.target" ];
+    description = "Enable NIC hardware offloads and RPS";
+    script = ''
+      for iface in enp1s0 enp2s0; do
+        ip link show "$iface" >/dev/null 2>&1 || continue
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" rx-udp-gro-forwarding on rx-gro-list off
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" tso on gso on sg on tx on rx on 2>/dev/null || true
+        for rxq in /sys/class/net/"$iface"/queues/rx-*; do
+          echo f > "$rxq"/rps_cpus 2>/dev/null || true
+        done
+      done
+    '';
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    wantedBy = [ "multi-user.target" ];
+    wants = [ "network-online.target" ];
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/hardware/razer-blade.nix
+++ b/.jjconflict-side-1/modules/nixos/hardware/razer-blade.nix
@@ -1,0 +1,19 @@
+{
+  # UEFI laptop bootloader (Razer Blade 17, 2019). Windows dual-boot via systemd-boot.
+  # Windows entry is automatically detected by systemd-boot.
+  boot.loader = {
+    efi.canTouchEfiVariables = true;
+    systemd-boot.enable = true;
+  };
+
+  # Razer Blade 17 peripherals: daemon + udev rules.
+  hardware.openrazer.enable = true;
+
+  # CPU/device power management + suspend-on-lid-close.
+  powerManagement.enable = true;
+
+  services = {
+    fstrim.enable = true;
+    udisks2.enable = true;
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/hardware/rpi.nix
+++ b/.jjconflict-side-1/modules/nixos/hardware/rpi.nix
@@ -1,0 +1,55 @@
+{ pkgs, ... }:
+
+{
+  boot.kernelParams = [
+    # Older Raspberry Pi-class boards still need these cgroup knobs for RKE2.
+    "cgroup_enable=cpuset"
+    "cgroup_enable=memory"
+    "cgroup_memory=1"
+    # Disable USB runtime autosuspend; external SSD drops offline under load
+    "usbcore.autosuspend=-1"
+    # Bind SABRENT/JMicron enclosure to usb-storage, bypassing UASP
+    "usb-storage.quirks=152d:a578:u"
+  ];
+
+  # Silences Raspberry Pi firmware debug flooding on all RPi hosts through
+  # fushi/nemishi/minish. 4 = warnings and above still appear.
+  boot.consoleLogLevel = 4;
+
+  nixpkgs.overlays = [
+    (_: super: {
+      makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
+    })
+  ];
+
+  networking = {
+    useNetworkd = true;
+
+    # Single NIC bridge — all traffic (flannel, SSH, Longhorn) on one wire.
+    bridges.br0.interfaces = [ "end0" ];
+  };
+
+  # NIC performance tuning: hardware offloads + RPS for the USB3 GigE port.
+  systemd.services.network-nic-performance = {
+    after = [ "network-online.target" ];
+    description = "Enable NIC hardware offloads and RPS";
+    script = ''
+      for iface in end0; do
+        ip link show "$iface" >/dev/null 2>&1 || continue
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" rx-udp-gro-forwarding on rx-gro-list off
+        ${pkgs.ethtool}/bin/ethtool -K "$iface" tso on gso on sg on tx on rx on 2>/dev/null || true
+        for rxq in /sys/class/net/"$iface"/queues/rx-*; do
+          echo f > "$rxq"/rps_cpus 2>/dev/null || true
+        done
+      done
+    '';
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    wantedBy = [ "multi-user.target" ];
+    wants = [ "network-online.target" ];
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/hardware/rpi4.nix
+++ b/.jjconflict-side-1/modules/nixos/hardware/rpi4.nix
@@ -1,0 +1,11 @@
+{
+  imports = [
+    ./rpi.nix
+  ];
+
+  hardware.raspberry-pi."4".fkms-3d.enable = true;
+
+  # Disable UAS for external USB drives - use more stable usb-storage
+  # Blacklist UAS kernel module to prevent crashes on VL805
+  boot.blacklistedKernelModules = [ "uas" ];
+}

--- a/.jjconflict-side-1/modules/nixos/hardware/rpi5.nix
+++ b/.jjconflict-side-1/modules/nixos/hardware/rpi5.nix
@@ -1,0 +1,20 @@
+{
+  imports = [
+    ./rpi.nix
+  ];
+
+  # Install the firmware specifically for the Raspberry Pi 5
+  # because the nixpkgs doesn't provide it by default anymore
+  # up to Raspberry Pi 4
+  hardware.raspberry-pi.firmware = {
+    enable = true;
+    uboot.enable = true;
+  };
+
+  boot.kernelParams = [
+    # Probe error -12 (ENOMEM) is also hit when the default 64 MiB CMA pool is too
+    # small for the NVMe admin queue / PRP DMA buffers. Bump it so the driver can
+    # allocate. Confirmed: without cma=512M the probe fails even with the overlay.
+    "cma=512M"
+  ];
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/agent.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/agent.nix
@@ -1,0 +1,16 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./machine.nix
+  ];
+
+  services.knix = {
+    enable = true;
+    role = "agent";
+    serverAddr = "https://192.168.1.28:9345";
+    tokenFile = config.sops.secrets.rke2-token.path;
+  };
+
+  sops.secrets.rke2-token.restartUnits = [ "rke2-agent.service" ];
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/ai.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/ai.nix
@@ -1,0 +1,221 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+{
+  # cargo.nix / dist.nix-style: addToSystemPackages = true + extraPackages -> cargo.nix inherits?
+  services.hermes-agent = {
+    enable = true;
+    addToSystemPackages = true;
+    environmentFiles = [
+      config.sops.templates.hermes-agent-env.path
+      config.sops.templates.hermes-agent-matrix-env.path
+    ];
+    extraPackages = with pkgs; [
+      curl
+      corepack
+      gh
+      git
+      graphify
+      honcho
+      nodejs
+      rtk
+      yarn
+    ];
+    settings = {
+      context.engine = "lcm";
+      custom_providers = [
+        {
+          name = "aperture-anthropic";
+          base_url = "https://ai.taila659a.ts.net/v1";
+          api_mode = "anthropic_messages";
+          model = "glm-4.7";
+          models = [
+            "glm-4.7"
+            "glm-5.2"
+          ];
+        }
+        {
+          name = "aperture-openai";
+          base_url = "https://ai.taila659a.ts.net/v1";
+          api_mode = "chat_completions";
+          model = "stepfun/step-3.7-flash:free";
+          models = [
+            "tencent/hy3:free"
+            "mistral/labs-leanstral-1-5"
+            "openrouter/openrouter/free"
+            "stepfun/step-3.7-flash:free"
+          ];
+        }
+      ];
+      documents."honcho.json" = builtins.toJSON {
+        baseUrl = "https://honcho.taila659a.ts.net";
+        hosts.hermes = {
+          peerName = config.networking.hostName;
+          aiPeer = "telsha";
+          workspace = "hermes";
+          observationMode = "directional";
+          writeFrequency = "async";
+          recallMode = "hybrid";
+          dialecticCadence = 3;
+          sessionStrategy = "per-session";
+          enabled = true;
+          saveMessages = true;
+          dialecticReasoningLevel = "low";
+          pinPeerName = false;
+        };
+      };
+      fallback_providers = [
+        {
+          api_mode = "chat_completions";
+          model = "poolside/laguna-s-2.1:free";
+          provider = "custom:aperture-openai";
+        }
+        {
+          api_mode = "chat_completions";
+          model = "labs-leanstral-1-5";
+          provider = "custom:aperture-openai";
+        }
+        {
+          api_mode = "chat_completions";
+          model = "stepfun/step-3.7-flash:free";
+          provider = "custom:aperture-openai";
+        }
+      ];
+      matrix = {
+        allowed_rooms = [ "!QUaAaCBlSIBcYyOyLb:matrix.taila659a.ts.net" ];
+        allowed_users = [
+          "@admin:matrix.taila659a.ts.net"
+          "@shikanime:matrix.taila659a.ts.net"
+        ];
+      };
+      memory.provider = "honcho";
+      model = {
+        default = "tencent/hy3:free";
+        provider = "custom:aperture-openai";
+        base_url = "https://ai.taila659a.ts.net/v1";
+      };
+      auxiliary = {
+        vision = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        web_extract = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        compression = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        skills_hub = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        approval = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        mcp = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        title_generation = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        memory_query_rewrite = {
+          provider = "custom:aperture-anthropic:openai";
+          model = "auxiliary";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        tts_audio_tags = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        triage_specifier = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        kanban_decomposer = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        profile_describer = {
+          provider = "custom:aperture-openai";
+          model = "openrouter/openrouter/free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+      };
+      mcp_servers.aperture = {
+        url = "https://ai.taila659a.ts.net/mcp";
+        enabled = true;
+      };
+      # Bare `hermes`/`hermes chat` launches the Ink TUI by default; token
+      # streaming on for live agent output. Explicit --cli/--tui still wins.
+      display = {
+        interface = "tui";
+        streaming = true;
+      };
+    };
+    extraDependencyGroups = [
+      "computer-use"
+      "honcho"
+      "matrix"
+    ];
+  };
+
+  sops = {
+    secrets = {
+      hermes-agent-api-server-key = {
+        group = "hermes";
+        owner = "hermes";
+        restartUnits = [ "hermes-agent.service" ];
+      };
+      hermes-agent-matrix-access-token = {
+        group = "hermes";
+        owner = "hermes";
+        restartUnits = [ "hermes-agent.service" ];
+      };
+      hermes-agent-matrix-recovery-key = {
+        group = "hermes";
+        owner = "hermes";
+        restartUnits = [ "hermes-agent.service" ];
+        mode = "0600";
+      };
+    };
+    templates = {
+      hermes-agent-env = {
+        content = ''
+          API_SERVER_ENABLED=true
+          API_SERVER_KEY=${config.sops.placeholder.hermes-agent-api-server-key}
+        '';
+      };
+      hermes-agent-matrix-env = {
+        content = ''
+          MATRIX_HOMESERVER=https://matrix.taila659a.ts.net/
+          MATRIX_ACCESS_TOKEN=${config.sops.placeholder.hermes-agent-matrix-access-token}
+          MATRIX_E2EE_MODE=required
+          MATRIX_HOME_ROOM=!QUaAaCBlSIBcYyOyLb:matrix.taila659a.ts.net
+          MATRIX_RECOVERY_KEY_FILE=${config.sops.secrets.hermes-agent-matrix-recovery-key.path}
+        '';
+        restartUnits = [ "hermes-agent.service" ];
+      };
+    };
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/base.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/base.nix
@@ -1,0 +1,119 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./minimal.nix
+  ];
+
+  nix = {
+    extraOptions = ''
+      !include ${config.sops.templates.nix-config.path}
+    '';
+    settings.experimental-features = [
+      "flakes"
+      "nix-command"
+    ];
+  };
+
+  sops = {
+    secrets.nix-access-token.reloadUnits = [ "nix-daemon.service" ];
+    templates.nix-config.content = ''
+      extra-access-tokens = "github.com=${config.sops.placeholder.nix-access-token}"
+    '';
+  };
+
+  services = {
+    comin = {
+      enable = true;
+      # Node exporter listens on localhost only — vmagent scrapes from 127.0.0.1.
+      exporter.listen_address = "127.0.0.1";
+      remotes = [
+        {
+          name = "origin";
+          url = "https://github.com/shikanime-labs/machines.git";
+        }
+        {
+          name = "origin";
+          url = "https://forgejo.taila659a.ts.net/shikanime-labs/machines.git";
+        }
+      ];
+    };
+
+    # Local host metrics pipeline: node_exporter -> vmagent -> vminsert.
+    prometheus.exporters = {
+      node = {
+        enable = true;
+        listenAddress = "127.0.0.1";
+        disabledCollectors = [
+          "bcachefs"
+          "fibrechannel"
+          "infiniband"
+          "ipvs"
+          "mdadm"
+          "nfsd"
+          "os"
+          "rapl"
+          "tapestats"
+          "zfs"
+        ];
+        enabledCollectors = [
+          "interrupts"
+          "processes"
+          "systemd"
+          "tcpstat"
+        ];
+      };
+      process.enable = true;
+      smartctl.enable = true;
+      systemd.enable = true;
+    };
+
+    vmagent = {
+      enable = true;
+      extraArgs = [
+        "-enableTCP6"
+      ];
+      prometheusConfig.scrape_configs = [
+        {
+          job_name = "comin";
+          static_configs = [
+            { targets = [ "127.0.0.1:4243" ]; }
+          ];
+        }
+        {
+          job_name = "node";
+          static_configs = [
+            { targets = [ "127.0.0.1:9100" ]; }
+          ];
+          # Every host scrapes 127.0.0.1:9100 and remoteWrites the SAME
+          # instance label, so VM merges all nodes into one series → garbage
+          # rates. Rewrite to a unique per-host identity + real cluster label.
+          relabel_configs = [
+            {
+              target_label = "instance";
+              replacement = config.networking.hostName;
+            }
+            {
+              target_label = "cluster";
+              replacement = "nishir";
+            }
+          ];
+        }
+      ];
+      remoteWrite.url = "https://telemetry.taila659a.ts.net/insert/0/prometheus";
+    };
+  };
+
+  # Required for node-exporter textfile collector.
+  systemd.tmpfiles.rules = [
+    "d /var/lib/node_exporter/textfile_collector 0755 root root -"
+  ];
+
+  # This value determines the NixOS release from which the default
+  # settings for stateful data, like file locations and database versions
+  # on your system were taken It's perfectly fine and recommended to leave
+  # this value at the release version of the first install of this system
+  # Before changing this value read the documentation for this option
+  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html)
+  system.stateVersion = "26.05";
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/builder.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/builder.nix
@@ -1,0 +1,49 @@
+{ config, pkgs, ... }:
+
+{
+  imports = [
+    ./machine.nix
+  ];
+
+  nix.settings.trusted-users = [ "builder" ];
+
+  services.gitea-actions-runner = {
+    package = pkgs.forgejo-runner;
+    instances = {
+      forgejo = {
+        enable = true;
+        name = config.networking.hostName;
+        tokenFile = config.sops.templates.forgejo-runner-token.path;
+        url = "https://forgejo.taila659a.ts.net";
+        labels = [
+          "docker:docker://node:22-bookworm"
+          "nixos-latest:docker://nixos/nix"
+          "native:host"
+        ];
+      };
+    };
+  };
+
+  sops = {
+    secrets = {
+      codeberg-runner-token.restartUnits = [ "codeberg-runner-${config.networking.hostName}.service" ];
+      forgejo-runner-token.restartUnits = [ "forgejo-runner-${config.networking.hostName}.service" ];
+    };
+    templates = {
+      codeberg-runner-token.content = ''
+        TOKEN=${config.sops.placeholder.codeberg-runner-token}
+      '';
+      forgejo-runner-token.content = ''
+        TOKEN=${config.sops.placeholder.forgejo-runner-token}
+      '';
+    };
+  };
+
+  virtualisation.docker = {
+    daemon.settings = {
+      fixed-cidr-v6 = "fd00::/80";
+      ipv6 = true;
+    };
+    enable = true;
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/distributed.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/distributed.nix
@@ -1,0 +1,92 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  mkHostname = hostName: "${hostName}.taila659a.ts.net";
+
+  mkBeelinkBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "x86_64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 4;
+    speedFactor = 2;
+    supportedFeatures = [
+      "nixos-test"
+      "benchmark"
+      "big-parallel"
+      "kvm"
+    ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkRpiBuildMachine = hostName: {
+    hostName = mkHostname hostName;
+    sshUser = "builder";
+    system = "aarch64-linux";
+    protocol = "ssh-ng";
+    maxJobs = 2;
+    speedFactor = 1;
+    supportedFeatures = [ "nixos-test" ];
+    mandatoryFeatures = [ ];
+  };
+
+  mkBuildMachines =
+    machines:
+    let
+      selfHostname = mkHostname config.networking.hostName;
+    in
+    builtins.filter (m: selfHostname != m.hostName) machines;
+
+  mkSshKnownHost = { hostName, publicKey }: {
+    "${mkHostname hostName}".publicKey = publicKey;
+  };
+
+  mkSshKnownHosts =
+    knownHostsList:
+    let
+      selfHostname = mkHostname config.networking.hostName;
+      mergedHosts = mergeAttrsList knownHostsList;
+    in
+    filterAttrs (name: _value: selfHostname != name) mergedHosts;
+in
+{
+  nix = {
+    buildMachines = mkBuildMachines [
+      (mkBeelinkBuildMachine "ashira")
+      (mkBeelinkBuildMachine "manash")
+      (mkBeelinkBuildMachine "nalsha")
+      (mkRpiBuildMachine "fushi")
+      (mkRpiBuildMachine "minish")
+      (mkRpiBuildMachine "nemishi")
+    ];
+
+    distributedBuilds = true;
+
+    settings.builders-use-substitutes = true;
+  };
+
+  programs.ssh.knownHosts = mkSshKnownHosts [
+    (mkSshKnownHost {
+      hostName = "fushi";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILrDoPfjV+jRuGXdsc+TlgaL/+eO9pPqav6SG+tl1nPC";
+    })
+    (mkSshKnownHost {
+      hostName = "minish";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFWXSOEAx3pEzeoaqKV4gCCEVK3do+f2oJWlL++lGA/N";
+    })
+    (mkSshKnownHost {
+      hostName = "manash";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDW8I5803nYCNIKmzXBgfVDYpOJvYH0jg8ht5Djr72eL";
+    })
+    (mkSshKnownHost {
+      hostName = "ashira";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILxxDA8yBStWRl43qL15IvnKrLRW9Y2KlRAtEnxm4n3X";
+    })
+    (mkSshKnownHost {
+      hostName = "nalsha";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGAFFXlS4bbJnvo2CaPdKPHX2EFyrfF/KHfcwsVgOffE";
+    })
+  ];
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/follower.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/follower.nix
@@ -1,0 +1,14 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./leader.nix
+  ];
+
+  services.knix = {
+    serverAddr = "https://192.168.1.28:9345";
+    tokenFile = config.sops.secrets.rke2-token.path;
+  };
+
+  sops.secrets.rke2-token.restartUnits = [ "rke2-server.service" ];
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/graphical.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/graphical.nix
@@ -19,6 +19,7 @@
         # resolve on Niri's spawned PATH (compositor launches them directly).
         laptopSessionUtils = [
           brightnessctl # backlight/brightness keys under Niri
+          ddcutil # DDC/CI external monitor brightness/control
           fuzzel # app launcher; Niri's default config binds Super+R to it
           gparted-full # disk partition GUI (full FS tool set: resize/move any fs)
           pavucontrol # audio mixer GUI (volume keys only step, no panel)

--- a/.jjconflict-side-1/modules/nixos/profiles/graphical.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/graphical.nix
@@ -1,0 +1,89 @@
+{ pkgs, ... }:
+
+{
+  imports = [
+    ./machine.nix
+    ./workstation.nix
+  ];
+
+  environment = {
+    # Niri's built-in default spawns `${env TERMINAL alacritty}` on Super+Enter.
+    # Point it at Ghostty (provided by the home config) without a full config.kdl.
+    sessionVariables.TERMINAL = "ghostty";
+
+    # Gaming + laptop utilities the graphical session needs at the system level.
+    systemPackages =
+      with pkgs;
+      let
+        # Wayland session utilities: launcher + media/backlight controls that must
+        # resolve on Niri's spawned PATH (compositor launches them directly).
+        laptopSessionUtils = [
+          brightnessctl # backlight/brightness keys under Niri
+          fuzzel # app launcher; Niri's default config binds Super+R to it
+          gparted-full # disk partition GUI (full FS tool set: resize/move any fs)
+          pavucontrol # audio mixer GUI (volume keys only step, no panel)
+          playerctl # media-key control for MPRIS players
+        ];
+      in
+      laptopSessionUtils;
+  };
+
+  hardware = {
+    # WiFi / Bluetooth firmware for the laptop radios.
+    enableRedistributableFirmware = true;
+    graphics = {
+      enable = true;
+      enable32Bit = true; # Gaming: 32-bit for Wine/Proton
+    };
+    bluetooth.enable = true;
+    nvidia = {
+      open = true;
+      modesetting.enable = true;
+      powerManagement.enable = true;
+    };
+  };
+
+  programs = {
+    # Niri compositor (ships wayland-sessions/niri.desktop; the greeter lists it).
+    niri.enable = true;
+
+    # Noctalia shell/bar as a systemd user service (auto-starts in the Wayland session).
+    noctalia = {
+      enable = true;
+      recommendedServices.enable = true;
+      systemd.enable = true;
+    };
+
+    noctalia-greeter.enable = true;
+
+    # Niri forces XWayland off (the wayland-session import passes enableXWayland=false).
+    # Re-enable it so X11 apps actually start under Niri.
+    xwayland.enable = true;
+  };
+
+  # greetd daemon. `default_session.user` defaults to "greeter" (auto-created by the module).
+  # The Noctalia Greeter module sets default_session.command to its session binary.
+  services = {
+    # Flatpak sandboxing for graphical hosts. The module asserts xdg.portal.enable,
+    # so the portal must be on or the build fails.
+    flatpak.enable = true;
+
+    greetd.enable = true;
+
+    # Secret Service daemon so Thunderbird's login manager stores credentials
+    # encrypted (Niri ships no keyring today).
+    gnome.gnome-keyring.enable = true;
+
+    # XWayland for the rare X11 app under Niri. Keep xserver on for the XWayland socket.
+    xserver.enable = true;
+  };
+
+  xdg.portal.enable = true;
+
+  # polkit authority daemon: required for the privilege prompts that
+  # pkexec/gparted raise. Noctalia's built-in in-session agent (enabled via
+  # programs.noctalia.settings.shell.polkit_agent in the home module) registers
+  # against this daemon, so the external polkit-gnome agent is intentionally
+  # omitted to avoid two agents racing for the session-bus registration.
+  security.polkit.enable = true;
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/leader.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/leader.nix
@@ -1,0 +1,95 @@
+{
+  imports = [
+    ./machine.nix
+  ];
+
+  services = {
+    knix = {
+      enable = true;
+      addons.flux = {
+        instance.extraConfig.instance.sync = {
+          interval = "1m";
+          kind = "GitRepository";
+          path = "clusters/nishir/overlays/tailnet";
+          pullSecret = "";
+          ref = "refs/heads/main";
+          url = "https://github.com/shikanime-labs/manifests.git";
+        };
+
+        operator.extraConfig.web.ingress = {
+          enabled = true;
+          annotations."tailscale.com/tags" = "tag:web";
+          className = "tailscale";
+          hosts = [
+            {
+              host = "nishir-flux";
+              paths = [
+                {
+                  path = "/";
+                  pathType = "ImplementationSpecific";
+                }
+              ];
+            }
+          ];
+          tls = [
+            { hosts = [ "nishir-flux" ]; }
+          ];
+        };
+      };
+      # Tailscale IP SANs — required because agents resolve hostnames to IPv6
+      # first; without these the load balancer's TLS handshake to the supervisor
+      # port (9345) fails with "tls: internal error".
+      extraConfig.tls-san =
+        let
+          ashira = [
+            "ashira.taila659a.ts.net"
+            "100.71.195.97"
+            "fd7a:115c:a1e0::c53a:c362"
+          ];
+          manash = [
+            "manash.taila659a.ts.net"
+            "100.74.220.28"
+            "fd7a:115c:a1e0::8d3a:dc1c"
+          ];
+          nalsha = [
+            "nalsha.taila659a.ts.net"
+            "100.126.72.116"
+            "fd7a:115c:a1e0::be3a:4875"
+          ];
+          nishir = [
+            "nishir.taila659a.ts.net"
+            "100.80.177.233"
+            "fd7a:115c:a1e0::fc3a:b1ea"
+          ];
+        in
+        ashira ++ manash ++ nalsha ++ nishir;
+
+      traefik.extraConfig.ports = {
+        syncthing = {
+          port = 22000;
+          expose.default = true;
+          exposedPort = 22000;
+          protocol = "TCP";
+        };
+        syncthing-udp = {
+          port = 22000;
+          expose.default = true;
+          exposedPort = 22000;
+          protocol = "UDP";
+        };
+      };
+    };
+
+    # Expose RKE2 API (9345) and Kubernetes API (6443) as a single Tailscale Service.
+    tailscale.serve = {
+      enable = true;
+      services.nishir = {
+        advertised = true;
+        endpoints = {
+          "tcp:6443" = "tcp://127.0.0.1:6443";
+          "tcp:9345" = "tcp://127.0.0.1:9345";
+        };
+      };
+    };
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/machine.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/machine.nix
@@ -1,0 +1,65 @@
+{ config, ... }:
+
+{
+  imports = [
+    ./base.nix
+  ];
+
+  services = {
+    avahi = {
+      enable = true;
+      nssmdns4 = true;
+      nssmdns6 = true;
+      publish = {
+        addresses = true;
+        enable = true;
+        workstation = true;
+      };
+    };
+
+    openssh = {
+      enable = true;
+      openFirewall = true;
+    };
+
+    tailscale = {
+      authKeyFile = config.sops.secrets.tailscale-authkey.path;
+      enable = true;
+      extraUpFlags = [
+        "--accept-routes"
+        "--ssh"
+      ];
+      openFirewall = true;
+      useRoutingFeatures = "server";
+    };
+
+    # Userspace hardware watchdog + system resource monitor
+    watchdogd = {
+      enable = true;
+      settings = {
+        meminfo.enabled = true;
+        timeout = 120; # Increased from 15s to prevent premature reboots
+      };
+    };
+  };
+
+  sops.secrets.tailscale-authkey.restartUnits = [ "tailscaled.service" ];
+
+  # XFS no longer panics on I/O errors: on USB-backed nodes a transient
+  # enclosure I/O error was panicking the kernel and reboot-looping. Let XFS
+  # remount read-only and ride out the hiccup instead.
+  systemd.oomd.enable = true;
+
+  # zram swap so the kernel OOM-killer isn't the first responder on small nodes.
+  # PSI is enabled by default on NixOS std kernel; that also lets systemd-oomd run.
+  zramSwap.enable = true;
+
+  # Force glibc to prefer IPv4 over IPv6 for dual-stack destinations.
+  networking.getaddrinfo.precedence = {
+    "::1/128" = 50;
+    "::/0" = 40;
+    "2002::/16" = 30;
+    "::/96" = 20;
+    "::ffff:0:0/96" = 100;
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/minimal.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/minimal.nix
@@ -1,0 +1,45 @@
+{
+  # Make home-manager use packages from system
+  home-manager = {
+    backupFileExtension = "backup-before-nix";
+    useGlobalPkgs = true;
+    useUserPackages = true;
+  };
+
+  nix = {
+    # Cleanup disk weekly
+    gc = {
+      automatic = true;
+      dates = "weekly";
+      options = "--delete-older-than 30d";
+    };
+
+    # Optimize nix store weekly
+    optimise = {
+      automatic = true;
+      dates = [ "weekly" ];
+    };
+
+    # Allow wheel users to interact with the daemon
+    settings = {
+      download-buffer-size = 524288000;
+      trusted-users = [ "@wheel" ];
+    };
+
+  };
+
+  # Automatically upgrade NixOS
+  system.autoUpgrade = {
+    enable = true;
+    flags = [ "--accept-flake-config" ];
+    flake = "github:shikanime-labs/machines";
+  };
+
+  # This value determines the NixOS release from which the default
+  # settings for stateful data, like file locations and database versions
+  # on your system were taken It‘s perfectly fine and recommended to leave
+  # this value at the release version of the first install of this system
+  # Before changing this value read the documentation for this option
+  # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html)
+  system.stateVersion = "26.05";
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/nishir.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/nishir.nix
@@ -1,0 +1,71 @@
+{ lib, pkgs, ... }:
+
+with lib;
+
+{
+  imports = [
+    ./machine.nix
+    ./wifi.nix
+  ];
+
+  networking = {
+    firewall = {
+      # Cluster -> tailnet egress. Pods route via the node (flannel host-gw),
+      # so their traffic reaches the host on the CNI bridge (cni0) and must be
+      # forwarded out tailscale0 to reach tailnet CGNAT addresses
+      # (100.64.0.0/10, e.g. *.ts.net). The node already holds these routes via
+      # Tailscale --accept-routes; only the firewall FORWARD policy (default
+      # DROP) blocks it. Egress-only: return traffic is ESTABLISHED and allowed
+      # by conntrack. IPv4 + IPv6 (pod ranges are fd00::/56).
+      extraCommands = ''
+        iptables -I INPUT -i br+ -j ACCEPT
+        iptables -I FORWARD -i br+ -j ACCEPT
+        ip6tables -I INPUT -i br+ -j ACCEPT
+        ip6tables -I FORWARD -i br+ -j ACCEPT
+        iptables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT
+        ip6tables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT
+      '';
+      extraStopCommands = ''
+        iptables -D INPUT -i br+ -j ACCEPT 2>/dev/null || true
+        iptables -D FORWARD -i br+ -j ACCEPT 2>/dev/null || true
+        ip6tables -D INPUT -i br+ -j ACCEPT 2>/dev/null || true
+        ip6tables -D FORWARD -i br+ -j ACCEPT 2>/dev/null || true
+        iptables -D FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
+        ip6tables -D FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
+      '';
+    };
+  };
+
+  services = {
+    knix = {
+      # Bridge interface — flannel, firewall, and sysctl rules all target br0.
+      # Bonded on Beelink (bond0 → br0), single-NIC on RPi (end0 → br0).
+      interface = "br0";
+
+      # Use host-gw for flannel overlay — zero encapsulation overhead on same-LAN clusters
+      canal.backend = "host-gw";
+    };
+
+    tailscale.serve.services.syncthing = {
+      endpoints."tcp:22000" = "tcp://127.0.0.1:22000";
+      advertised = true;
+    };
+  };
+
+  systemd.services.tailscale-serve-syncthing = {
+    description = "Expose RKE2 and Kubernetes APIs via Tailscale serve with HTTPS";
+    after = [ "tailscaled.service" ];
+    wants = [ "tailscaled.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    script = ''
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --http=80 https+insecure://127.0.0.1:443
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --https=443 https+insecure://127.0.0.1:443
+    '';
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/wifi.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/wifi.nix
@@ -1,0 +1,43 @@
+{ config, ... }:
+
+{
+  networking.wireless = {
+    enable = true;
+    secretsFile = config.sops.templates.wifi.path;
+    networks = {
+      "SFR_E368".pskRaw = "ext:psk_sfr_e368";
+      "SFR_E368_5SGHZ".pskRaw = "ext:psk_sfr_e368_5ghz";
+      "Vintage Korean".pskRaw = "ext:psk_vintage_korean";
+    };
+  };
+
+  sops = {
+    secrets = {
+      wifi-sfr-e368 = {
+        owner = "wpa_supplicant";
+        group = "wpa_supplicant";
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+      wifi-sfr-e368-5ghz = {
+        owner = "wpa_supplicant";
+        group = "wpa_supplicant";
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+      wifi-vintage-korean = {
+        owner = "wpa_supplicant";
+        group = "wpa_supplicant";
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+    };
+    templates = {
+      wifi = {
+        content = ''
+          psk_sfr_e368=${config.sops.placeholder.wifi-sfr-e368}
+          psk_sfr_e368_5ghz=${config.sops.placeholder.wifi-sfr-e368-5ghz}
+          psk_vintage_korean=${config.sops.placeholder.wifi-vintage-korean}
+        '';
+        restartUnits = [ "wpa_supplicant.service" ];
+      };
+    };
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/profiles/workstation.nix
+++ b/.jjconflict-side-1/modules/nixos/profiles/workstation.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+
+{
+  imports = [
+    ./base.nix
+  ];
+
+  programs.gnupg.agent = {
+    enable = true;
+    enableExtraSocket = true;
+    pinentryPackage = pkgs.pinentry-all;
+    settings.default-cache-ttl = 60 * 60;
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/users/automata.nix
+++ b/.jjconflict-side-1/modules/nixos/users/automata.nix
@@ -1,0 +1,20 @@
+{
+  users.users.automata = {
+    initialHashedPassword = "";
+    isNormalUser = true;
+    home = "/home/automata";
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOuenA6cT5pkPEwdGvmvXRjVqFTv2QwpyYrB7gvMy0/X"
+    ];
+  };
+
+  home-manager.users.automata = {
+    imports = [
+      ../../../modules/home/base.nix
+      ../../../modules/home/cloud.nix
+      ../../../modules/home/vcs.nix
+      ../../../modules/home/workstation.nix
+    ];
+    programs.bash.enable = true;
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/users/builder.nix
+++ b/.jjconflict-side-1/modules/nixos/users/builder.nix
@@ -1,0 +1,7 @@
+{
+  users.users.builder = {
+    isNormalUser = true;
+    home = "/home/builder";
+    useDefaultShell = true;
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/users/nishir.nix
+++ b/.jjconflict-side-1/modules/nixos/users/nishir.nix
@@ -1,0 +1,11 @@
+{
+  users.users.nishir = {
+    extraGroups = [ "wheel" ];
+    home = "/home/nishir";
+    initialHashedPassword = "$y$j9T$HB1msXB0DEq00J48zRpB20$/3rhVrTzGrv1j/cPvZ0clOM2gEe1TeylUG39wgD0C42";
+    isNormalUser = true;
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH+tp1Xfz7NomHCZuDPlfj3XW5hm9t0TiCyEeudRraoe"
+    ];
+  };
+}

--- a/.jjconflict-side-1/modules/nixos/users/shika.nix
+++ b/.jjconflict-side-1/modules/nixos/users/shika.nix
@@ -1,0 +1,64 @@
+{ config, lib, ... }:
+
+with lib;
+
+let
+  toDhall = generators.toDhall { };
+in
+{
+  imports = [
+    ../../../modules/home/ai.nix
+    ../../../modules/home/base.nix
+    ../../../modules/home/cloud.nix
+    ../../../modules/home/fontconfig.nix
+    ../../../modules/home/ghostty.nix
+    ../../../modules/home/graphical.nix
+    ../../../modules/home/helix.nix
+    ../../../modules/home/starship.nix
+    ../../../modules/home/vcs.nix
+    ../../../modules/home/workstation.nix
+    ../../../modules/home/zed-editor.nix
+  ];
+
+  identities = {
+    enable = true;
+
+    ghstack.enable = true;
+
+    glab.enable = true;
+
+    gouv = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/cloud-pi-native"
+      ];
+    };
+
+    operator-6o = {
+      enable = true;
+      git.condition = "gitpath:${config.home.homeDirectory}/Source/Repos/github.com/operator6o";
+      jj.extraConfig."--when".repositories = [
+        "${config.home.homeDirectory}/Source/Repos/github.com/operator6o"
+      ];
+    };
+
+    shikanime.enable = true;
+  };
+
+  programs.bash.enable = true;
+
+  sops = {
+    age.keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
+    defaultSopsFile = ../../../secrets/shikanime.enc.yaml;
+    defaultSopsFormat = "yaml";
+    secrets.cachix-token = { };
+    templates.cachix-config.content = toDhall {
+      authToken = config.sops.placeholder.cachix-token;
+      hostname = "https://cachix.org";
+    };
+  };
+
+  xdg.configFile."cachix/cachix.dhall".source =
+    config.lib.file.mkOutOfStoreSymlink config.sops.templates.cachix-config.path;
+}

--- a/.jjconflict-side-1/modules/nixos/virtualisation/containerdisk.nix
+++ b/.jjconflict-side-1/modules/nixos/virtualisation/containerdisk.nix
@@ -1,0 +1,43 @@
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.containerdisk;
+in
+{
+  imports = [
+    "${modulesPath}/virtualisation/disk-image.nix"
+  ];
+
+  options.containerdisk = {
+    name = mkOption {
+      type = types.str;
+      description = "Container image name to assign to the built containerdisk.";
+    };
+
+    settings = mkOption {
+      type = types.attrsOf types.anything;
+      default = { };
+      description = "Extra attributes bound directly to the dockerTools.buildImage config attrset.";
+    };
+  };
+
+  # Reference: https://github.com/kubevirt/kubevirt/blob/main/docs/container-register-disks.md
+  config.system.build.containerdiskImage = pkgs.dockerTools.buildImage {
+    inherit (cfg) name;
+
+    copyToRoot = pkgs.runCommand "containerdisk" { } ''
+      mkdir -p $out/disk
+      cp -v ${config.system.build.image}/${config.image.fileName} $out/disk/${config.image.fileName}
+    '';
+
+    config = cfg.settings;
+  };
+}

--- a/.jjconflict-side-1/secrets/ashira.enc.yaml
+++ b/.jjconflict-side-1/secrets/ashira.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:bkZbtYiQMqPwPtSQRS7yp0DcMlBFqo19mYAGAQqEF6S3j5qf3okjDyaig1iQgS8=,iv:TF9l3sc4GZMDqMviLcwbec/3ZwW/31LGjm+sN3BNddo=,tag:AHXmz82qDWB/AJLexg3AIw==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:R5xFpFiK9dC62N9z7f3P/vxHe0oaDYurmd3zSnPccg1pk7v7WN+bt72qaMfADpmzzdhcjg1SWTcjxSQ=,iv:bGbmEG9S6RbbeHfZCxcpgRo/YRod0vsSrfRkNMAZ1Go=,tag:DD7fuG6pPHDRBevvHE7P5Q==,type:str]
+rke2-token: ENC[AES256_GCM,data:ZhjHnX2cGo1fKoo2GoJa4xshr+8nMo1SwJ8UdVWYc4a2FbV/ehDTSlaEz8DbE9J9aLvEiJ3oJCFBBD8SqitfTxo5S1JpbJy0kYKrse6a5D/fvHcZVFjWE6g10ONS/v8NDJywhe4yb9cxMMsr,iv:E2x2yMigVlgH/Rb0uaNYQ/x2Qk/dJe2uIf+EFRxHTTI=,tag:LlVJN6KAqlUcoeg9/fnKWg==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:16:56Z"
+  mac: ENC[AES256_GCM,data:IQZlaopB1rbqovdLcrqwUeHnh3AcGarPlR+vP5LUxJZ0kGBSGLIoHKT1/E2dZsRF8nQgS7oGzerbUcIbIwrd/dM64FBBfvRh7uA81d+BrPMGlGsQ8Vphr7OUZKj83zAYrJRL6shVNYLhfsP15mA7Jk2WAP3lygq4whWnyiPhalI=,iv:tudWaflVADz3gvwnzC87ddYqpQb3Ubu9D+wK1gEeIR0=,tag:f2tT/BQGbOmLeou7OZKfyA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUR3NzSTkwNFQ4d1d6bllX
+        M3MzNFF2Y1NyOXluZHVlNlArMUd0Y0srS3pvCk9WWndlTnhrcnIrZnlZTE9qUHMw
+        ajZINDlnZHR0ZzZZNUZ6clpid2d5S2cKLS0tIEFRK1o4YldGNlFyQi9PV21NRVhQ
+        NDlMU2dncjNoekRYUWJ2eExBRFhVK3MKZ1Twn79tKsndCEqkX3x505kLR2CGGKP0
+        5gijo+lh0LthON7GmJ+59kAxXNPsYK1kGQ02lCF2drQz2K5DY8ASvA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYQ1VKVWZSaHFjSW5EcXAy
+        MFJzSkxsdmpiS0toUzZSMi9WbTRya3JqV0VZCmlGRCs0VWNnY2pRazNjd3Y2QUV1
+        QUtSN0MzV0YrRHBvWHhGbVgyUGpQSHcKLS0tIGo4MWRKbnB6Q0JpcGUzT0U5NndX
+        YVIvZkU4VmNjSFQyMUVCeHhKVmZjVXcK/ZziPsyZTXy1DN5sBUQLn+Rys+IWcTJ2
+        MNHKnHyRV7rPccKO+Uhtr+WcW9OJ1xXXyW3OoIRqkz7lN3k+G/rXkw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBONmRjL3orRTIyU1FOTG83
+        QjlEV01wK0pGWnpaa0ZPVzFDNElwcWk0RWlNCkZPcW1QSlNDeERSUk5tTFpvMlht
+        WXh2YVoyc3ZXV0V4WVU2NWRoclVUYlUKLS0tIGJEc21LR1VENnpmSGx3czBVN1FH
+        S0dpTVpLOG5YbVF1a1gzd2ozeVVOZjQKpVwFVz8HwSCSsYgYnUxg1cA/jWTTUGlU
+        /GGt0GF9G4cFLYcUU1h9DqzdnrEDmcAS8AU5DlnTyXg6CPriXQovHQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSU09Bc0x0SC9Xd3FRZngz
+        Z1lLckptN2VlWTVrbzVNWHlSempvaTdsbVNVCmJGMC85VDRwNWZIaml2U0dhU1Jo
+        VzZ1eURFeDh1WEc0Sk9nb0w0S052czQKLS0tIE1lYloxRDJnaHpFaldUcEJtdmRF
+        aTR6Ty9OcHVTYW9BVmdZbHFOaXlPc1UKiQbKnZiKbRRi5bNpso2wjAf0XVQHYQUr
+        NXy3DZ3mIg0YTO1IwTDZ1059iXdYAHmWZrEShMfO7a0KUb3YA4BzmA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:qfFWKqM8wFIG5rE3wCURxZtGBtbcutjl+cMYIuIxvhxAotpfYMjnZsT6VxtCzwkQUFVZptqMBA8xB57UUwk=,iv:3ZA/q7WHvfscBSUkRuW5IzsPG8EMlZj+FQrE68QnWf0=,tag:3O7384nD+ahnWmLUkrDqqg==,type:str]

--- a/.jjconflict-side-1/secrets/builder.enc.yaml
+++ b/.jjconflict-side-1/secrets/builder.enc.yaml
@@ -1,0 +1,116 @@
+codeberg-runner-token: ENC[AES256_GCM,data:4uJawrEOfsM3DEVO9Zacv3HSWVGIuUZI1VrOuJleD/V659P02N093t5hMA==,iv:qP5hCFucau4gV2RlguA06df9JTaGumOuX2Fda4mtVj8=,tag:YX+MtZaZdwbBYSWEhAp86Q==,type:str]
+forgejo-runner-token: ENC[AES256_GCM,data:5V5mujkVjqxkSkE1F9oRDpWJlz2ubJc4EhRltQOp5q3DquB/1i/CQy5rgA==,iv:J3boywVhURVH9Fzv98oHcg5mz0euDftBJ1F07YAEsOM=,tag:m2lR8/x1NMzNw6imEc4XtA==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:28:03Z"
+  mac: ENC[AES256_GCM,data:rI0TEzb3brGH+kzYsSJtphUTL9yEd5XapIoA1Oo3AxzQScqzmE2r6X6mzrlAwK0IBlvrCZthmjitwRqcjxAXjW2abZQwbvCdjwIJAhGL6N+1ziiuXaQQfenwH0ow/Tqf7jvgFu/v5MA8oHTjuqPyCn7UuQjHinmXBjzIIT2c3N0=,iv:idioPVWqIGxwDszOYfqzwOOEMkLaoVL2liNtiXtwytw=,tag:oR7eLuxJOwt/XssPeaB5Yg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCNTl4WHdQVlMvOWYrdk5V
+        ME1xZUhzSEkxdXhDMWJLVXZXT01xNGZjZlRvCkJpNEdockUybjh1aWpJdkRXck1U
+        Ym9BZ25tWENmemYrWkgyQW5wMGpwT2cKLS0tIEJoUUQreERFMEdKWjFhNXROYStX
+        akNMYnhmTEVhcEFGTnlxNWRzc0o1djgKssBDBGpA0FGTD41SUPZ0Gq+aBvfZpDlp
+        qmbcwmh6WK+/zuEILwA2HZ6U14C4ML205ntg45id4iY4E1+vszwJVg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOWWhvUkhwSDZXV1MyVEZz
+        ZTNWREZRVjJCSVdVYzFIWWwzV1RaOU1yMkdFClIySVJ1K1ZWa1NNemZyZnlUMzFQ
+        cS9nWDlZZ3gvNzFKcFJGcUJONGVVQnMKLS0tIGtPUm9YS09JbXVsN3J2bzJlUHFn
+        SHNQL0xWOGowYlh0Z2E2QnllaDNWRVUKxjrJPfksk71OfJ7jszGdEChcrMubrjAv
+        V3OXt6xErb03Ao6x/8MXtoGcc+R5ssVWjFC6y65rSUyvbvGCCaneVg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuZkN0c0YrM1NvdEM5aGJI
+        dHRsUThTdHpWNkZPV0c3VEVObGhqdVlSa0VBCjUzcHg0VkZPL2VoUTJOcys1MVFR
+        UFNjQzNTaTFrM3BQZGp0dDJUTTJ1UEUKLS0tIFVoUmNYNGtNVFdPcHJCVTAvejR5
+        QUV1aDNKQzh6MlV4YlFhUkVqQi8wSVUKZCOtsLsim2X3G9oz35MYU3QvdGDqkl7u
+        QKifhCdc869nSlqQq13uHfi0fZt4qtKEdxzrkb6TUWOPO1A4/eOP9Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBORnJzK2dXbnFoZEVuQmdh
+        RnFhYjZBUTlVQmRZQVZOUjJnMk95UnV6ckJzCis0eXhERHNsRGREdVNBZWtTVkRi
+        RkdpeFQxRnVpUjBPK0JhNStwaVd3NTgKLS0tIENxSThIbWJENVhGYlJHSU9mWVdp
+        bHVBM2FhUkVrVTlCZS8rNWlUWk53UW8KlIOOf82n9Z0Zfg/NRffglM1ykMTKRP9F
+        KhZsljCGnmiE1SlQ77MRy49S0wFPMWJmGPHJJnd/IKK8GCLBO1Za+A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIL3Azc3JVUEdkZEYxVFVR
+        VjJNcXdkd0E3V0orRzFGdDc0Q0FXMlhsVUhZCkxlRk9HT3NLN3lybGNxd1NqbVVO
+        Z2o5WDlQNXVzRmw3MFl3enJ6dGlNbHcKLS0tIHJwNjh6Ukp1clhNOXNqTTgvVXV2
+        cERQOUFxajh5R1h1ZXZCTjZvVk9VT3MKzWBn+gY7uOvMuHu7rXOmA2uIgI5ckqxx
+        +q8PDflHbdEZT6uexswWwKygMlr1xE0Pg2aLOxZcyFsa3+ttNQSAIA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqTVVNTTFDMFR3SXBEYnho
+        VnF4OE1WcU90d0FWd1YvUGJHUUhDMFFiUUVNCmd5QkM0SUVBR2dYY0Z6VlF4eHJk
+        V1k0cVNIQXZMTmJzNjJaWUdVbFRiQ1EKLS0tIFhFSlJGMlJXUGZOSkNibHp1ZjR4
+        ZlhaNjUwT0JXdDZOZEM3UWpKM2ZtQUUKLYZcJ0nPrwt71nrEZKLGZdghoz95c0lX
+        tRWrtiQK0OIRgnVpUdKQWGWTUULvT0Lo8mh7uOVl2wZW3+V7UWT8cA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxT1JQL2U0QnpGKzJmYlkx
+        QS9RMXZaTy9IRW56MVVPTGNxRGVJK1RtM25VCkt2Z3JXVForYjJXQThWMlE2QlM4
+        TzlTN1pKQzAvRWlZNXl2cFBodWVKNGcKLS0tIElFMy9NMHFlZElRL0pwRkVLdXpT
+        c1pDbHRDK2NucEQ2dFBOdWlsK1lqOFkKfw8uBv+Z9mogXi1I0bIN1fFnk7+H7VEE
+        MMeYmIZGWkwDhCmH/5e7Um+PQ6DNTx7yUjj2YzIvbp3IsGwCORpmvQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJUUhTSCtjYm9VMnRLMnBz
+        b3FIV1NONjJEblN3bWVWeVdZUjBNTjZuWWo0Ck82ZmxoTEoxU0hXNW8ydms1eXZw
+        Yy9yV2VtNFI1aXZRYUpqT3huVU9GRVkKLS0tIGFub05PQ0dRWjZPUjViTmdaK1Iz
+        VjkwS1ByTW8rUjFVL1lMVVA2anJFT2sKIMUCDi487H807PINn7MDQSrnAvvrFtyw
+        10It6rpHQeHh3DV3CrsnHjsk5AJvFHHVjdXriXKKmFVgzDGPPR72Xg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyTEZjNys0T2ZzQ1ZCTWE3
+        MXRIb3JtREhVK0xuL3N1VDVEZ0t3b1U5OUN3Ci9GSVpGZVRUVmZNMDdYNitYc0lw
+        UDJ1NW90MGhXNDlUd1N4MVd6a21jYnMKLS0tIHgvM0g0SzN1QTZTcjBuOXVySFNN
+        cnpzN3Q0YlNoWThWL2Q1azVjS2xveTAKOcm34DduIdHH6kIzAVbNbHQW/BdrhHt0
+        YbT6RLltrrigugxH2vjv/2Ve0IOdQvOHkvUP4h9B4l/OCzSf88jlcA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDZTFabDN4YlNwVEUyNi9q
+        SEVNUkUxdEdPa0o2N1hmRy9VM1BBZ3puL0Z3CkxRRExabHI1V0FrRGk2REdxV2ZR
+        VllBaVNpRGs4TVBpQ3NOSFIwc0xwVU0KLS0tIFkrSjBrdDBqdzFIMGVwbWs3Zzhp
+        aVRvZVF3MkFHd2lrY04wOUtGUmlTZ1UKCeWRPAiRoHD68gkJ0UY1nS8b6H58/S3A
+        IaYl6uK6Kixc2O/fQbZ7BfGgvHABaV4GrYUONWCCDRp99p6O390Yfw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4QkZFc2ZVRWZ5dWFMcWVs
+        Q3lia3g5bWRXdEJoa3hQdElDRDhxMVVPYW5vClhxS0x3SVRmRmpSZVZxMndnbjZ2
+        eS93aHR5ZHFZQ09YN2lKbU5WU3NXZlUKLS0tIHdyOGc5Y3ZOdUdqZlRQOURrQThq
+        SGJPbVBlTUp0aFMrWG5TWTQ1WHB4YWsK7HXOkWsjZao4QsyxjogEM1RPQMi19Tey
+        UCQ6NAF7b4hQDHcB2C01j4uKGAKCCHKK1DbNwCniliRxJc119lLIrg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5MC9jNXU3ZHRsUUVBYkEz
+        dHU1aERWQ29aVWxyaEJYV2FZQTdhRVFmM0U4Ck9lZGppWUZjbjRQNnU3dHIzclk4
+        M0NzVlBpeFBJZ2NkRi92dXhDcEFlK1UKLS0tIHcwWFMwV2pHL2c0a0ZBeWhja2NS
+        VlJhYXoxOEcya0JQY0tZNzBUUDllVWMK4oS3Rpb9AQwatA/OykeoJ7AqNrZ72kLw
+        sJnIwoiBT9Guzdz4CLzYcbHCDkhrMNU4SlVbG6QTtLJfpp59p5G8tQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d

--- a/.jjconflict-side-1/secrets/fushi.enc.yaml
+++ b/.jjconflict-side-1/secrets/fushi.enc.yaml
@@ -1,0 +1,45 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:3FV3y8ElvePApyX/uqMo3xy5Pt66YtbNc/e6dEGpJZ7nTWF1z/nJdWQS+GlhwtnA,iv:/ljlAwygMaMm7jQEzhanb23DwcHcxQc9B1yW4DdsrYI=,tag:23Ac8PYQG05bOB59iiJL6A==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:Ou7lVgiGZz2/oF2gsdeQao/qwX0qsCbxElCbP3FyKGDrBQy8ePjDWIXW2fMGVVV8i6+OMGJPQTVKrGs=,iv:5OHFZRMaxQgd/uyMsH7LTPiSsK46UriJEuY6ozMND3M=,tag:I/nYVqw6I4ieUqdRw0Erlw==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:17:39Z"
+  mac: ENC[AES256_GCM,data:Y257wW8/3h/624yfXz803LBR0wyNjqxYpajlqo0UsCL4X8yDoI/2w7vfgQMCTDvp4pA97n/UXy0CUpxXd78JpuFBrQlZTxFs94eTun30AYbkx5BOOQsGhHh5biq6gMTYnzl0FG7Mneef33IiMpNhOZ+W6wkCaXMaTK3bN5AUGkQ=,iv:XKtysKpR+G+z/sgNswnzpuAsu1voFM765wqZT+4jYRA=,tag:uRYv9T0Xa+01oaohznLwEA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVMG85VE91bGtXdkpRRHZo
+        MmNKVE9YOEhQcGRtODZKMk1sSHlQa3V5R1NFCk9GZVhpcVdGdS9ES2Q5WTZlK2Zz
+        d1hqYkdHWEtpd0U4UWhmWngxaEpEVzQKLS0tIHdYd0txZHliN0hhVmRsSStsdFRJ
+        Zkw4R1JNN2YyVUR0Um54NldldHlJUVUKK0FLH/vXC3XEXhEn+5l0mUlrYsxovfJ3
+        z6ollcJobYstMLFpddyes6mpvfiir/nisNBaXcGqjloiGlqu0YefeA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyNFNpYktoSjI1WlZ3MnJ3
+        cGdJNG0zL3cxQzk5RUxMaGJ6YW5iNnBITlNFCmNhaytOc21FUldMbXYrTFJIbzNz
+        WVprQ3VnZVlleFFvR3FFN09XK1R5K2sKLS0tIE9iWlJMM3YzUUR1cXNXdFRYWE95
+        YWV6ME9wTHFvSnl1cFFtT3JXaDJ4MncKI9AMHtjIjGRavoCG6y9cJEP9/h5mEJol
+        oEpI120i0Qd3mXP+GcI/k9Xwh7m58EFiPbeNE+dJWKoIMz6yYlHSYA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZRGcrNDQzWFhXOE1ZVU55
+        ajVnL2ZtTTF2VWo3NHJmRDd5V05hQXRHaGdRCmpNOVIvUmZVM0QwMndRSWhoY3Ji
+        RUxsMzFPdzgzQzlqd29LcjRpM2hpMFEKLS0tIExZRzZZTjBYZGNtbzFPWVR5cTZw
+        WisvWGtEVDZuSmh2OHZrN0xUOGVodzgKZzK+Zc0EYPf/Nnco8zyL16/28nbSWqLH
+        157s0N0ZdzphCE/v95LZiSks1gUmxwANJFUA/qrwRSOpnLAcdDrzFA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJQ01QSWxMQmpvWFdDSjNU
+        bkJrRzhsbEpJbjZncUxURjhxR0d1dmdGUndzCm5ETEdaUUgrZDI1dVVLUmxHVFlJ
+        WUE1OWhBbUFqUzJ1c1JwbG0xTFhXa00KLS0tIGk0d0xKWHFXVElSZ3BUZlRSdUFO
+        dnA4UXUzMFV6bFY0by9Ic1dZRi91RE0KROZyLBLbOWWnOu0Sg62wREsFtz0Z1FbT
+        2i8bZUw+abcqWM+jmCde1LFJhLKcOzZa1+I1p/AgRufEyosvOyu0ig==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:nB67fYGbvsJOP2TYTzsYWKok+eO86y4NCbxA8IxIO7EKLxQzXRvVNk8GElJQhfDOjEoK1txy6cbqZxBLFg==,iv:k2Ctjj8NPZI1sTIWAX2zUbrEWvlTRCQFfhVJq67FTfQ=,tag:uyPlzKtVfKgc29Q4d8zt1w==,type:str]

--- a/.jjconflict-side-1/secrets/ishtar.enc.yaml
+++ b/.jjconflict-side-1/secrets/ishtar.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ""
+hermes-agent-matrix-recovery-key: ""
+nix-access-token: ENC[AES256_GCM,data:dvLgcrShcdgCflS79pyH916it+qlb/ZDGsMik0z+uP3FJ0pAhlSABg==,iv:i2RDw9AdrQ2SIX7raa42MvYC1TcLkMrr8vW3xDAiLY0=,tag:HSZ/jj/NOSpm7UyADHnkCw==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:46:00Z"
+  mac: ENC[AES256_GCM,data:G7nr0yj6oiZxLOrZeRyV9eqPkN/18ya4sM9cexHTgx+2Pxpm5FK5dacLUrv1bIAVc6MZRIvL+DuGBhJiLKmPwNXBF5DVm8xJiGYDyNGQx93kTD+6Q0sG/pzOUbUfN2tvFCMA861BNR85+dFaiD+HzzAHm7kU5Qn764Xd5P/7lBQ=,iv:v6WdeUbTojwMXdZBFs36QJoODdfdxXeQgwWVx9VZTw8=,tag:x6/2+n9/rrlbzu56WoZOkg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPaXlEUEdpM1ZHK01jaVhJ
+        cGpUN2hUOGhvcG9VV3BZOFNSTlJUckM3bGw4CmNHa2hvajh0REJjbi9vUEwvNUNZ
+        UnZvSktrTnIzaEVqQ1BGbTlPMDZjSncKLS0tIHJPN3NGc1FBTDlZZktnalkvVG5Y
+        SXhFSUlDMUt4d1dqa0x1QnRTOHRyN2cKkxWxU6aVmeEdjDCIpCRl0aMjLfQvDxR7
+        RpZGvIsrIyN8fMRSVPexBmz13pYNOp5TPn8sGzzCTuH7FJkODWuoSA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA2NmNTSmFHeUJ6Vk1CMVlM
+        dUl5d3crckRFcmVMS1Iwa20wam1TQTNjWVIwClc1aFlRekVoeGQwQmJ5cEFXVEhO
+        YUgxdEZYSnJiSUFCWldhdWdYK3FYVUkKLS0tIHFvME00bHg2bWh5Nm02WXlVakJo
+        SXdDQldsMktSNTgwcWJDVDMyR3RRcTgKhZgm2T00H3BVGCKw5lGa78nErhkGUrdT
+        gSh1P36cuN3nx+/RMGpioYumqvu+3JyYV5jEIHEfuCW2sxD0HGi4uw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPNDZZRE55WStIZ0lnd0pn
+        WDkrRW5hTEJkSXlHbm1sK2NSZ29FOGRIMjNrCmNWUGdCczVPNmpROXFFZFU1TUdt
+        bXZ0citZZEdwaW41emc0S2JEY0NvREEKLS0tIEMxZkVEdjBaMXhmNWR2ZCtkbDBm
+        M0VVS1RKL1NmanRrUzVYT2N4OWNrdG8K4neostjZo6JrGW1pI3TFABbEosrUTmNb
+        SiCyknpLz29ng4r2dZSUds4Op6+ubHwb8m590WEmn8LwZyqX5HGdPw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQOGFLUkZRQU0ybFNOMkRt
+        K3dxYUVGMVluNG1zUDZVdExKckxiTGlxOFJnClgycHBubHJUVWZ5c29pOC9SUDly
+        emY2SlZ5U0hPQTVCM0UrOUVKcllFQkkKLS0tIGppUjJ0U2dzS0tnMjl0RVNzSGdh
+        cVlXY25iZHp0NExlKzVNeUEzc0hoTUkKx1QhFKVBRnD+4MnTLWcl8ZvHEkVNex8N
+        ZE2g1TX/32RRbJgsnfJz2XDvc8gO7bZmdCy7R8pE8Cr76x4T8GnaNQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:QQ18Tq7iBlgkeEkaUnud637nnwu6gMuPxCg7fKmICKGF3Ams7XT8CuL5aWle0uqasRbGTP9I9Ba5zbk1oZw=,iv:0z9M0KgyfETHzET1DakAIPOHnGLdF/bvHC6fTcyORyA=,tag:uLHwZ2axKDFgPA8F5eok6w==,type:str]

--- a/.jjconflict-side-1/secrets/machine.enc.yaml
+++ b/.jjconflict-side-1/secrets/machine.enc.yaml
@@ -1,0 +1,116 @@
+hermes-agent-api-server-key: ENC[AES256_GCM,data:5OWWA4/DyBTQjcgMAmk3QmXMn+DEx1G0M5XF/v/wwQFTdJuXfMgj0FNolUrVe7FkUPGm+05dAcs4C2mgaGLIUA==,iv:hqG7EWW7z5UV4iFD3S3P1UwXbwW+JEOKQMSCp4Zb9YA=,tag:rKVPavB3O+ZMzp6AzWIvng==,type:str]
+nix-access-token: ENC[AES256_GCM,data:YNiJgkCbdEaZJU4igBelAh3zZEqLF+iPcZ5J73cEB/UOshbveGjR8w==,iv:ZPZ/4H2zoNABDj5OxdRipaYz3x2b9Q2emems6Z/3ogc=,tag:LNviUqqX1XKmtB6H8ySjcQ==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-26T16:12:41Z"
+  mac: ENC[AES256_GCM,data:GLgJoqvx5oi7n/dz/zOKAY7g3FrwZUo5+VLjSqTHl1IKZkXQRTRyX98Z1hnzcUoC4bWkAfEhzOZoaTiWs0jYFoF7/T8i7MyvRFHnlE45BJwI2Cb5Lnc8QKQ1Ypxj+L14+k8cCgn2qIvxaP1V5Ga8BDawrfjnE+ykEPRYoTCpTTo=,iv:BI5Jiugmtip1phWrqqHSD0egHCM1a2O39TIleA/zcQ4=,tag:IOc8wOFyS0oyhgay8Z8a3w==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
+        Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
+        eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
+        V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
+        y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
+        QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
+        L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
+        L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
+        lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
+        eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
+        aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
+        QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
+        +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
+        dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
+        RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
+        UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
+        OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
+        RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
+        MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
+        NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
+        8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
+        KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
+        ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
+        eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
+        Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
+        VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
+        RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
+        QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
+        bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
+        VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
+        bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
+        ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
+        PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
+        ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
+        ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
+        VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
+        wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
+        aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
+        V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
+        ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
+        NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
+        MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
+        QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
+        UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
+        EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
+        OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
+        UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
+        enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
+        Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d

--- a/.jjconflict-side-1/secrets/manash.enc.yaml
+++ b/.jjconflict-side-1/secrets/manash.enc.yaml
@@ -1,0 +1,45 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:7nXFjGr+JEn8UsIs4omppTF6Tw5xihebJQzlu31ZEFyIxCl9fCPgOQK429weIwY=,iv:4bLASEe8v0XUf2NEQBHvhsXggk/oKv4oIj60RsVR/b8=,tag:UWtc9GIQnmEjvi/UL5rtWA==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:dk14TvqJ5rL4lIaRbbpoDx9odEoK9Xzozh2cugcPqJMih+RnqBmm4xqq5Q6inHd5P/aDW2MWKmVUsTg=,iv:7zEvuOGjTEp1K7QjmXkj1oc3WyqjESiqQTXfq3IH4uU=,tag:CjXivh7qKWx9LHO7yTvI1w==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:18:10Z"
+  mac: ENC[AES256_GCM,data:f1+JQ9sBCpeqscBOvsqYqknAckhGiVef59wWWn8/5uujqOY6op/4Zv8IHkhmzxMAqWL3In0IiuR3z2Vxlcg/vx1CalJYCBp9g9wusVh4LJYUlOHgRg+3PkggjKtt0Gk4FQp6xDFEpYUb6tYwvI3ZQQZqXOM0N5Fr0bUlZrrAcFs=,iv:z32EVTDnWYoRk328seltQ27Zsk+S26sQ+33mPRA5rFM=,tag:KbjThtF5rF+7bwK0UJFQfg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnQW5WQUNmWDQ0YnNnWFN0
+        VFhGT01QeXo4T3NYOUhtSzJjdFIxcWdhSm5zCmcxNFNDSnR2RC9sdW5CQzFGWFJO
+        TmNpZkZDZ2hPV21QZGxHYkdIa1g4ZU0KLS0tIG1xMmovbUFSOXQrTnJjRXhFcXlr
+        Ykk0TkdIMThwcllYaUZOZlZZMFV2NDgKpwZbcGniXL5j5E0oaExuxy2yg0mzvt9W
+        EuT/O0zCnGfGlvPAiuCI3d+dNZ0fnKb4e/kDTz1cZlSTTZ0bu5E7Kg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIU0dKOGlMN3hFZnlXNjRw
+        ZU5rQS9HRHJucm9qa3p6b2pZdWVSY28vdW5jCm1wcFJRYlNibktyOVdHR0JVN2Fh
+        MnkvenRVRnljc21pRmllcXZmdk90UXMKLS0tIFJOTkFRam82UUQzOHZDeDZaNnVi
+        WGdHaFRTZElrNXlUbG51MWlFeXpYaWsKju6PbORYFqDxsxhSc8BAIsVE2TMM3qHN
+        qLtAQP90kLZ7hZ7dXtS6tI9LUG9wiFf3R3RPKQyIYcjSkmmT5CLEuQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjSjJRNWc1YTNzZWVEeFhO
+        TnFObW9qZkpKWjc3R2ZQQ1BMdlFBU0VJYzBrCmlGa3BUa1p4ZzR4SmRxZjFmWnhD
+        a0RtWVZFblRsdG1pYXJmU1lTQ3NvTWMKLS0tIFo0elo1TktuTnRzamRlMkpZaFRs
+        d2J0T3hBc21oa0xpY2lxZzF3ZC9Ia00KJ476XOLRCEEZv3JvH/TEZqpWC6JW+es5
+        RGr/7WmvMm9DyPliwGdMETzWfDSweN545QiLofFrs7xAYBuSTBS3eA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrUTJjVUpQVEoxVHdzQ2dS
+        TU9uTitUTmlRa01TWENFVnc1bW1KL2MwWVdNClNUcWhDNGo3ZDVBeWxzWm1DcW1S
+        ZlQrcnY5TXRSQlUwV2lUNUpFWUdiSzQKLS0tIDVpdEN1d21TbTlubFZGUnFoMTdY
+        bVR2SmRvV3FPZks4cCtVWk5VM3gvK1UKldfANDooYmyhSUXuFXkx41FHlg48PdNQ
+        acSGNMHbpHdWryTy1/InQ/zYON+eFRxCp6saLUaThEjRVjC5HLBvig==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:ZEPLllMaCT6CL/niE64vzCZYxU/4qwqofSH3/vcBZdrZI5PrwiIfjp85/QGRkxDl8CVZh8nhNd9hlrJ1ew==,iv:zgmCYCcyfiokdTDvMqMGYLKc8Z8DJoj2Rwz1hUk7Sok=,tag:yPdHH+uVG0y5DHBGmGUXMQ==,type:str]

--- a/.jjconflict-side-1/secrets/minish.enc.yaml
+++ b/.jjconflict-side-1/secrets/minish.enc.yaml
@@ -1,0 +1,45 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:t/6TKQa5ADbuXqKu5OZYFoL+INArb8S86mxFRSPnr25ip1EqQsPPHSrZJDL0CZ6O,iv:WWeJhWX2vrWPLQFw41ZAbdszjDqvmMVHVv1xyVOxp0Q=,tag:jEHodqzhI20aoqTYz8UwCg==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:baIGapTb1ZxNFM+0Brpkk30osUGAm0D6/1OuidEp5gg0113Q8VcsEixILICW84v5av70wGGpwr5eOxM=,iv:uu8GsQOY082GaKhSCIdtHwqLHab5ovyGHX4Guilr8e8=,tag:bNUTvmpnviwmHCvVpOl0fg==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:18:42Z"
+  mac: ENC[AES256_GCM,data:HPX7PRSCZm50WAWtIgYafxZvcZn5Q/jiyRFLjIPsMesQmFuOWHM7S9IUu/D5YFVxCjxP3ban9fbGSRbWhNMZmM4s/pdbpqmOk7+85EkwPCcgzBimZDgNz8yAtEta9UcIs6na3MKCNhAHOEkHdckgMR2g5wNK3/0OVdpuZ+rb5qE=,iv:qZPm0NCs4HWFbtRhMdDglQEl13Ki9st03ckRtPyI6MQ=,tag:9hNM+EteFFbyJdpJWH/2Kg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0WW53NlJJM0wyeDh6NTBO
+        YUQzOVBmMGZpM0M1aVU0Z1FzcEFhenVIV0JVCmh4eHU4NjFxb3VKeFF5Z1ZPNjd6
+        Y1VsVHd3aVRSL2FkNVY4NkFVWEZaRmcKLS0tIGlOclNjYzdaUDVwZU5FamNnM0hF
+        SSt5cU8vUTBEcEJld0tlSUFJY1I4RXcK0J5UaTjZjDdOS2gPoPIXe/CJsLnZsgq+
+        r9un3SUpKWfpFdHfBOAFa/l/7gMdCyVSXpRg8QXH8DvzFByetu2W3A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzckRVNFRKYUl5bDFHV2lO
+        czd2UHlBWW5JQ0xpT3I4WmFmZW1Ldnd3Sm1ZCnd2KzFFUmUxUFIvQTFrT2JiRkI2
+        cC83OXdOU2hwdk02V0ZnUE1jQk1Da3cKLS0tIDZzVGN4R3dtV3E5b0VuTVVvQ0x5
+        QTU3ME9mUmJmQjNXa0hBdnBpYmNBZzAKXg3mnJAiWEM7fmKcTr218fueMup6Keyd
+        Iw3mxTr/AaGSE3WRw9U3FLhPnyuGaBduPyEJ3fKr34M4ITnrqBs1SQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBURDBVTlQzZTFhNlU4VTVu
+        YkMvOTBDdEhTTUpnQW5hOVg5RlNWZS9VQlFZCnpUWW9XRTVmOGlFSTJ6TXBtL3R3
+        ZVRVd3c5RlBXUStIdGJ5WGptZEJDcDQKLS0tIEVPeXVNS1BqU0dvOGZpaXZhR0RY
+        TENmd0lqUlRiaVo3eEh6L3dwcVp6NncKpuYVtzBxRTHAyamjTLkgxdw0uzMc3/nU
+        oaeakcpJACr1GQb6/TjiL64igMvgQ69h9AEvYABrgdGzqwi8H8fOBA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvSnExcC9PYUk1MVBMZlJI
+        S2M1RTN1WkJWUEZUNFZuWXdPeXA1dVFXODIwCm93Q2ppenBMTlMwbUk1SmZpM3JD
+        L3UyRTdEQ3hEZyt2RE9YUzNROTd4Q2sKLS0tIDJxU2dqZjRkYnJocytFeU1pWFdn
+        c1lUbG8rRExyazczdGdXbWpuazc4SEEKt0AO2VurRA31lERMofSaycgs+ZDA9mZV
+        GqJebZNxc/5KvEXx/rxQTqjaN3tGRDR/oCxVGF0ljVKsnvWfrGNH1g==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:hh4dCCPW/ggnQNz0PiMIIYrgXS6GS7ZLHloUtgXZqmD+Kqcd4N8+E+/Jh4M3lb6iWrjcnLbp5o7XTqMhBg==,iv:pDDPciOy36G5LTIeQom3TnsH8hpl96lFjwAD0wK+lHA=,tag:BSGUbHdGs2jkeFuvOMXX9w==,type:str]

--- a/.jjconflict-side-1/secrets/nalsha.enc.yaml
+++ b/.jjconflict-side-1/secrets/nalsha.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:snW3Mss2JXZLy533H36PA6iKA6GgPpN4c+h/pocvvyJHNH7heJq/0+Nodw2VSI/a,iv:yTRhmH5anA5ZmthhbGgFZcbgSOsJ3MXWHB7Jupt0XHw=,tag:o4srWprcFEI91OblmyCXWQ==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:19Im7ckaD/nWE/HaMlmoVpgUlnxBs04emF280l7r8U3U0ll93yTmYvesGH/2S6d62gHH1GIOAQTycZM=,iv:9rqUZp/qd81P7uB7/H6pvw5lJswN9FagZi6WedRJKzs=,tag:yJ6VBVpvMGgoddOzxG8oJQ==,type:str]
+rke2-token: ENC[AES256_GCM,data:g/AJcEXEFsdCvQVrXEhPjR5ZIrWPXRW3bmLjqD1UifvjAC9wpJ/xZKsA0Au+ssA2JUy0P+Rei0jOoSWYA6SWiflXTVbAOI5ILfa/KABnifxcTqJYgyHGM1hXdfcDC4UO9x1JG+Pa5FFisZqe,iv:2DecG6Y2IDS6Cj36B4TjGaHTjyyCh2wuh9Lwc0BgLEs=,tag:YubnDbaHkGrv2mFhlTfNag==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-04T23:19:06Z"
+  mac: ENC[AES256_GCM,data:CjUzO/g//T9VeJKuw18xifslkVEXYsXuManGX6/jwfJXhAzTIhvrPnVETBugYc0y5TdzApALOCN1RWSlp8o/yHMx2FKJ5VvJF1Sox35YwG6EIAq+dr7VcHiMiyXBl/6Ng5Vp098X+uc6W7M0doZR2csBpbUZ6DvkVuwkXbBlGPg=,iv:GnfJGaFRuIy5dDqhHiYld2gvdFjA/1mDPJQBjKYarh0=,tag:UjcCq5XmwAdiGtXOx5Q9WA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6UTYvYkNDKzRhWEQvaHlB
+        OWE3L1RhdVUwTHprN3pEd2dBU0NsdGx1TnpVCkdmZHpaU3JoWHNWNXRKYTFsTDhR
+        R2xJbWN6akh0MWlNV0hMbno3RjNaNEkKLS0tIEFHTXlsTi9pNXFaMi9QUVQ4by9z
+        UStzajZyOGlLTDRWeVRXZSt4N1dEWG8KRrRLSEaYv1dQNwbIXZ0bWC34fg0KAZZI
+        xJNIqLa9fV9a5HRABcHwJ2gBJWhw948IUELVl62JuyYO+hlXBvXYag==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBodnNBQmR6ckZNaDcyM3Yw
+        U1h5S1plYS9vUmJoRHB0dmVBejlQdWVCclQ4CmFTVFU4UU1RNVRHMGxhNDMyd0h0
+        QXlWaW80bkY2VlpIUm5NdU1xQXBZZ3cKLS0tIDhOdEF4Wm9aVGhlYWRqVjdCeXdl
+        b0RTSGYyWkowNnpGWVMxN3hBNjdRNHMKXOuB3CcuTEgTyNmfM4UBj3naUqH1xTBJ
+        DunoIIyv0BwpQw/USUm9RA2Xh8et8PuUJzlAcHe3Tj5k8EFQJiUuGA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZMlZsenJGamlzZGtzM29T
+        MHNtTFBhdmNQRitzcGNNc3BCTmpyTXJoYnk4CjRkNTdidjJ4c2g1T1UxQzB2T3k3
+        bEFlZmEyak5rY3hIQ0ZUVjhFZkhzbUUKLS0tIHV2cjRBLzZMOTN1Snp1R0VRbktW
+        SUdVUEhGM0V1dFhwVE4wY1o0OUllTDAK6SG1HnF9oTtChJfm/y0cCs8+a+BMD39F
+        Sc2OLJkve33/SVexI3inmFadAA5+CtAdnF7F+t8vNJEhC1kGjfn1OA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBweXVWeGtVM3pWb21KTWhz
+        ZENWTVFxTmVYeHFXSVpIYWdIYzcwYXd1bW5NCmt2ZEttMEI0aERqTlVGVFRvYTFJ
+        Q1V2K2c3aVlDNXVFQkhpNExRMlphalUKLS0tIGxRcUYzekJPZjlJbGd3M1JCRWhi
+        NWEzZWpSdC9FNG16NEtXYnZPVjZ6Z0UK2aJRKUkSJfRt8Yuca1rFmkrfYFlBuKbM
+        /fuD9Sh/NcSoO/H3mzP2vqIYo+DLUidc3y5/nX2NreZ0A1Lmf1dEwg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:VYdbGIAIfhzkTR4S6uXdVrVRZ5ik8+yeImeEAnhMndXCUrpfkiL4kZmcZuZuSqzJdcrApGqerjKQYalSDek=,iv:5UdlWSJebS37zz2/t1bgtTk+4J+37osTgi8ieIHE/II=,tag:c99a1/G8MdzUtzjce5w+cA==,type:str]

--- a/.jjconflict-side-1/secrets/nemishi.enc.yaml
+++ b/.jjconflict-side-1/secrets/nemishi.enc.yaml
@@ -1,0 +1,46 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:waGWq5I2MZEmHYUQzNu53lj9/D8FAhnmwTSpPnz3+BaMsYhZe5qe/Xf7e5Fifhrq,iv:/lQmN5UrwDNwlIFAhGky4BkHL5RfaQsYVdjF2TYm+ZM=,tag:me2eFvJMSqXE8OJ0h2ETcQ==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:rw+peVbm/oTOVhfMUrmAQI31EAYcLp+XH7WBeL6ae3CtUSb8ZP0xeVO2nFXDa0yIP4ygVYE7AHEXyv4=,iv:ogXQ9rysIiFbB5YEaiOEYcdyLBwT+3KXmIPeITsVgyw=,tag:8EWoTDQXDdIfuUADjlXulA==,type:str]
+rke2-token: ENC[AES256_GCM,data:jr3FAFEMjcJYp5GEZ2QiNA4FOlc79Ebg3isbIF8zyiGq2CJM4LnKV4LrrqAhoW/J0uG5WtEszZVGrET5umR4oohcwxIcRwxzNZ8v2ZlqboxUyjHO23eyKUw7HKdq53DIv5Xr2baxs4996S0b,iv:nyn6F2MxQehUVoQF5IA/BP/RK5PRnf7Hq2z4+B/DdTg=,tag:EC+B433pMRQzs3UhHgZQKQ==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-18T00:13:15Z"
+  mac: ENC[AES256_GCM,data:vIgUr98wab8yZwvwks8gFoFRBcuTP66ILb4DM6Gj950a1QZdm+eos9mWf5GXFDarT/MGXxax8WTTIQGuAdtRXIyOiTmNqljxJsPusYhGEGkcGpUdoCMqCumEEl/7qr9oaxJo2LcGVO2cCL3fpygJnzr4xl/DE80JpR34saGoD9A=,iv:1IF46VBM9kBmKfKcZ7Us5XyySBdxVxXRQ0YvOj4e7ZQ=,tag:L7Kpqf3wAYv1swYyL3tH1w==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYTVEvN09BZ2s4eG12QmxT
+        dzZvY2cyejZDbUNBVENBVFcrcTFVTDZQakdVCnJkL1pRTXRTYWY3QUxsUGV4Q2g0
+        Q2dOSFkvRkRlZHpvREVFVXBsY0FnZUEKLS0tIDFsMGkrOW03RXViSU5XWEhWSHlw
+        RW5hUkp0OGFoVVVPYXZqeERROXhHbjgKsQ2j9Qz3xDwomUNK0KfHUeIAoV3ipZ+e
+        hoiHvEOS5gxrrm3wn6M0JQdrx+mLDST3QgCEG1NLrQHsD3hZIvZ4rA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmYS83a0hBWDdKS2xMQ0dB
+        cWZKOG5idUpxbUNTRHdZb0JSbnBHWllZMmdBCndGY204bi83V3pETmgyM0dRTUNY
+        M2lyeEJaUlhEQURZajZHRlgvc3JWdjQKLS0tIEZXdG9xMCtpd2lVYURXeVBpLzN5
+        TG94YTZKOUtJRnVhQzhBUEp5bkphM0kKNx+4tH3ZiwX1tmBjM9J5Xhsye/N2ZRk3
+        HYJn56R87j8M6+Pjy/dT9z+bBu30Xa33IIA0yflpC2yXgm3TZAjyew==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEV2hYNzBBQ3krbVBqNytQ
+        Y2g2aERsdUF0RlpuUTN5T05PZ0ZGNWF1Y1ZnClJKeEZMa3diSVFvRkdKUWVsSGwr
+        SzY2cEpsNGt3T1dPRkFQZ05UNjdGY3cKLS0tIG1CK2FFMmFiSFlaUFRKV2hIMWVu
+        b2hvRDRSU2NyWVhEM0tUZEdtclUwdzAKvOZCDzwxkS6CTP50t4qrXaLy2qp7xL5s
+        j5KirK6PGEHzvZqVwCdPHygbhSSg6uYWmDUfCdz/+BXY5DXBglj6Eg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPTWZWK3FLVHVTOWNZbFY5
+        Qkd3VDNGU2d3ZWs0dlJGYk5tUDFLSTFGWW1rClhuVXNrbmZNRzV2Wkw4VUU5OWlv
+        M2taWHphc04wcFZrM2VoMnExYU5PdU0KLS0tIG92MGs3MFpvcWVlY0hoVFBTWkw1
+        RHZ2aWpjbVhzeDVqaStVWFdGNWVGbGsK5lgNMIpU2h5W7QPSeA7upQBUBNPWs6WW
+        z9rPyuGgRb2rjym6HQxC94Cq1IItHaJrFFE9vLNE67+vDEMZusIwzA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+tailscale-authkey: ENC[AES256_GCM,data:xBCR5J/gLhrS8i86SShPyr4HNCb+AsrcZx5SrD3Povej80HglRPZ2Os2gRE1XvwEkpBwXpGw2eHvdbnCwqw=,iv:V0Nl34zHjQfl3+kqTRlCxnUkUNMKwaNgEmHxPRHMaQQ=,tag:bg9TbfaxahQVrWUWPgQ1uA==,type:str]

--- a/.jjconflict-side-1/secrets/nishir.enc.yaml
+++ b/.jjconflict-side-1/secrets/nishir.enc.yaml
@@ -1,0 +1,88 @@
+rke2-token: ENC[AES256_GCM,data:5AosLTIWOjoCETFBJHXWe7R6NiSiUmpLULA7P0/zdwx9CnwyLlQBHiNR63RjqJLpbfzBQ7aD6+1a4SuhdJWQg+BXGWU/zuecJk48oOH+Na/BtRlKl/6XQBFGfQMfPxOypEsy6w74ujUv30vW,iv:HMhX5w6NJQ0MtE74qSAfgTiPrHfMqIQnEQeakW0OxBo=,tag:nwB2AYQvMq0Vg24P5fuhgA==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:28:10Z"
+  mac: ENC[AES256_GCM,data:43xVYtGcD2XSX7cYsgYPs5Vu7BO+A7LxqKCvMXsj6pqJU5IqpdAF6D4bHEX47lgpwjKwCzQa+6Ad6no0nVs//WGFySZkoDzSbr1cWOf3AFb0vJxDzQhI6r+UyoGjhli9GJ4padRiG9A+0Yzsa2PLjpSAxc4enhPXxsmwW6FrO4g=,iv:gShWJlO9hMqMaWuRCNWqsfrX9DyNCESzQZ5JOWUpxuM=,tag:KqKhGsyl6TpXMZyRTkbENw==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxNkRFcVlscU9HcGx6N1F0
+        cWVKVXhTajFoSGFLTkZQS3NjL3l3RGxpa2hFCnhaQW5VclJtRTVTajJnVmdpbUtQ
+        bkdwY0VycFlBUVYxR3hPcnNOdUZVQ2MKLS0tIDQ4eTlyN2Jqei9jTXlGRmRYSkRG
+        YmJtQVNDRlpra0NWT2dtaXltMzRsbjgKtyZ5N4geIO+URngJfGDufSYQLVWcsG70
+        LomV1fBJS18WKug62RmnoHOzONzroGRAKE5BwmGrr2tjbzUy8EZvGQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBCNk5tanVqR1BsbXo1OWpl
+        SlBLL25MSkhPc0FrY2RBcU82b3VTYjMxbFhFClpJUTBEK1I2MTBDY3hYN01yanJZ
+        VTZXMThUWHVRMzZyRGRIRC9xd2RYMVUKLS0tICt5eEV4REg5Yk1UaVM4TXhUVHli
+        cG5GU1A0dG1nNW1ZMktueTh6RjNDSHMKkHw3vgjEy46GMddJsV1XgFO9b1+FQqYK
+        bDd916OUqerXwGArZfV91s+tdvMMNetJzE4v/n9rFjz4pCPeQaFmGA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLWFlROXlBa1lRM3djd3ha
+        SktwNDFSVG1LSVZ3d1FyU2FCV0FPcjVuWlVNCmYyM002cFZldGNkT1FpTmxLRWNy
+        UUlLeDR1eVV0OWU4ejY5Q1RrMmlsbjgKLS0tIExFZkZydlNZck1oYW1pK1pHWSsy
+        RVN6K09LRjV6anFYM25rRWREWlpsb0EKLUAo+l8ZqfImRfJeSsk0QBCOiFhpJHMh
+        vIV1kDY1TZwiYT5klbv0KrcFMY0SQiZgFtuCDWxP+YOSr+ERnyTugA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoN3JVdDIwZmJEcG80UFRW
+        eklocDY0ZHpJZFN3VEtxcTlvTlgwSldENjFzCndWcDI3QXpZV21ZaEtpMjIzT0Fi
+        WndZZWdqUlprVDRNYmhwYmR6RGtqQlUKLS0tIG54d21CQWRVcXpnUE8xbXYxVkI0
+        YXNrd3FETWJHRG0xLzRYaWJHRU82dHcK345pk8mV2j7WY5fzfPGUxJ3CpwfAj66P
+        giyG29Iw2ANqjdxwyOtB60vC/AZt+4mhMxCjqGIpNOM+j8kTJ6sfZA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlUGhhbGh5ZENrcXp0b1l3
+        VFlKNnlyVWp2bndxN2lFUjhhay8xSmcwNEFJCktmVjZQL1ZTREQwd2xkaW5PMWlI
+        VC9XNVlOWGhpTHhDdEQrZm1yQUxZTUkKLS0tIDUycHJVQlVndVN1WUNGSjZXMkxB
+        RkZRcWZ6ZmV6L094ODhpRFlhYlplN0EKHVIhsIJMMHUW9SVAaKdsMgW9N3z/79Lz
+        PXCIPj3q76/QD+RMacE691KI9OtNSTmcwTqNt+a45J6vlGV1+InArg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDaWV2NzY0SXRSdzZPVnNj
+        ODEvRUkybEx2UlMwaTdIeGRtby9aSmw3bUZvCnpoS1ZTQXpOb0RFU3FMc01wZm9V
+        ZVZCczlaVlppUExTZk1UNGFpUkxQTXMKLS0tIEs3NlNvY083WXNTWnREZzNieDZ4
+        YjJ2ZStwNW5YZEM0QmU2ZjNWK200a2sKLulTRxCziQ/il/aZ0JZ5EKGTiIPVutRI
+        NDasw/7GIBTzMARRaeoErYOkME2x06hBUsLJsj0dYN7VEgGXZIHFIQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxazhlZWZKdlA3amhBcDdQ
+        SXNTT0hTaHppOG9MMHJvbCttb2JrYzdXalNnCnE5Y0tvMWE5T3ZkOTZaUEF1RUNC
+        bFVYNVUwbUdPeGFZbHYwVFdVNXRIQXcKLS0tIFQ1QUJkTWxseG05N1FkRFNMNE5I
+        dk5EcVBBckw5cndQRU96eEd1aVl2TUUKXoM8ncbFKQk8Ot/NEa4o+pXLnJ+MkJJb
+        kk+ui15uZkXQpp10diukYIcztKVqO7HSAbGPWJf5x5PN5OkFww9GhQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBvQWQ5N29NQ1pGb0R0Ync0
+        Yk84YkxxRHh6QXhDM3VZZlY2MlhMM283akRrCnVlbzlLUUZhT1ZFOGUxSm9WbWpv
+        ZHNndFRoT1UzL0VXa3RyTHY5cVhqZU0KLS0tIHNGVVhDQVc0NGI0blVRWmxDUFcz
+        RVZ4SEF3alF0bCtKSS9EaE56YmFHUWcKqthvweRL6fjR0ogcxE99RYhtyvX50mMv
+        Qu8ZOw65dwU4DfgYxjmhigh4AVJZp5wTaiIEbU4CiYPhrtvOBAHAdA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPZXhJd1ozZjlPK0ZMWDg0
+        OFhYU3RCN3NjaDBEdmYvWXgwVXFGY3ZDVmdRCm9zTWE3bGpCdWNDQ3ZpcGtjZXNY
+        aUFZY1B6NGlhV0xYRGVvbzRlM0FqMTAKLS0tIFlUT0hydCtzUmhIeUIvTFN0Zkw0
+        OUNSZlUrVG1WODZvN29KMjFSM1MrVlEKjzCCTBaVLHkhpjdjSTevl4m0NLCr3QGz
+        ICUCYkG+mh/fKa82CtdvebjIVvHzzdqcp/2E2X1hQqNeMlmtgkV4nQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-side-1/secrets/nixtar.enc.yaml
+++ b/.jjconflict-side-1/secrets/nixtar.enc.yaml
@@ -1,0 +1,44 @@
+cachix-token: ENC[AES256_GCM,data:dwXGa5vw/rMwCj2hXQOGR+qxrc29gMKpqATFm4gmIBKJ5A36Hav2Sib8SNU6NwhvHXi79scQLE/wt8Qyn9M1JH+IgoI44Qbde5sWCBtoYHNJFC3Ai1uhYKqWgv4AUAkBndi2PtSguZe1a+sM69QgXnlY8AAkHM/y7CXShBLQ97kGo8ma/+7u+mzHTablMz23Hw==,iv:4wqET0AwsNOSKSZENOwrMnDtL98JXqhSrSDG8DOJoqU=,tag:VI6pUkNx/1Wm0+yEGix6Zg==,type:str]
+nix-access-token: ENC[AES256_GCM,data:dvLgcrShcdgCflS79pyH916it+qlb/ZDGsMik0z+uP3FJ0pAhlSABg==,iv:i2RDw9AdrQ2SIX7raa42MvYC1TcLkMrr8vW3xDAiLY0=,tag:HSZ/jj/NOSpm7UyADHnkCw==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-06-29T16:39:19Z"
+  mac: ENC[AES256_GCM,data:aZzVwt076CLVFqVqgrcH5dCB2tXjC3z8e1VhFE4JYLYvPJVuR6AfX9kadML0Xx16bkNojpkD5y/BRiACnL+72126iqPtU0w9sWFfbL+1OIxeicqwsJUW+g1vtB8RcmDnPVN2ZcFdE+Blsz2FmRoMgozC8UbbKuqAsPESVrnl5IM=,iv:iYZb1OT0nsZANSFhCgxETcTISIQZID/7TTXvYhMdMcY=,tag:7SmHXqBbzRF9JNxtglCUDg==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4cXBHSWNwOXRXU0JMYVhh
+        Qk52TXUzZ3JCUmtoZGNaSG9acnVhdVVlSldVCmhNdUN6amxlbC9uTk1DaDBTSTQ2
+        aUJQL2hPSU40RGV3eGlHd29TOEc4QzQKLS0tIGJ5ZzhwaVcvVHBVdHpWSmlub2hK
+        UXU0U1E5UWZEdnNWSWtxTStmQW5ibGMKgv959BPaSISSi0RKYYw416q287byXhM+
+        sEcSvTyKPwkNy5ITz6khAwpHHXxdyUXpHL0WrYVVMwd9+aspdSDDKQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwVFlwWnV4NVVsZGlQMjJZ
+        bHRrbExVZVFkR3F0eENlQ3E1azFVcUJ5REI0ClQ5Y2ZTK1BPblFlN1VOSnU2Yk1L
+        ajZabW0xbzFjM1ljQ2NDaEhQL2hCdTAKLS0tIFUvaENYa20wdG00UHBEblpZdDMv
+        eDBabzRJbUFseTl3RlMvVVh1U1c1ck0K1FleW5E945xk3OqAGqu2yHy4qnAdnDBK
+        hfbL+O2aRQMYHiLv2EqTQk2w9TCp9lndCBdLEkDRo33shYgStCbizw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1Tmx5RFZISXp0WTY3dXZD
+        d3hGS0JtR1E1QkQyVm1ZM3JoNlVERjdNNHlnCk9WRklkOW1pQnBrQzVIOW9uSFV2
+        STRnSFdoVi81SXlmODhmdjhwcTJpZGMKLS0tIHd0bE42RWtFVXNjQytlRVhyZ0lQ
+        ZDlSUE0vZGJBamlhUnlvd0ZwOHhTd0EKRpQSQdoHUfZsSKqmZls/DPIt8w3O9I7Z
+        RCRPzvy061e8RAdGo1MwC0BnLfFN9G2e2VfBtDFqx5kbKMbZJgKDOg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB6SE42dDA4Y3ZtZkpUTGli
+        VnRMdG5lci9mS1E0N1UwR3krSE1FVVFnV3lrCmtZcG1SUkQ3UDl3VDVkY05iZ3cr
+        cnpJT1JDRmRGV2tzVHNFcFZZQ0VWRlEKLS0tIE5DU1FhbWxBRXJncDVHbWI0TDk5
+        czk5VmY5ZVg1cDh5Szk5TjNmWXBIWlkKe3cCxU1z3lD4qLryQgPtNgBSBCT6R3nA
+        qZVBZzbK9LZheByMR3yBTHagFtFC8v9JGXEnmKMe1+OkBVMVd481JA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-side-1/secrets/shikanime.enc.yaml
+++ b/.jjconflict-side-1/secrets/shikanime.enc.yaml
@@ -1,0 +1,34 @@
+cachix-token: ENC[AES256_GCM,data:dwXGa5vw/rMwCj2hXQOGR+qxrc29gMKpqATFm4gmIBKJ5A36Hav2Sib8SNU6NwhvHXi79scQLE/wt8Qyn9M1JH+IgoI44Qbde5sWCBtoYHNJFC3Ai1uhYKqWgv4AUAkBndi2PtSguZe1a+sM69QgXnlY8AAkHM/y7CXShBLQ97kGo8ma/+7u+mzHTablMz23Hw==,iv:4wqET0AwsNOSKSZENOwrMnDtL98JXqhSrSDG8DOJoqU=,tag:VI6pUkNx/1Wm0+yEGix6Zg==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-25T23:45:28Z"
+  mac: ENC[AES256_GCM,data:OnoSFR6Mj6oCGJwLU5UJpFpmPj5F4MH7JWADgNr/XpLb1OT8Jb01RWzU9vnjmocANMjhL0Hmi69CCxDSS+1C/uJBEbntWh8y15Kx22wKYGX0D0JM9UVZL6MjqK2czgleRV8Tw84GncxhrSPTCsXFS6TtRR5vpGYH5M7f7T0wxAY=,iv:HcSoommTPisTDv70BQAZPlVx4AU3Xro1b2wpzj2VRcE=,tag:Pj6Np0b5PrQDzaMA1hNbhQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrSUJHTHBMQTZIa2YvUUYw
+        bFljMUt2Um54MTF1WnhJWWJXbEpKeTdYZGdrCm01bnFOUmpucENXTW9xbEFvQ0tD
+        bkpNUDRJY1BaaTgvZjhjbEQxYXFybGcKLS0tIDhnL2hCdytFYXVxQ3JtWGFSc2lG
+        WXlCcGZhVWwvd0JXc202eUFpYjJlV3MK8BUcmudbDHXPQpM0lrb8mG1MZAxY8Z4M
+        zWnpHZ1pUCILw7QiTF0XFL4C6RhATEkW7MwAmiffaeskgPScWrkzHQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3d3RwcU5lMEsweUIzVDFV
+        TmVlZXdoelY1bkc4ZnZSQ3A0QXh6enovOXlFCkR0YnUrLzRDWWZaaEhxcGMvSUhi
+        SStzUFg3OWlZUllIQWFrSEQ3RkdJMXcKLS0tIEtUMllaTVRQeHFVNlhFOVluMktI
+        aGk0clZGNWE2OU9UTWhnbjZjcEM5N3cKfMJT8JYSRz97Jh/BWMcvn9Jznfhcn0zn
+        VWRpQ81l2qlMITy1wepwaNAWvPJqMDlG/RWcWswYg1lSLNZRjxsMCg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNT3RRcjk3bXdpMHV5bWdW
+        WEsydEVRbExZTWhUK1NWWVgyWnBnNmszaUdVCkVPZkZFT2R3QWpka3h3QnZBbVRY
+        UFY4NnNSK1JMMmplZ3hybXpxS1g4QWMKLS0tIHdmYk1DMU9rbFVhRnNPVDFFU21G
+        WHZrckl6WkpVNFhHR0V2blhvd0pndFUKRthQwsIiNQtnStWWnvtlu4j/cnyA12/M
+        bqlF2P+pbNaikcC19l+unag2LOmjZK3wv8f73eZuGDG/XMaV3649rw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-side-1/secrets/telsha.enc.yaml
+++ b/.jjconflict-side-1/secrets/telsha.enc.yaml
@@ -1,0 +1,44 @@
+cachix-token: ENC[AES256_GCM,data:FRHttdD/mTcbI9oniGsaCCkZofvzGKvmRRuyRBRlq+MPqmC0oH2cSGrxNDirw7KnWQSbClUlT88MJSXZK3jn2eCtV+O1sw33/shVPmeLqCKdKliYFLPSgzvcYScBmHkIkScJAkcJYsiNVapuXdca8cufg2cvbW39xfo0JhDFzSF3iAQf53Mem0bfCFTtG4O49w==,iv:Dn2L1qrttIC+hKyJR7M6vPMZOhPz7K/QPmwOqFpPVCw=,tag:2T4i7ZuA2Jjrpb2veTqDCg==,type:str]
+nix-access-token: ENC[AES256_GCM,data:DxJtamrimFuFVhi/3mJDIsndFg2e9L7d6wKRBKuS+XK97JQuRQvjKA==,iv:LIveL80d5piluFLeskVGv9AXamsxhNBbAD7LyjGkB7g=,tag:OfcJU//3e8cTxINgAtRpug==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-06-29T16:38:57Z"
+  mac: ENC[AES256_GCM,data:hB73dXZeJHId3lvCNSVxkuyFBVu0rX1hh68R4hyIRMan9qmAxrUPLJPloLBTJhww7TlktVYkuCe3Gnj87gM7MdTNPARGtk3e5uTj03irpNxDnDPQTtgYRUFDqvzVduzi5l/IA3AMIwVWWDMcFuxlC9S4pilWZmiEXaX7LtfD1Kk=,iv:PLbNqX0saZ2VsFKIkq0PqGoCFn8XtNSsFR6F/ol4/pI=,tag:8klp2hNOBVC2WKg68Oafqw==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4Y2dVc2N4eVQrcDF3NGJr
+        dWpYeGRSL2RzU1JBL0pXWTRGMUVQNVBpMEdRCmZvZkxQamJ3dFVrZFZ2YXBiNnNL
+        NUdaR3pKcEsvc0IvejUyWkF4UkRLaXcKLS0tIHdmZ3U3TVJVRDNnTlBwOFVFTzUw
+        azN3aVg4VGlYRzhBS0tzS0FrdFhRbnMKjxH2zknTPLnlb7zmAoO/81QQdh9sowi2
+        zkF6xBMMVXzOadpmhjNMiSkToALXeJXmu9kgrIn5Dr3lkBid0ZvufA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTdFRKVlRMbjdZN0ZZV1ZE
+        V3pjaUJvVVVtUTVIdHRkWS91aXViZERNZ2pVCjlwZUVvRU5xeGpLazFXSnNjMkFq
+        djJiZUNmc2JnTDQ0MG4rdytmd3ZpNXcKLS0tIEdUVzNENmdubE9oZVVVTUZYNmE5
+        WWg2WTc3cStla2cvZVZuS0RuUTFCajgKk6vpB8yDQAhrPvOp/6WRaovVx9sUtyXu
+        5EjTeBT+pOh4c165/dvW1HYffZVcmDByYTx7UCtHmXut6Q3c2BtHbA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByc25qN2xXSHdCQytTUUlN
+        ZGtqTFdxb1loY0laSnI5enRiT3lvYzBDTjBNClYzL2hkdkVuTWRRcU54RHFTdUF0
+        OExEeFpDQ1pPVGdkRWRGZG53SWxRd28KLS0tIHZaUW5jRjRTbCtJNDNVdEt6U2NN
+        RDdmaXZlY0xBV2ZmaU5icUtzTUtySlUKRjuup5MJRFFfo6M24erFpxFj+4TFBihj
+        HGQ9LcTfDM0OQNcOgCLDDD0QfNhBS7hwamD4YSssaybpv4ljghDQ4g==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzNi9PZlRUUGozZVZVdUdN
+        cWd3VXdSMUN6dnJpWWpaSnJXR09hM01OSGtNCmIxMmpsSjd2V3lUMWtyU3lITFpV
+        T3VqWnVTdUh2TzNGUDhhVVNITmVCMlkKLS0tIG45Q3JEdFNUN01tTXFLb3Uwajdn
+        Y3EzWVVpaWNiWWxWMFlsaHNVR0huZDAKRHxYA7g0KdK3Z8TMwqvX1sDKlP9sEUvA
+        PQ8X5L7B7iStPOdNtWwgxEOUGAsM9tlAj5ZYlf1d7zc6ZcjPZpHWWA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g

--- a/.jjconflict-side-1/secrets/wifi.enc.yaml
+++ b/.jjconflict-side-1/secrets/wifi.enc.yaml
@@ -1,0 +1,117 @@
+sops:
+  version: 3.13.1
+  lastmodified: "2026-07-26T16:12:54Z"
+  mac: ENC[AES256_GCM,data:POanrPpnw0ErniQ/gVdZxnj5FXCkvojkM5dxdQpYnPt/UKx2g6OiGa3OCgJJkWcbqm22C9HVvZz1MnH4nITpgm8SZarVkFe+copLy5QWCIHU2uUXmnYZhOHOofGgwcySaNcAU/GErA2OFuesR3480lHbiVwS+pAtMAVWVcJdWYs=,iv:sf+do3G6vpM4titItbWGFs+i2v5Ab5q8X6qy6Fn7/bA=,tag:PpC/flqV8NdWMxCvv1sdMQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
+        Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
+        eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
+        V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
+        y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
+        QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
+        L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
+        L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
+        lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
+        eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
+        aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
+        QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
+        +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
+        dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
+        RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
+        UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
+        OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
+        RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
+        MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
+        NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
+        8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
+        KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
+        ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
+        eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
+        Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
+        VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
+        RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
+        QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
+        bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
+        VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
+        bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
+        ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
+        PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
+        ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
+        ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
+        VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
+        wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
+        aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
+        V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
+        ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
+        NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
+        MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
+        QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
+        UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
+        EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
+        OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
+        UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
+        enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
+        Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+wifi-sfr-e368: ENC[AES256_GCM,data:FMmP09ByePKeRAxMEqKd5cbdQy4=,iv:i9y4k87u55Xp+oFbzKSXJef8pxL30rvM2/5gugmUAZM=,tag:KAeko7NNYUlM3ir+bDdoKw==,type:str]
+wifi-sfr-e368-5ghz: ENC[AES256_GCM,data:E6UFUAu9lvCFVIiDP8CHtkllxUY=,iv:NCV4qq/AqODIxtdO+DxV13Is72uECFqJXC5CNvOioNk=,tag:uxzwB7OPf/+KemYYsSTolA==,type:str]
+wifi-vintage-korean: ENC[AES256_GCM,data:8KFQG7RTtzFT57Jb/t4=,iv:aWlD4X1r1AXTELksH2KjtANKiaxqJ9ZYNWAaMdqnn2k=,tag:ZuccHQT6mWqvQCLg5wjkeQ==,type:str]

--- a/.jjconflict-side-1/skaffold.yaml
+++ b/.jjconflict-side-1/skaffold.yaml
@@ -1,0 +1,10 @@
+apiVersion: skaffold/v4beta9
+kind: Config
+metadata:
+  name: niximgs
+build:
+  artifacts:
+    - custom:
+        buildCommand:
+          nix run github:shikanime-studio/nix-containers -- skaffold build
+      image: ghcr.io/shikanime-labs/machines/catbox

--- a/JJ-CONFLICT-README
+++ b/JJ-CONFLICT-README
@@ -1,0 +1,11 @@
+This commit was made by jj, https://jj-vcs.dev/.
+The commit contains file conflicts, and therefore looks wrong when used with
+plain Git or other tools that are unfamiliar with jj.
+
+The .jjconflict-* directories represent the different inputs to the conflict.
+For details, see
+https://docs.jj-vcs.dev/latest/git-compatibility/#format-mapping-details
+
+If you see this file in your working copy, it probably means that you used a
+regular `git` command to check out a conflicted commit. Use `jj abandon` to
+recover.

--- a/modules/nixos/profiles/graphical.nix
+++ b/modules/nixos/profiles/graphical.nix
@@ -19,6 +19,7 @@
         # resolve on Niri's spawned PATH (compositor launches them directly).
         laptopSessionUtils = [
           brightnessctl # backlight/brightness keys under Niri
+          ddcutil # DDC/CI external monitor brightness/control
           fuzzel # app launcher; Niri's default config binds Super+R to it
           gparted-full # disk partition GUI (full FS tool set: resize/move any fs)
           pavucontrol # audio mixer GUI (volume keys only step, no panel)


### PR DESCRIPTION
## Summary
Completes task `t_0aa9e097` (Verify Noctalia monitor ddcutil brightness control).

The literal live round-trip (`ddcutil detect` / `getvcp 10` / `setvcp 10 50` / `getvcp 10` on the physical Noctalia panel) could **not** be executed from this runner: ishtar's booted system lacks `/dev/i2c-*` and loading `i2c-dev` requires `sudo nixos-rebuild switch` as root, but `shika` has no passwordless sudo. So this PR verifies the integration at the **NixOS config level** and fixes the three root-cause gaps that would have blocked any live test.

## Commits
- `ba2c5629` Enable Noctalia DDC/CI monitor integration (`brightness.enable_ddcutil = true`)
- `f5114000` Add ddcutil to graphical profile (cherry-picked; was orphaned on a sibling branch → flag-on/binary-absent before this)
- `e0bb98fe` Enable i2c-dev for DDC/CI monitor control on ishtar (`hardware.i2c.enable`, `shika` added to `i2c` group)

## Config-level verification (nix eval of actual ishtar config, exit 0 each)
- `home-manager.users.shika.programs.noctalia.settings.brightness.enable_ddcutil` → `true`
- ddcutil (2.2.7) present in `environment.systemPackages` → `true`
- `hardware.i2c.enable` → `true`
- `i2c-dev` in `boot.kernelModules` → `true`
- `shika` in `i2c` group (`users.users.shika.extraGroups`) → `true`
- `i2c-udev-rules` in `services.udev.packages` → `true`
- full config instantiates: `system.name` → `"ishtar"`

## Human step after merge + deploy
```sh
sudo nixos-rebuild switch      # loads i2c-dev, installs udev rule, grants i2c group
newgrp i2c                     # or log out/in so shika picks up the i2c group
ddcutil detect                 # expect the Noctalia monitor + its I2C bus
ddcutil capabilities --bus <bus>   # confirm feature x10 (Brightness) supported
B=$(ddcutil getvcp 10 --bus <bus> | awk '/current/{print $4}')
ddcutil setvcp 10 50 --bus <bus>
ddcutil getvcp 10 --bus <bus> # expect 50
ddcutil setvcp 10 $B --bus <bus>   # restore original
```

Full transcript: `verification_log_t_0aa9e097.md` (attached to the task).