### PR TITLE
Disable Noctalia 'Reserve Space' for bar and dock

### DIFF
--- a/modules/home/graphical.nix
+++ b/modules/home/graphical.nix
@@ -6,6 +6,9 @@
     enable = true;
     systemd.enable = true;
     settings = {
+      # Disable bar/dock exclusive-zone reservation (was upstream default true).
+      bar.main.reserve_space = false;
+      dock.reserve_space = false;
       backdrop = {
         enabled = true;
         blur_intensity = 0.5; # default; 0.0 = no blur, 1.0 = max


### PR DESCRIPTION
Disable Noctalia Reserve Space: set bar.main.reserve_space=false and dock.reserve_space=false in modules/home/graphical.nix. Additive; no other surface touched. nix-instantiate parse + pre-commit hooks pass.