### PR TITLE
Add builtin GTK4 theme ID to Noctalia theme.templates

### DIFF
--- a/modules/home/graphical.nix
+++ b/modules/home/graphical.nix
@@ -40,6 +40,11 @@
       theme = {
         mode = "auto";
         source = "wallpaper";
+        templates = {
+          # Materialize Noctalia's built-in GTK4 theme (assets/templates/gtk/gtk4.css
+          # -> $XDG_CONFIG_HOME/gtk-4.0/noctalia.css). gtk3 is owned by t_a28d4c43.
+          builtin_ids = [ "gtk4" ];
+        };
       };
     };
   };


### PR DESCRIPTION
## Summary
Registers `"gtk4"` in `programs.noctalia.settings.theme.templates.builtin_ids` so Noctalia materializes its built-in GTK4 theme (`assets/templates/gtk/gtk4.css` → `$XDG_CONFIG_HOME/gtk-4.0/noctalia.css`), mirroring the sibling GTK3 entry (t_a28d4c43).

- `modules/home/graphical.nix`: add `builtin_ids = [ "gtk4" ]` under `theme.templates`.

## Validation
Static (no NixOS graphical host available on this macOS runner):
- `nix-instantiate --parse` OK on the module.
- `"gtk4"` confirmed as a catalog/template id in the pinned noctalia rev (`builtin.toml` → `[catalog.gtk4]` + `[templates.gtk4]` → `gtk-4.0/noctalia.css`).
- Rendered TOML shape `theme.templates.builtin_ids = ["gtk4"]` matches noctalia's config schema (TOML key `builtin_ids`).

Live GTK4 render check deferred to a NixOS graphical host (`isntar`).

## Merge coordination
⚠️ This PR's single-element list intentionally scopes to GTK4 only. The two sibling tasks edit the **same** `theme.templates.builtin_ids` list:
- t_a28d4c43 — GTK3
- t_42434451 — ghostty / helix / niri / starship / community_ids

On merge, the three must be combined into one merged `builtin_ids` list (e.g. `[ "gtk3" "gtk4" "ghostty" "helix" "niri" "starship" … ]`). Reviewer/commander should resolve into a single entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)