### PR TITLE
fix: pin skaffold.yaml to nix-containers digest-driven ref-read fix

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,5 +6,5 @@ build:
   artifacts:
     - custom:
         buildCommand:
-          nix run github:shikanime-studio/nix-containers -- skaffold build
+          nix run github:shikanime-studio/nix-containers/d02b45cf -- skaffold build
       image: ghcr.io/shikanime-labs/machines/catbox


### PR DESCRIPTION
Docker 28 / containerd v2 emit an empty `Loaded image: ` repo line for nix's tagless image tarball; the unpinned nix-containers ref's readImageLoadedRef passed it to name.ParseReference(""), producing `could not parse reference: ` before the digest line was read.

Pin to github:shikanime-studio/nix-containers/d02b45cf, which makes readImageLoadedRef digest-driven: scans the whole docker load stream, extracts the sha256 digest (sha256: prefix optional), reconstructs ref.Context()@sha256:<digest>, and skips rather than aborts on unparseable/empty lines.

Upstream fix: shikanime-studio/nix-containers#57.
Pre-flight: `nix flake prefetch github:shikanime-studio/nix-containers/d02b45cf` resolves (sha256-W5jzhqB46htpPV78pDE7QFKWcwz9tlDRrQVm+OG5V0Y=).

Triggers:\n  shikanime-labs/machines CI run 30947020015