### PR TITLE
feat: add Noctalia Bitwarden plugin (official/bitwarden) + fix wiring

### DIFF
--- a/.github/scripts/validate-noctalia-plugins.py
+++ b/.github/scripts/validate-noctalia-plugins.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Validate Noctalia v5 plugin manifests and Luau entries.
+
+Checks grounded in noctalia 5.0.0 (src/scripting/plugin_manifest.cpp):
+  * plugin.toml must parse and declare id (author/plugin), name, plugin_api.
+  * settings require key + label_key (no bare label/description).
+  * entry .luau files referenced by manifest must exist.
+  * launcher_provider entries should define onQuery; service entries update().
+No network, no Nix — pure static sanity so CI catches breakage fast.
+"""
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ENTRY_KINDS = {
+    "widget",
+    "panel",
+    "shortcut",
+    "desktop_widget",
+    "launcher_provider",
+    "service",
+}
+
+errors: list[str] = []
+
+
+def err(msg: str) -> None:
+    errors.append(msg)
+
+
+def balanced_luau(path: Path) -> bool:
+    src = path.read_text(encoding="utf-8")
+    depth = 0
+    in_str: str | None = None
+    in_line_comment = False
+    in_block = False
+    i = 0
+    while i < len(src):
+        c = src[i]
+        nxt = src[i + 1] if i + 1 < len(src) else ""
+        if in_line_comment:
+            if c == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+        if in_block:
+            if c == "]" and nxt == "]":
+                in_block = False
+                i += 2
+                continue
+            i += 1
+            continue
+        if in_str:
+            if c == "\\":
+                i += 2
+                continue
+            if c == in_str:
+                in_str = None
+            i += 1
+            continue
+        if c == "-" and nxt == "-":
+            in_line_comment = True
+            i += 2
+            continue
+        if c == "[" and nxt == "[":
+            in_block = True
+            i += 2
+            continue
+        if c in ("'", '"'):
+            in_str = c
+            i += 1
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth < 0:
+                return False
+        i += 1
+    return depth == 0 and not in_str
+
+
+def luau_defines(path: Path, fn: str) -> bool:
+    return f"function {fn}" in path.read_text(encoding="utf-8")
+
+
+def validate_plugin(toml_path: Path) -> None:
+    try:
+        data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+    except Exception as e:  # noqa: BLE001
+        err(f"{toml_path}: TOML parse error: {e}")
+        return
+
+    pid = data.get("id")
+    if not pid or "/" not in str(pid):
+        err(f"{toml_path}: missing/invalid 'id' (expected author/plugin)")
+    if not data.get("name"):
+        err(f"{toml_path}: missing 'name'")
+    if not isinstance(data.get("plugin_api"), int) or data["plugin_api"] < 3:
+        err(f"{toml_path}: missing/invalid 'plugin_api' (>= 3)")
+
+    for s in data.get("setting", []):
+        if not s.get("key"):
+            err(f"{toml_path}: setting missing 'key'")
+        if not s.get("label_key"):
+            err(f"{toml_path}: setting '{s.get('key')}' missing 'label_key'")
+        if "label" in s:
+            err(f"{toml_path}: setting '{s.get('key')}' uses 'label'; use 'label_key'")
+
+    for kind in ENTRY_KINDS:
+        for entry in data.get(kind, []):
+            entry_file = entry.get("entry")
+            if not entry_file:
+                err(f"{toml_path}: {kind} '{entry.get('id')}' missing 'entry'")
+                continue
+            fpath = toml_path.parent / entry_file
+            if not fpath.exists():
+                err(f"{toml_path}: entry file '{entry_file}' not found")
+                continue
+            if not balanced_luau(fpath):
+                err(f"{fpath}: unbalanced braces/strings")
+            if kind == "launcher_provider" and not luau_defines(fpath, "onQuery"):
+                err(f"{fpath}: launcher_provider must define onQuery(text)")
+            if kind == "service" and not luau_defines(fpath, "update"):
+                err(f"{fpath}: service must define update()")
+
+
+def main() -> int:
+    plugins_dir = ROOT / "plugins"
+    if not plugins_dir.exists():
+        print("no plugins/ dir, nothing to validate")
+        return 0
+    for toml_path in plugins_dir.rglob("plugin.toml"):
+        validate_plugin(toml_path)
+    if errors:
+        print("Validation FAILED:")
+        for e in errors:
+            print(f"  - {e}")
+        return 1
+    print("All Noctalia plugin manifests valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/plugins.yaml
+++ b/.github/workflows/plugins.yaml
@@ -1,0 +1,25 @@
+name: Plugin Validation
+permissions:
+  contents: read
+"on":
+  pull_request:
+    paths:
+      - "plugins/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "plugins/**"
+  workflow_dispatch: {}
+
+jobs:
+  validate-bitwarden:
+    name: Validate Noctalia plugins
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate plugin manifests and entries
+        run: python3 .github/scripts/validate-noctalia-plugins.py

--- a/modules/home/graphical.nix
+++ b/modules/home/graphical.nix
@@ -13,10 +13,25 @@
       };
       calendar.enabled = true;
       location.auto_locate = true;
-      plugins.enabled = [
-        "noctalia/bitwarden"
-        "noctalia/translator"
-      ];
+      # Load the Bitwarden vault-lookup plugin from this repo (path source).
+      # Location points at the official source dir, so the plugin id
+      # "shikanime/bitwarden" resolves to plugins/official/bitwarden/plugin.toml.
+      # (noctalia/translator is an upstream-official plugin: auto-seeded source,
+      # so it needs no source declaration.)
+      plugins = {
+        sources = [
+          {
+            kind = "path";
+            name = "machines-local";
+            location = "plugins/official";
+            enabled = true;
+          }
+        ];
+        enabled = [
+          "shikanime/bitwarden"
+          "noctalia/translator"
+        ];
+      };
       shell = {
         font = "Fira Code";
         polkit_agent = true;

--- a/modules/nixos/profiles/graphical.nix
+++ b/modules/nixos/profiles/graphical.nix
@@ -25,8 +25,14 @@
           pavucontrol # audio mixer GUI (volume keys only step, no panel)
           playerctl # media-key control for MPRIS players
         ];
+
+        # Bitwarden CLI: required by the official/bitwarden Noctalia plugin, which
+        # shells out to `bw` for vault auth + credential lookup.
+        vaultUtils = [
+          bitwarden-cli
+        ];
       in
-      laptopSessionUtils;
+      laptopSessionUtils ++ vaultUtils;
   };
 
   hardware = {

--- a/plugins/official/bitwarden/lookup.luau
+++ b/plugins/official/bitwarden/lookup.luau
@@ -1,0 +1,90 @@
+-- Bitwarden launcher provider: type "bw <query>" to search the vault.
+-- Selecting a result copies its password to the clipboard.
+--
+-- Shares BW_SESSION with the service entry via pluginDataDir() and reads
+-- vault status from noctalia.state["bw_status"].
+
+local SESSION_FILE = noctalia.pluginDataDir() .. "/bw_session"
+local cachedItems: { [string]: string } = {}  -- id -> name, for onActivate
+
+local function shellQuote(s: string): string
+  return "'" .. string.gsub(s, "'", [['\'']]) .. "'"
+end
+
+local function readSession(): string?
+  local data = noctalia.readFile(SESSION_FILE)
+  if data == nil or #data == 0 then return nil end
+  return (data:gsub("\n$", ""))
+end
+
+function onQuery(text: string)
+  local session = readSession()
+  if session == nil or session == "" then
+    launcher.setResults(text, {
+      { id = "locked", title = "Bitwarden locked", subtitle = "Open settings or wait for the service to unlock" },
+    })
+    return
+  end
+
+  local q = text:match("^%s*(.*)%s*$") or ""
+  if q == "" then
+    launcher.setResults(text, {
+      { id = "hint", title = "Type to search your vault", subtitle = "e.g. bw github" },
+    })
+    return
+  end
+
+  local cmd = "BW_SESSION=" .. shellQuote(session) .. " bw list items --search " .. shellQuote(q)
+  noctalia.runAsync(cmd, function(res)
+    if res.exitCode ~= 0 then
+      launcher.setResults(text, {
+        { id = "err", title = "Bitwarden error", subtitle = (res.stderr or "lookup failed"):gsub("\n.*", "") },
+      })
+      return
+    end
+    local ok, items = pcall(noctalia.json.decode, res.stdout)
+    if not ok or type(items) ~= "table" then
+      launcher.setResults(text, {})
+      return
+    end
+    local results: {{ id: string, title: string, subtitle: string, category: string }} = {}
+    cachedItems = {}
+    for _, item in ipairs(items) do
+      local id = item.id
+      if id ~= nil then
+        local name = item.name or "(unnamed)"
+        local user = item.login and item.login.username or ""
+        cachedItems[id] = name
+        table.insert(results, {
+          id = id,
+          title = name,
+          subtitle = user ~= "" and (item.login.uris and #item.login.uris > 0 and item.login.uris[1].uri or user) or "",
+          category = "Bitwarden",
+        })
+      end
+    end
+    launcher.setResults(text, results)
+  end)
+end
+
+function onActivate(id: string)
+  local session = readSession()
+  if session == nil or session == "" then
+    noctalia.notifyError("Bitwarden", "Vault is locked")
+    return
+  end
+  local name = cachedItems[id] or id
+  local cmd = "BW_SESSION=" .. shellQuote(session) .. " bw get password " .. shellQuote(id)
+  noctalia.runAsync(cmd, function(res)
+    if res.exitCode ~= 0 then
+      noctalia.notifyError("Bitwarden", "Could not read password")
+      return
+    end
+    local pw = (res.stdout:gsub("\n$", ""))
+    if noctalia.copyToClipboard(pw, "text/plain") then
+      noctalia.notify("Bitwarden", "Copied password for " .. name)
+    else
+      noctalia.notifyError("Bitwarden", "Clipboard unavailable")
+    end
+  end)
+end

--- a/plugins/official/bitwarden/plugin.toml
+++ b/plugins/official/bitwarden/plugin.toml
@@ -1,0 +1,57 @@
+# Noctalia v5 plugin manifest for Bitwarden vault lookup.
+# Schema verified against noctalia 5.0.0 (src/scripting/plugin_manifest.cpp).
+# File MUST be named plugin.toml; plugin id is "author/plugin".
+
+id = "shikanime/bitwarden"
+name = "Bitwarden"
+version = "0.1.0"
+author = "shikanime-labs"
+license = "MIT"
+description = "Retrieve credentials from a Bitwarden vault via the bw CLI."
+plugin_api = 3  # base feature set: state, runAsync, launcher_provider, service
+
+# Plugin-level settings (shared across every entry). Services/launcher providers
+# are singletons with no per-instance settings surface, so all config lives here.
+[[setting]]
+key = "server_url"
+type = "string"
+label_key = "setting.server_url"
+default = "https://vault.bitwarden.com"
+
+[[setting]]
+key = "client_id"
+type = "string"
+label_key = "setting.client_id"
+description_key = "setting.client_id.desc"
+default = ""
+
+[[setting]]
+key = "client_secret"
+type = "string"
+label_key = "setting.client_secret"
+description_key = "setting.client_secret.desc"
+default = ""
+
+[[setting]]
+key = "master_password_file"
+type = "file"
+label_key = "setting.master_password_file"
+description_key = "setting.master_password_file.desc"
+default = ""
+
+# Headless background loop: owns the bw auth lifecycle, publishes status to state.
+[[service]]
+id = "bw"
+entry = "service.luau"
+
+# Launcher prefix "bw " to search the vault and copy a credential on select.
+[[launcher_provider]]
+id = "lookup"
+entry = "lookup.luau"
+prefix = "bw"
+glyph = "🔐"
+include_in_global_search = false
+debounce_ms = 250
+  [[launcher_provider.category]]
+  label = "Bitwarden"
+  glyph = "🔐"

--- a/plugins/official/bitwarden/service.luau
+++ b/plugins/official/bitwarden/service.luau
@@ -1,0 +1,142 @@
+-- Bitwarden service entry: owns the bw auth lifecycle.
+-- Runs headless; publishes vault status to noctalia.state["bw_status"] so the
+-- lookup entry and widgets can read it without re-authenticating.
+--
+-- Secret hygiene:
+--   * BW_SESSION is cached in pluginDataDir() (survives plugin updates), never pluginDir().
+--   * The master password is read from a file path in config, never logged or passed on argv.
+--   * We never print the session key or any vault secret.
+
+local SESSION_FILE = noctalia.pluginDataDir() .. "/bw_session"
+local STATUS_KEY = "bw_status"
+
+local function setStatus(status: string, detail: string?)
+  noctalia.state.set(STATUS_KEY, { status = status, detail = detail or "" })
+end
+
+local function shellQuote(s: string): string
+  return "'" .. string.gsub(s, "'", [['\'']]) .. "'"
+end
+
+-- Read the cached session key from disk (nil if absent).
+local function readSession(): string?
+  local data, err = noctalia.readFile(SESSION_FILE)
+  if data == nil or #data == 0 then
+    return nil
+  end
+  -- trim trailing newline
+  return (data:gsub("\n$", ""))
+end
+
+local function writeSession(key: string)
+  noctalia.mkdirAll(noctalia.pluginDataDir())
+  noctalia.writeFile(SESSION_FILE, key)
+end
+
+local function removeSession()
+  noctalia.removeFile(SESSION_FILE)
+end
+
+-- Run a bw command, feeding BW_SESSION via env (never argv). cb(err, stdout)
+local function bw(args: string, cb: (string?, string?) -> ())
+  local cmd = "BW_SESSION=" .. shellQuote(readSession() or "") .. " bw " .. args
+  noctalia.runAsync(cmd, function(res)
+    if res.exitCode ~= 0 then
+      cb(res.stderr or res.stdout or "bw failed", nil)
+      return
+    end
+    cb(nil, res.stdout)
+  end)
+end
+
+local function ensureServer()
+  local url = noctalia.getConfig("server_url")
+  if url == nil or url == "" or url == "https://vault.bitwarden.com" then
+    return
+  end
+  -- idempotent: bw config server is harmless to re-run
+  noctalia.runAsync("bw config server " .. shellQuote(url), function(_) end)
+end
+
+-- One-time API-key login (persistent after first success).
+local function loginIfNeeded(thenUnlock: () -> ())
+  noctalia.runAsync("bw login --apikey --check", function(res)
+    if res.exitCode == 0 then
+      thenUnlock()
+      return
+    end
+    local cid = noctalia.getConfig("client_id")
+    local csec = noctalia.getConfig("client_secret")
+    if cid == nil or cid == "" or csec == nil or csec == "" then
+      setStatus("needs-auth", "Set client_id/client_secret in plugin settings")
+      return
+    end
+    local env = "BW_CLIENTID=" .. shellQuote(cid) .. " BW_CLIENTSECRET=" .. shellQuote(csec)
+    noctalia.runAsync(env .. " bw login --apikey", function(r)
+      if r.exitCode ~= 0 then
+        setStatus("needs-auth", (r.stderr or "login failed"):gsub("\n.*", ""))
+        return
+      end
+      thenUnlock()
+    end)
+  end)
+end
+
+-- Unlock using the master password file, cache BW_SESSION.
+local function unlock()
+  local pwFile = noctalia.getConfig("master_password_file")
+  if pwFile == nil or pwFile == "" then
+    setStatus("needs-auth", "Set master_password_file in plugin settings")
+    return
+  end
+  local expanded = noctalia.expandPath(pwFile)
+  noctalia.runAsync("bw unlock --passwordfile " .. shellQuote(expanded), function(res)
+    if res.exitCode ~= 0 then
+      setStatus("locked", (res.stderr or "unlock failed"):gsub("\n.*", ""))
+      removeSession()
+      return
+    end
+    -- bw prints: "BW_SESSION=\"<key>\"" — extract the key.
+    local key = res.stdout:match('BW_SESSION="([^"]+)"')
+    if key == nil then
+      setStatus("locked", "unlock produced no session")
+      return
+    end
+    writeSession(key)
+    setStatus("unlocked")
+  end)
+end
+
+-- Ensure we are unlocked; if not, transparently login + unlock.
+local function ensureUnlocked()
+  local session = readSession()
+  if session == nil or session == "" then
+    setStatus("locked")
+    loginIfNeeded(unlock)
+    return
+  end
+  -- Verify the cache is still valid.
+  bw("status", function(err, out)
+    if err ~= nil then
+      setStatus("locked", "session invalid")
+      removeSession()
+      loginIfNeeded(unlock)
+      return
+    end
+    if out:find("unlocked") then
+      setStatus("unlocked")
+    else
+      setStatus("locked")
+      loginIfNeeded(unlock)
+    end
+  end)
+end
+
+function update()
+  ensureServer()
+  ensureUnlocked()
+end
+
+-- Kick off immediately on load.
+ensureServer()
+ensureUnlocked()

--- a/plugins/official/bitwarden/test/run.sh
+++ b/plugins/official/bitwarden/test/run.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Run the Bitwarden plugin test harness under the real Luau runtime.
+# Assembles stub + real entry-source + assertions into one script (the Luau CLI
+# has no io/require-from-toplevel), then executes it.
+#
+# Usage: bash plugins/official/bitwarden/test/run.sh
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+PLUGIN=plugins/official/bitwarden
+
+HEADER='
+local state, last_results, cmds, vfs, config, clipboard, mock
+local SESSION_PATH = "/virtual/bw_session"
+noctalia = {}
+launcher = {}
+local function reset()
+  state = nil; last_results = nil; cmds = {}; vfs = {}; config = {}; clipboard = { calls = 0, last = nil }; mock = { plan = nil }
+  noctalia.pluginDataDir = function() return "/virtual" end
+  noctalia.expandPath = function(p) return p end
+  noctalia.getConfig = function(k) return config[k] end
+  noctalia.readFile = function(p) return vfs[p] end
+  noctalia.writeFile = function(p, d) vfs[p] = d; return true end
+  noctalia.removeFile = function(p) vfs[p] = nil; return true end
+  noctalia.mkdirAll = function() return true end
+  noctalia.state = { set = function(_, v) state = v end }
+  noctalia.copyToClipboard = function(d) clipboard.calls = clipboard.calls + 1; clipboard.last = d; return true end
+  noctalia.notify = function() end
+  noctalia.notifyError = function() end
+  noctalia.json = { decode = json_decode }
+  noctalia.runAsync = function(cmd, cb)
+    table.insert(cmds, cmd)
+    local r = (mock.plan and mock.plan(cmd)) or { exitCode = 0, stdout = "", stderr = "" }
+    cb(r)
+  end
+  launcher.setResults = function(_, r) last_results = r end
+end
+'
+
+# minimal JSON parser (bw emits JSON; entries depend on decoding it)
+JSON='
+local function json_decode(s)
+  local i = 1
+  local function ws()
+    while i <= #s do local c = s:sub(i, i)
+      if c == " " or c == "\n" or c == "\t" or c == "\r" then i = i + 1 else break end end
+  end
+  local function str()
+    i = i + 1; local buf = {}
+    while i <= #s do local c = s:sub(i, i)
+      if c == "\"" then i = i + 1; return table.concat(buf) end
+      if c == "\\" then i = i + 1; local e = s:sub(i, i)
+        if e == "u" then local hex = s:sub(i + 1, i + 4); i = i + 4; buf[#buf + 1] = string.char(tonumber(hex, 16) or 63)
+        else local map = { ["\""] = "\"", ["\\"] = "\\", ["/"] = "/", b = "\b", f = "\f", n = "\n", r = "\r", t = "\t" }; buf[#buf + 1] = map[e] or e; i = i + 1 end
+      else buf[#buf + 1] = c; i = i + 1 end
+    end
+    error("json: unterminated string")
+  end
+  local function num()
+    local j = i; while j <= #s and s:sub(j, j):match("[%d%.%+%-eE]") do j = j + 1 end
+    local n = tonumber(s:sub(i, j - 1)); i = j; return n
+  end
+  local function arr()
+    i = i + 1; local t = {}; ws()
+    if s:sub(i, i) == "]" then i = i + 1; return t end
+    while true do ws(); t[#t + 1] = val(); ws()
+      local c = s:sub(i, i)
+      if c == "," then i = i + 1 elseif c == "]" then i = i + 1; return t else error("json array") end
+    end
+  end
+  local function obj()
+    i = i + 1; local t = {}; ws()
+    if s:sub(i, i) == "}" then i = i + 1; return t end
+    while true do ws(); local key = str(); ws()
+      if s:sub(i, i) ~= ":" then error("json object :") end
+      i = i + 1; ws(); t[key] = val(); ws()
+      local c = s:sub(i, i)
+      if c == "," then i = i + 1 elseif c == "}" then i = i + 1; return t else error("json object }") end
+    end
+  end
+  function val()
+    ws(); local c = s:sub(i, i)
+    if c == "{" then return obj() end
+    if c == "[" then return arr() end
+    if c == "\"" then return str() end
+    if c == "t" then i = i + 4; return true end
+    if c == "f" then i = i + 5; return false end
+    if c == "n" then i = i + 4; return nil end
+    if c:match("[%-%d]") then return num() end
+    error("json char " .. c)
+  end
+  return val()
+end
+'
+
+BODY='
+local passed, failed = 0, 0
+local function ok(cond, msg)
+  if cond then passed = passed + 1; print("  ok   " .. msg)
+  else failed = failed + 1; print("  FAIL " .. msg) end
+end
+local ITEMS = "[{\"id\":\"i1\",\"name\":\"github\",\"login\":{\"username\":\"me@x.io\",\"uris\":[{\"uri\":\"https://github.com\"}]}},{\"id\":\"i2\",\"name\":\"nologin\"}]"
+
+-- T1: config validation — missing API creds -> needs-auth
+reset()
+config = { server_url = "https://vault.bitwarden.com", client_id = "", client_secret = "", master_password_file = "" }
+mock.plan = function(cmd)
+  if cmd:find("bw login %-%-apikey %-%-check") then return { exitCode = 1 } end
+  return { exitCode = 0 }
+end
+SERVICE
+ok(state and state.status == "needs-auth", "missing client_id/secret -> needs-auth")
+
+-- T2: full auth happy path (apikey login + unlock)
+reset()
+config = { server_url = "https://vault.bitwarden.com", client_id = "cid", client_secret = "csec", master_password_file = "/tmp/pw" }
+mock.plan = function(cmd)
+  if cmd:find("bw login %-%-apikey %-%-check") then return { exitCode = 1 } end
+  if cmd:find("BW_CLIENTID=") then return { exitCode = 0 } end
+  if cmd:find("bw unlock") then return { exitCode = 0, stdout = "BW_SESSION=\"sess-999\"" } end
+  if cmd:find("bw status") then return { exitCode = 0, stdout = "unlocked" } end
+  return { exitCode = 0 }
+end
+SERVICE
+ok(state and state.status == "unlocked", "apikey login + unlock -> unlocked")
+ok(vfs[SESSION_PATH] == "sess-999", "session key cached in pluginDataDir")
+
+-- T3: credential retrieval + clipboard copy on activate
+reset()
+config = { server_url = "https://vault.bitwarden.com", client_id = "cid", client_secret = "csec", master_password_file = "/tmp/pw" }
+vfs[SESSION_PATH] = "sess-999"
+mock.plan = function(cmd)
+  if cmd:find("bw list items") then return { exitCode = 0, stdout = ITEMS } end
+  if cmd:find("bw get password") then return { exitCode = 0, stdout = "pw123" } end
+  if cmd:find("bw status") then return { exitCode = 0, stdout = "unlocked" } end
+  return { exitCode = 0 }
+end
+SERVICE
+LOOKUP
+onQuery("github")
+ok(last_results and #last_results == 2, "lookup returns 2 parsed items")
+ok(last_results and last_results[1].id == "i1", "lookup result id preserved")
+ok(last_results and last_results[1].subtitle:find("github.com"), "subtitle derives from login uri")
+onQuery("")
+ok(last_results and last_results[1].id == "hint", "empty query -> hint result")
+onActivate("i1")
+ok(clipboard.calls == 1 and clipboard.last == "pw123", "activate copies password to clipboard")
+
+-- T4: error handling — network failure on list + get
+reset()
+config = { server_url = "https://vault.bitwarden.com", client_id = "cid", client_secret = "csec", master_password_file = "/tmp/pw" }
+vfs[SESSION_PATH] = "sess-999"
+mock.plan = function(cmd)
+  if cmd:find("bw list items") then return { exitCode = 1, stderr = "Couldn'"'"'t connect to server" } end
+  if cmd:find("bw get password") then return { exitCode = 1, stderr = "timeout" } end
+  if cmd:find("bw status") then return { exitCode = 0, stdout = "unlocked" } end
+  return { exitCode = 0 }
+end
+SERVICE
+LOOKUP
+onQuery("github")
+ok(last_results and last_results[1].id == "err", "list network failure -> error result")
+clipboard.calls = 0
+onActivate("i1")
+ok(clipboard.calls == 0, "get failure -> no clipboard write")
+
+-- T5: invalid token — stale session, unlock rejected
+reset()
+config = { server_url = "https://vault.bitwarden.com", client_id = "cid", client_secret = "csec", master_password_file = "/tmp/pw" }
+vfs[SESSION_PATH] = "stale"
+mock.plan = function(cmd)
+  if cmd:find("bw status") then return { exitCode = 0, stdout = "locked" } end
+  if cmd:find("bw login %-%-apikey %-%-check") then return { exitCode = 1 } end
+  if cmd:find("BW_CLIENTID=") then return { exitCode = 0 } end
+  if cmd:find("bw unlock") then return { exitCode = 1, stderr = "invalid master password" } end
+  return { exitCode = 0 }
+end
+SERVICE
+ok(state and state.status == "locked", "invalid token -> locked")
+ok(vfs[SESSION_PATH] == nil, "invalid token -> cached session removed")
+
+-- T6: session reuse — valid cache, no re-login
+reset()
+config = { server_url = "https://vault.bitwarden.com", client_id = "cid", client_secret = "csec", master_password_file = "/tmp/pw" }
+vfs[SESSION_PATH] = "sess-999"
+mock.plan = function(cmd)
+  if cmd:find("bw status") then return { exitCode = 0, stdout = "unlocked" } end
+  return { exitCode = 0 }
+end
+SERVICE
+ok(state and state.status == "unlocked", "valid cached session -> unlocked")
+local relogin = false
+for _, c in ipairs(cmds) do if c:find("bw login") then relogin = true end end
+ok(not relogin, "no re-login when session valid")
+
+print("")
+print(passed .. " passed, " .. failed .. " failed")
+if failed > 0 then os.exit(1) end
+'
+
+# Substitute the real entry sources into the markers, then drop the markers.
+BODY=${BODY//SERVICE/$(cat "$PLUGIN/service.luau")}
+BODY=${BODY//LOOKUP/$(cat "$PLUGIN/lookup.luau")}
+
+# Assemble: JSON parser (defines json_decode) FIRST, then stub header that
+# references it, then the test body (which embeds the real entry sources).
+TMP=$(mktemp /tmp/bw_test.XXXXXX.luau)
+printf '%s%s%s' "$JSON" "$HEADER" "$BODY" > "$TMP"
+nix shell nixpkgs#luau -c luau "$TMP"
+rm -f "$TMP"

--- a/plugins/official/bitwarden/translations/en.json
+++ b/plugins/official/bitwarden/translations/en.json
@@ -1,0 +1,9 @@
+{
+  "setting.server_url": "Server URL",
+  "setting.client_id": "API client ID",
+  "setting.client_id.desc": "Bitwarden personal API key client id (Account Settings → API Key)",
+  "setting.client_secret": "API client secret",
+  "setting.client_secret.desc": "Bitwarden personal API key client secret. Stored in plugin data dir, not the repo.",
+  "setting.master_password_file": "Master password file",
+  "setting.master_password_file.desc": "Path to a file containing the vault master password, used to unlock non-interactively"
+}


### PR DESCRIPTION
## Summary
Lands the local **Bitwarden** vault-lookup plugin for Noctalia v5 (https://noctalia.dev/plugins/official/bitwarden) and fixes the wiring that main already carried but that never actually loaded the plugin.

- `plugins/official/bitwarden/` — v5 Luau plugin: a `service` entry owns the `bw` auth lifecycle (apikey login + unlock, `BW_SESSION` cached in `pluginDataDir()`), a `launcher_provider` entry exposes the `bw ` prefix and copies the selected credential to the clipboard. Secrets handled via `pluginDataDir()` + env only, never logged or passed on argv.
- CI: `.github/workflows/plugins.yaml` + `.github/scripts/validate-noctalia-plugins.py` static manifest/Luau validator.
- `.github/scripts/validate-noctalia-plugins.py` static manifest validator.

### Wiring reconciliation
main already had a wiring commit (`7c8e968f`) enabling `noctalia/bitwarden` with **no source** — but the manifest id is `shikanime/bitwarden` and a local plugin needs a `plugins.sources` path source. So it never resolved. This corrects:
- id → `shikanime/bitwarden`
- adds `plugins.sources` path source at `plugins/official`
- adds `bitwarden-cli` to the graphical profile systemPackages
- `noctalia/translator` stays a bare `enabled` entry (upstream-official, auto-seeded)

## Verification
- Manifest validator: passes
- `modules/home/graphical.nix` + `modules/nixos/profiles/graphical.nix`: `nix-instantiate --parse` OK
- `bitwarden-cli` present in nixpkgs
- Real-Luau harness `plugins/official/bitwarden/test/run.sh`: **14/14** pass

Supersedes the closed PR #1134 (its plugin files never merged, though its wiring did).

## Test plan
- [ ] Human: `nix build` / deploy to a graphical host, confirm `bw ` launcher prefix appears and a vault lookup copies a credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)