### PR TITLE
fix(login): set Noctalia greeter keyboard to Colemak layout

### DIFF
--- a/modules/nixos/profiles/graphical.nix
+++ b/modules/nixos/profiles/graphical.nix
@@ -94,7 +94,15 @@
       systemd.enable = true;
     };
 
-    noctalia-greeter.enable = true;
+    noctalia-greeter = {
+      enable = true;
+      # Colemak at the login screen: XKB "us" layout + "colemak" variant,
+      # written to greeter.toml's [keyboard] section (greeter-scoped, not system-wide).
+      settings.keyboard = {
+        layout = "us";
+        variant = "colemak";
+      };
+    };
 
     # OBS Studio — video recording and live streaming with recommended plugins
     # and virtual camera support (for Zoom/Teams). Hardware-accelerated on NVIDIA.


### PR DESCRIPTION
The login screen was missing explicit Colemak keyboard configuration in programs.noctalia-greeter.settings.keyboard. Added layout = "us" with variant = "colemak" to modules/nixos/profiles/graphical.nix.

Acceptance criteria: Login screen uses Colemak layout for all text input fields. No regressions in login functionality.

Co-authored-by: Operator 21O