### PR TITLE
chore(skaffold): pin nix-containers to release v0.1.0

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,5 +6,5 @@ build:
   artifacts:
     - custom:
         buildCommand:
-          nix run github:shikanime-studio/nix-containers -- skaffold build
+          nix run github:shikanime-studio/nix-containers/v0.1.0 -- skaffold build
       image: ghcr.io/shikanime-labs/machines/catbox


### PR DESCRIPTION
## Summary
- Pin the external skaffold build tool ref `github:shikanime-studio/nix-containers` to the **v0.1.0** release tag.

## Why
The unpinned ref resolved to a `nix-containers` commit whose `readImageLoadedRef` could not parse the tagless `Loaded image ID: sha256:<digest>` form emitted by Docker 28.0.4 / containerd v2.2.6 on CI. This caused the multi-platform `skaffold build` (linux/amd64,linux/arm64, push=true) to fail at the load step with `push images failed: failed to read loaded ref: could not parse reference:`.

v0.1.0 (shikanime-studio/nix-containers#56) contains the root-cause fix. This change only flips the pin.

## Verification
- `skaffold.yaml` now references `github:shikanime-studio/nix-containers/v0.1.0`.
- Acceptance: a CI run of this workflow (multi-platform skaffold build, push=true) no longer errors on the load step.

Refs: CI run 30304823288; upstream fix shikanime-studio/nix-containers PR #56; release v0.1.0.

🤖 Generated with [Hermes Agent](https://github.com/NousResearch/hermes)