### PR TITLE
Zero-trust mitigation: ZT-1/3/4/5/6/7 plus ZT-2/ZT-8 notes

### DIFF
--- a/.github/workflows/acl-diff.yaml
+++ b/.github/workflows/acl-diff.yaml
@@ -1,0 +1,39 @@
+name: Tailscale ACL drift check
+on:
+  push:
+    paths: ["tailscale/acl.hujson"]
+  pull_request:
+    paths: ["tailscale/acl.hujson"]
+
+jobs:
+  acl-diff:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Tailscale CLI
+        run: |
+          curl -fsSL https://tailscale.com/install.sh | sh -s -- -q
+
+      - name: Run ACL diff check
+        env:
+          TS_API_KEY: ${{ secrets.TAILSCALE_API_KEY }}
+          TS_TAILNET: ${{ vars.TS_TAILNET }}
+          TS_ACL_FILE: tailscale/acl.hujson
+        run: |
+          if [ -z "${TS_API_KEY:-}" ] || [ -z "${TS_TAILNET:-}" ]; then
+            echo "TAILSCALE_API_KEY or TS_TAILNET is not set; skipping ACL diff."
+            exit 0
+          fi
+          tailscale acl --json < "$TS_ACL_FILE" > /tmp/committed-acl.json
+          curl -fsSL -H "Authorization: Bearer ${TS_API_KEY}" \
+            "https://api.tailscale.com/api/v2/tailnet/${TS_TAILNET}/acl" \
+            > /tmp/console-acl.json
+          if ! diff -u /tmp/console-acl.json /tmp/committed-acl.json; then
+            echo "::error::Committed tailscale/acl.hujson diverges from console ACL."
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -166,8 +166,15 @@ other machines.
 ## Related Repos
 
 This repository follows the same general shape as the other Shikanime
-configuration repos:
+configuration repositories:
 
 - `x-shikanime/manifests`
 - `shikanime-studio/knix`
 - `x-shikanime/colemak`
+
+## Zero-Trust follow-ups
+
+- ZT-2 — MFA on the SSH path: enforce IdP MFA in the Tailscale admin console
+  and ACL once `tailscale/acl.hujson` is populated.
+- ZT-8 — Rotate the committed password hashes in `nishir.nix` and
+  `ishtar/configuration.nix` on a 6-month calendar.

--- a/hosts/nixtar/configuration.nix
+++ b/hosts/nixtar/configuration.nix
@@ -102,10 +102,24 @@ in
   services = {
     openssh = {
       enable = true;
+      openFirewall = false;
+      settings = {
+        passwordAuthentication = false;
+        kbdInteractiveAuthentication = false;
+        listenAddress = "tailscale0";
+      };
+    };
+    tailscale = {
+      enable = true;
+      authKeyFile = config.sops.secrets.tailscale-authkey.path;
       openFirewall = true;
+      useRoutingFeatures = "server";
+      extraUpFlags = [ "--ssh" ];
     };
     xserver.videoDrivers = [ "nvidia" ];
   };
+
+  security.sudo.wheelNeedsPassword = true;
 
   sops = {
     age = {
@@ -115,6 +129,8 @@ in
     };
     defaultSopsFile = ../../secrets/nixtar.enc.yaml;
     defaultSopsFormat = "yaml";
+    secrets.tailscale-authkey = { };
+    secrets.builder-ssh-key = { };
   };
 
   users.users.shika = {

--- a/modules/nixos/node.nix
+++ b/modules/nixos/node.nix
@@ -49,9 +49,20 @@
       };
     };
 
+    fail2ban = {
+      enable = true;
+      maxretries = 5;
+    };
+
     openssh = {
       enable = true;
-      openFirewall = true;
+      openFirewall = false;
+      settings = {
+        passwordAuthentication = false;
+        kbdInteractiveAuthentication = false;
+        # Restrict direct internet-facing SSH to the Tailscale overlay.
+        listenAddress = "tailscale0";
+      };
     };
 
     tailscale = {

--- a/modules/nixos/observability-logs.nix
+++ b/modules/nixos/observability-logs.nix
@@ -1,0 +1,40 @@
+{ lib, pkgs, ... }:
+
+{
+  options = {
+    services.observability-logs = lib.mkOption {
+      type = lib.types.null_or (lib.types.submodule({
+        enable = lib.mkEnableOption "observability log shipping";
+        settings = lib.mkOption {
+          type = lib.types.attrsOf lib.types.anything;
+          default = {};
+        };
+      }));
+      default = null;
+    };
+  };
+
+  config = lib.mkIf (config.services.observability-logs != null && config.services.observability-logs.enable) {
+    services.promtail = {
+      enable = true;
+      settings = config.services.observability-logs.settings // {
+        clients = (config.services.observability-logs.settings.clients or {}) // {
+          default = {
+            endpoint = [
+              "http://127.0.0.1:3100/loki/api/v1/push"
+            ];
+          };
+        };
+        positions = {
+          filename = "/tmp/positions.yaml";
+        };
+        server = {
+          http_listen_port = 9080;
+          grpc_listen_port = 0;
+        };
+      };
+    };
+    environment.systemPackages = [ pkgs.promtail ];
+  };
+}
+

--- a/modules/nixos/users/builder.nix
+++ b/modules/nixos/users/builder.nix
@@ -1,0 +1,21 @@
+{ pkgs, lib, ... }:
+
+let
+  builderSshKeyFile = config.sops.secrets.builder-ssh-key.path;
+in {
+  imports = [ ../server.nix ];
+
+  sops.secrets.builder-ssh-key = {
+    restartUnits = [ "sshd.service" ];
+    format = "binary";
+  };
+
+  users.users.builder = {
+    isNormalUser = true;
+    home = "/home/builder";
+    openssh.authorizedKeys.keys = [
+      (lib.readFile builderSshKeyFile)
+    ];
+    useDefaultShell = true;
+  };
+}

--- a/tailscale/acl.hujson
+++ b/tailscale/acl.hujson
@@ -1,0 +1,9 @@
+{
+	// policies: []
+	// Placeholder ACL. Replace with exported Tailscale ACL JSON after first
+	// policy-as-code sync. Do NOT edit policy rules here until CI diff check
+	// is enabled for tailscale/acl.hujson.
+	"groups": {},
+	"tagOwners": {},
+	"acls": []
+}


### PR DESCRIPTION
## What
Implements the first three phases of the ZT-1..8 fleet mitigation plan.

## Changes
- ZT-1: disable SSH password/kbd-interactive auth fleet-wide in `modules/nixos/node.nix`; enable `fail2ban`.
- ZT-3: restrict sshd `listenAddress` to `tailscale0` in `modules/nixos/node.nix`.
- ZT-6: enable Tailscale, require sudo password, and scope sshd in `hosts/nixtar/configuration.nix`.
- ZT-5: add `tailscale/acl.hujson` placeholder and `.github/workflows/acl-diff.yaml`.
- ZT-4: add `modules/nixos/observability-logs.nix` skeleton.
- ZT-7: add `modules/nixos/users/builder.nix` wired to a new `builder-ssh-key` secret.
- ZT-2/ZT-8: add README notes for manual ACL IdP-MFA enforcement and hash rotation.

## Remaining manual steps
- Export real Tailscale ACL into `tailscale/acl.hujson` and enable CI secrets.
- Generate builder deploy key and store encrypted secret in `secrets/nixtar.enc.yaml`.
- Opt each host into `observability-logs.nix` and configure Loki endpoints.
- Confirm operator sudo password behavior and Tailscale ACL policy on console.