### PR TITLE
graphical: route sudo through polkit GUI (Noctalia agent) in graphical sessions

### DIFF
--- a/modules/home/graphical.nix
+++ b/modules/home/graphical.nix
@@ -1,4 +1,34 @@
+{ lib, pkgs, ... }:
+
 {
+  # GUI sudo: route `sudo` through polkit so the fleet-standard Noctalia
+  # polkit agent raises its password dialog in graphical sessions (see
+  # t_58a950d3 / t_d3a9bbfd). pkexec can't serve interactive-shell/edit
+  # requests (-i/-s/-e), so those fall through to the real sudo unchanged.
+  # On headless sessions (SSH, TTY) the real sudo runs too. Gated to Linux
+  # (the Noctalia agent is Wayland/Linux only); macOS keeps native sudo.
+  home.packages = lib.mkIf pkgs.stdenv.isLinux [
+    (pkgs.writeShellScriptBin "sudo" ''
+      real_sudo() {
+        for p in /run/wrappers/bin/sudo /run/current-system/sw/bin/sudo /usr/bin/sudo; do
+          [ -x "$p" ] && exec "$p" "$@"
+        done
+        echo "sudo: unable to locate the real sudo binary" >&2
+        exit 1
+      }
+      # pkexec cannot emulate sudo's interactive/shell/edit modes.
+      for a in "$@"; do
+        case "$a" in
+          -i|--login|-s|--shell|-e|--edit|--stdin) real_sudo "$@" ;;
+        esac
+      done
+      if [ -n "''${DISPLAY:-''${WAYLAND_DISPLAY:-}}" ] && command -v pkexec >/dev/null 2>&1; then
+        exec pkexec "$@"
+      fi
+      real_sudo "$@"
+    '')
+  ];
+
   # Global Noctalia desktop shell theme for graphical Linux hosts.
   # NixOS-level programs.noctalia has no `settings`; theming is home-manager only,
   # so this is the shared home module all graphical users import.


### PR DESCRIPTION
## Summary

Bare `sudo` in a graphical session now raises the fleet-standard Noctalia polkit authentication-agent password dialog instead of a TTY prompt.

- `modules/home/graphical.nix`: wrap `sudo` (Linux only) so it execs `pkexec` when a display is present and `pkexec` exists, falling through to the real `sudo` otherwise.
- Interactive/shell/edit/stdin modes (`-i`/`-s`/`-e`/`--stdin`) bypass the wrapper — `pkexec` cannot emulate those, so they run the real `sudo` unchanged.
- Headless (SSH/TTY, no DISPLAY/WAYLAND_DISPLAY) runs the real `sudo` unchanged.
- macOS keeps native `sudo` (gated via `pkgs.stdenv.isLinux`).

## Background

This is the implementation step of the sudo-GUI coordination task `t_b5ac7dcc`. Supporting work in child tasks:
- `t_58a950d3` — mechanism research: sudo has no native GUI; the standard prompt is the DE polkit agent; Noctalia's is the fleet standard.
- `t_d3a9bbfd` — Noctalia polkit-agent dialog design + hi-fi mockup.
- `t_248f28e1` — contract test: 9/9 assertions pass (graphical→pkexec, headless→sudo, interactive/edit/stdin bypass, missing-pkexec fallback, exit-code propagation, verbatim argv).
- `t_fcdb71a0` — this implementation.

## Test plan

- [x] `nix-instantiate --parse` OK on `modules/home/graphical.nix`
- [x] 5-path wrapper sim test (no recursion/hang)
- [x] pre-commit (gitlint + trufflehog) pass
- [x] 9/9 contract assertions (t_248f28e1)
- [ ] Human eyeball: live Noctalia polkit dialog on a graphical Linux host (cannot render on macOS dev box)

DCO sign-off: [verified] per repo convention.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)