### PR TITLE
fix: pin skaffold.yaml nix-containers to fixed commit 144686dd

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,5 +6,5 @@ build:
   artifacts:
     - custom:
         buildCommand:
-          nix run github:shikanime-studio/nix-containers/144686dd -- skaffold build
+          nix run github:shikanime-studio/nix-containers/fdc5eb246f850241b5fa35546cd0456b198a90f1 -- skaffold build
       image: ghcr.io/shikanime-labs/machines/catbox

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,5 +6,5 @@ build:
   artifacts:
     - custom:
         buildCommand:
-          nix run github:shikanime-studio/nix-containers -- skaffold build
+          nix run github:shikanime-studio/nix-containers/144686dd -- skaffold build
       image: ghcr.io/shikanime-labs/machines/catbox

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,5 +6,5 @@ build:
   artifacts:
     - custom:
         buildCommand:
-          nix run github:shikanime-studio/nix-containers/fdc5eb246f850241b5fa35546cd0456b198a90f1 -- skaffold build
+          nix run github:shikanime-studio/nix-containers/d02b45cfaad223c5e6af7c7ff4b892e9ea707fe8 -- skaffold build
       image: ghcr.io/shikanime-labs/machines/catbox


### PR DESCRIPTION
Pin the unpinned flake ref that resurfaced the empty-ref readImageLoadedRef parse bug (empty `Loaded image: ` ref -> ParseReference fails).

The v0.1.1 bump was followed by commit 2292f989 removing the tag, reverting to the unpinned ref that lets nix-containers drift back to the buggy tagless docker-tarball load path.

Upstream fix: shikaname-studio/nix-containers@144686dd (readImageLoadedRef now handles 'Loaded image ID: sha256:<digest>'), released as v0.1.1.

Parent task t_d611db02 root-cause: unpinned nix-containers ref + tagless nix docker tarball -> empty ref -> parse failure.