### PR TITLE
Add xhost for gparted root Xwayland access

### DIFF
--- a/modules/nixos/profiles/graphical.nix
+++ b/modules/nixos/profiles/graphical.nix
@@ -21,6 +21,7 @@
       nautilus # file manager GUI
       pavucontrol # audio mixer GUI (volume keys only step, no panel)
       playerctl # media-key control for MPRIS players
+      xhost # lets gparted's root-launch wrapper grant root the Xwayland display
       xwayland-satellite # bridge x11 apps
     ];
   };


### PR DESCRIPTION
## Summary
GParted is X11-only and must run as root. Its launcher wrapper runs `xhost +SI:localuser:root` to grant root access to the session's Xwayland `:0` (owned by user `shika`, uid 1000). That grant silently no-ops because `xhost` is not on `shika`'s PATH, so the elevated gparted fails at GTK display-open with `Authorization required` / `cannot open display:`.

One-line fix: add `xhost` to ishtar's `systemPackages` (the only host importing `profiles/graphical.nix`, which ships `gparted-full`).

## Verification done
- `nix eval .#nixosConfigurations.ishtar.config.environment.systemPackages` confirms `xhost` is now in ishtar's closure (`true`), no warnings.
- Full `nix build` of the ishtar toplevel not run here: command-tier is aarch64-darwin and the x86_64-linux remote builders are unreachable. Config evaluation itself succeeds (no attribute/parse errors).

## Verification needed on ishtar (post-merge/deploy)
```sh
sudo nixos-rebuild switch   # or your usual deploy
which xhost                 # should resolve now
# From shika's graphical session (not a root ssh):
pkexec gparted              # should open; xhost grant now succeeds
```
Alternative: from shika's session, `pkexec gparted` already inherits DISPLAY/XAUTHORITY and only needs the polkit prompt (polkit is enabled) — independent of this fix.

Signed-off-by: 21O Operator <william.phetsinorath@shikanime.studio>