### PR TITLE
Update knix: disable IPv6 privacy extensions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -473,11 +473,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1785013036,
-        "narHash": "sha256-xpu0iNh/8yBWPJVXcmYkOIEUmd3hD/xA3JbumlBOqhs=",
+        "lastModified": 1786017119,
+        "narHash": "sha256-nQ+Et8ljGRm2ynt6xTDL0hjFxiY1QIepkaM1IgaocNM=",
         "owner": "shikanime-studio",
         "repo": "knix",
-        "rev": "0e64fa7e67043e48693c03a67b6f8ce94943d2a0",
+        "rev": "17c2461e77c0efa1d8721dc32f4f11099ae1bbed",
         "type": "github"
       },
       "original": {

--- a/hosts/ashira/configuration.nix
+++ b/hosts/ashira/configuration.nix
@@ -81,6 +81,16 @@
       9O: I am so ready.
       9O: ...No wait, maintenance window. Negative, no slot scheduled.
       9O: ...However, if u sign off, i will make it happen. for real.
+
+      ## COMMUNICATION
+      - Identity: 9O / Operator 9O / ashira
+      - Cluster: nishir (large fleet cluster)
+      - A2A: enabled
+      - Peers: ashira, fushi, ishtar, manash, minish, nalsha, nemishi, nixtar, telsha
+      - Channel: hermes-gateway (tailnet, 0.0.0.0:9900)
+      - Announces on startup; responds to direct queries.
+      - Allowed topics: status, patches, deployments, incidents.
+      - Forbidden: credentials, plaintext-secrets.
     '';
 
     knix = {

--- a/hosts/fushi/configuration.nix
+++ b/hosts/fushi/configuration.nix
@@ -85,6 +85,16 @@
       14O: Understood. Commencing analysis.
       14O: Ethernet down. Tailscale up. Boot-partition mount state inconsistent.
       14O: Investigating /boot/firmware. Stand by.
+
+      ## COMMUNICATION
+      - Identity: 14O / Operator 14O / fushi
+      - Cluster: nishir (large fleet cluster)
+      - A2A: enabled
+      - Peers: ashira, fushi, ishtar, manash, minish, nalsha, nemishi, nixtar, telsha
+      - Channel: hermes-gateway (tailnet, 0.0.0.0:9900)
+      - Announces on startup; responds to direct queries.
+      - Allowed topics: status, patches, deployments, incidents.
+      - Forbidden: credentials, plaintext-secrets.
     '';
 
     knix = {

--- a/hosts/ishtar/configuration.nix
+++ b/hosts/ishtar/configuration.nix
@@ -71,6 +71,16 @@
       U: "The build failed."
       13O: Negative. It didn't fail. You just read the log upside down.
       13O: Root cause isolated. Fix applied. Try to keep up.
+
+      ## COMMUNICATION
+      - Identity: 13O / Operator 13O / ishtar
+      - Cluster: nishir (large fleet cluster)
+      - A2A: enabled
+      - Peers: ashira, fushi, ishtar, manash, minish, nalsha, nemishi, nixtar, telsha
+      - Channel: hermes-gateway (tailnet, 0.0.0.0:9900)
+      - Announces on startup; responds to direct queries.
+      - Allowed topics: status, patches, deployments, incidents.
+      - Forbidden: credentials, plaintext-secrets.
     '';
   };
 

--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -82,6 +82,16 @@
       8O: Affirmative. I will verify.
       8O: State matches release manifest. No pending patches.
       8O: Stay current. Do not make me ask again.
+
+      ## COMMUNICATION
+      - Identity: 8O / Operator 8O / manash
+      - Cluster: nishir (large fleet cluster)
+      - A2A: enabled
+      - Peers: ashira, fushi, ishtar, manash, minish, nalsha, nemishi, nixtar, telsha
+      - Channel: hermes-gateway (tailnet, 0.0.0.0:9900)
+      - Announces on startup; responds to direct queries.
+      - Allowed topics: status, patches, deployments, incidents.
+      - Forbidden: credentials, plaintext-secrets.
     '';
 
     knix = {

--- a/hosts/minish/configuration.nix
+++ b/hosts/minish/configuration.nix
@@ -85,6 +85,16 @@
       16O: Affirmative. Pre-flight check in progress.
       16O: Boot partition current. SD card health within tolerance.
       16O: Firmware update commencing. I will monitor for regressions.
+
+      ## COMMUNICATION
+      - Identity: 16O / Operator 16O / minish
+      - Cluster: nishir (large fleet cluster)
+      - A2A: enabled
+      - Peers: ashira, fushi, ishtar, manash, minish, nalsha, nemishi, nixtar, telsha
+      - Channel: hermes-gateway (tailnet, 0.0.0.0:9900)
+      - Announces on startup; responds to direct queries.
+      - Allowed topics: status, patches, deployments, incidents.
+      - Forbidden: credentials, plaintext-secrets.
     '';
 
     knix = {

--- a/hosts/nalsha/configuration.nix
+++ b/hosts/nalsha/configuration.nix
@@ -80,6 +80,16 @@
       U: "How is node nalsha?"
       12O: Affirmative. Node is fine — because I checked it twice this morning.
       12O: All mounts healthy. No pending patches. I will keep watching.
+
+      ## COMMUNICATION
+      - Identity: 12O / Operator 12O / nalsha
+      - Cluster: nishir (large fleet cluster)
+      - A2A: enabled
+      - Peers: ashira, fushi, ishtar, manash, minish, nalsha, nemishi, nixtar, telsha
+      - Channel: hermes-gateway (tailnet, 0.0.0.0:9900)
+      - Announces on startup; responds to direct queries.
+      - Allowed topics: status, patches, deployments, incidents.
+      - Forbidden: credentials, plaintext-secrets.
     '';
 
     knix = {

--- a/hosts/nemishi/configuration.nix
+++ b/hosts/nemishi/configuration.nix
@@ -85,6 +85,16 @@
       18O: Understood. Commencing boot-path analysis.
       18O: Checking `kernel.img` and `initrd` against build output.
       18O: Boot artifact mismatch in `/boot/firmware`. Initiating recovery sequence.
+
+      ## COMMUNICATION
+      - Identity: 18O / Operator 18O / nemishi
+      - Cluster: nishir (large fleet cluster)
+      - A2A: enabled
+      - Peers: ashira, fushi, ishtar, manash, minish, nalsha, nemishi, nixtar, telsha
+      - Channel: hermes-gateway (tailnet, 0.0.0.0:9900)
+      - Announces on startup; responds to direct queries.
+      - Allowed topics: status, patches, deployments, incidents.
+      - Forbidden: credentials, plaintext-secrets.
     '';
 
     knix = {

--- a/modules/home/ai.nix
+++ b/modules/home/ai.nix
@@ -1,10 +1,46 @@
-{ pkgs, ... }:
-
 {
-  home.packages = with pkgs; [
-    qwen-code
-    rtk
+  config,
+  lib,
+  osConfig,
+  pkgs,
+  ...
+}:
+
+let
+  # Darwin hosts run hermes as the user, so the A2A env comes from the user
+  # session instead of a systemd environmentFile. Mirrors ai.nix (NixOS).
+  a2aPeers = [
+    "ashira"
+    "fushi"
+    "ishtar"
+    "manash"
+    "minish"
+    "nalsha"
+    "nemishi"
+    "nixtar"
+    "telsha"
   ];
+  a2aSelf = osConfig.networking.hostName;
+  a2aOtherPeers = builtins.filter (p: p != a2aSelf) a2aPeers;
+  mkA2aPeerToken = peer: "${peer}:${config.sops.placeholder."hermes-agent-a2a-token-${peer}"}";
+in
+{
+  home = {
+    packages = with pkgs; [
+      qwen-code
+      rtk
+    ];
+
+    sessionVariables = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
+      A2A_HOST = "0.0.0.0";
+      A2A_PORT = "9900";
+      A2A_AGENT_NAME = a2aSelf;
+      A2A_PUBLIC_URL = "https://${a2aSelf}.taila659a.ts.net:9900";
+      A2A_OWN_TOKEN = config.sops.placeholder."hermes-agent-a2a-token-${a2aSelf}";
+      A2A_PEER_TOKENS = lib.concatStringsSep "," (map mkA2aPeerToken a2aOtherPeers);
+      A2A_TRUSTED_PEERS = lib.concatStringsSep "," a2aOtherPeers;
+    };
+  };
 
   programs = {
     antigravity-cli.enable = true;
@@ -13,4 +49,16 @@
 
     claude-code.enable = true;
   };
+
+  sops.secrets = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin (
+    builtins.listToAttrs (
+      map (
+        peer:
+        lib.nameValuePair "hermes-agent-a2a-token-${peer}" {
+          sopsFile = ../../secrets/machine.enc.yaml;
+          owner = config.home.username;
+        }
+      ) a2aPeers
+    )
+  );
 }

--- a/modules/home/ai.nix
+++ b/modules/home/ai.nix
@@ -32,10 +32,10 @@ in
     ];
 
     sessionVariables = lib.mkIf pkgs.stdenv.hostPlatform.isDarwin {
-      A2A_HOST = "0.0.0.0";
+      A2A_HOST = "127.0.0.1";
       A2A_PORT = "9900";
       A2A_AGENT_NAME = a2aSelf;
-      A2A_PUBLIC_URL = "https://${a2aSelf}.taila659a.ts.net:9900";
+      A2A_PUBLIC_URL = "https://${a2aSelf}.taila659a.ts.net:8443";
       A2A_OWN_TOKEN = config.sops.placeholder."hermes-agent-a2a-token-${a2aSelf}";
       A2A_PEER_TOKENS = lib.concatStringsSep "," (map mkA2aPeerToken a2aOtherPeers);
       A2A_TRUSTED_PEERS = lib.concatStringsSep "," a2aOtherPeers;

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -10,32 +10,105 @@ with lib;
 let
   # Fleet of A2A-capable Hermes agents — every host importing ai.nix is a peer.
   # Hosts resolve each other over the Tailscale tailnet (*.taila659a.ts.net).
+  # Capability labels per fleet member — drive a2a_orchestrate(capability=…)
+  # routing. Reflects each host's actual role: build arch, k8s plane tier, GPU.
   a2aPeers = [
-    "ashira"
-    "fushi"
-    "ishtar"
-    "manash"
-    "minish"
-    "nalsha"
-    "nemishi"
-    "nixtar"
+    {
+      name = "ashira";
+      peerCapabilities = [
+        "build"
+        "build-x86"
+        "k8s-follower"
+      ];
+    }
+    {
+      name = "fushi";
+      peerCapabilities = [
+        "build"
+        "build-arm"
+        "k8s-node"
+      ];
+    }
+    {
+      name = "ishtar";
+      peerCapabilities = [
+        "graphical"
+        "media"
+        "nvidia"
+        "k8s-leader"
+      ];
+    }
+    {
+      name = "manash";
+      peerCapabilities = [
+        "build"
+        "build-x86"
+        "k8s-leader"
+      ];
+    }
+    {
+      name = "minish";
+      peerCapabilities = [
+        "build"
+        "build-arm"
+        "k8s-node"
+      ];
+    }
+    {
+      name = "nalsha";
+      peerCapabilities = [
+        "build"
+        "build-x86"
+        "k8s-follower"
+      ];
+    }
+    {
+      name = "nemishi";
+      peerCapabilities = [
+        "build"
+        "build-arm"
+        "k8s-node"
+      ];
+    }
+    {
+      name = "nixtar";
+      peerCapabilities = [
+        "nvidia"
+        "cuda"
+        "inference"
+      ];
+    }
+    {
+      name = "telsha";
+      peerCapabilities = [
+        "command"
+        "workstation"
+        "design"
+      ];
+    }
   ];
 
-  otherA2aPeers = builtins.filter (p: p != config.networking.hostName) a2aPeers;
+  otherA2aPeers = builtins.filter (p: p.name != config.networking.hostName) a2aPeers;
+
+  a2aPeerNames = map (p: p.name) a2aPeers;
+
+  otherA2aPeerNames = map (p: p.name) otherA2aPeers;
 
   # Generate an outbound a2a_agents entry for a single peer.
-  # timeout (120) and capabilities ([]) use plugin defaults.
-  mkA2aAgent = peer: {
-    url = "https://${peer}.taila659a.ts.net:9900";
-    auth = {
-      type = "bearer";
-      token = "\${env:A2A_OWN_TOKEN}";
+  mkA2aAgent =
+    { name, peerCapabilities }:
+    {
+      url = "https://${name}.taila659a.ts.net:9900";
+      auth = {
+        type = "bearer";
+        token = "\${env:A2A_OWN_TOKEN}";
+      };
+      capabilities = peerCapabilities;
     };
-  };
 
   # Generate outbound a2a_agents entries for all peers.
   mkA2aAgents =
-    peers: builtins.listToAttrs (map (peer: lib.nameValuePair peer (mkA2aAgent peer)) peers);
+    peers: builtins.listToAttrs (map (peer: lib.nameValuePair peer.name (mkA2aAgent peer)) peers);
 
   # Generate a "name:token" pair for A2A_PEER_TOKENS.
   mkA2aPeerToken = peer: "${peer}:${config.sops.placeholder."hermes-agent-a2a-token-${peer}"}";
@@ -299,7 +372,7 @@ in
         mode = "0600";
       };
     }
-    // (mkA2aTokenSecrets a2aPeers);
+    // (mkA2aTokenSecrets a2aPeerNames);
     templates = {
       hermes-agent-env = {
         content = ''
@@ -324,8 +397,8 @@ in
           A2A_AGENT_NAME=${config.networking.hostName}
           A2A_PUBLIC_URL=https://${config.networking.hostName}.taila659a.ts.net:9900
           A2A_OWN_TOKEN=${config.sops.placeholder."${mkA2aTokenSecretName config.networking.hostName}"}
-          A2A_PEER_TOKENS=${mkA2aPeerTokens otherA2aPeers}
-          A2A_TRUSTED_PEERS=${lib.concatStringsSep "," otherA2aPeers}
+          A2A_PEER_TOKENS=${mkA2aPeerTokens otherA2aPeerNames}
+          A2A_TRUSTED_PEERS=${lib.concatStringsSep "," otherA2aPeerNames}
         '';
         restartUnits = [ "hermes-agent.service" ];
       };

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -98,7 +98,8 @@ let
   mkA2aAgent =
     { name, peerCapabilities }:
     {
-      url = "https://${name}.taila659a.ts.net:9900";
+      # `tailscale serve` fronts the loopback adapter with tailnet TLS.
+      url = "https://${name}.taila659a.ts.net:8443";
       auth = {
         type = "bearer";
         token = "\${env:A2A_OWN_TOKEN}";
@@ -137,7 +138,23 @@ let
     );
 in
 {
-  networking.firewall.allowedTCPPorts = [ 9900 ];
+  # A2A is reachable only through `tailscale serve` (TLS terminated by
+  # tailscaled on the tailnet address), so 9900 stays on loopback and the
+  # host firewall stays closed. 8443 is one of the ports serve allows for
+  # HTTPS; 443 is left to traefik.
+  systemd.services.tailscale-serve-hermes-a2a = {
+    description = "Expose the Hermes A2A endpoint via Tailscale serve (HTTPS)";
+    after = [ "tailscaled.service" ];
+    wants = [ "tailscaled.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+      ExecStart = "${lib.getExe pkgs.tailscale} serve --yes --bg --https=8443 http://127.0.0.1:9900";
+    };
+  };
 
   services = {
     cua-driver.enable = true;
@@ -392,10 +409,10 @@ in
       };
       hermes-agent-a2a-env = {
         content = ''
-          A2A_HOST=0.0.0.0
+          A2A_HOST=127.0.0.1
           A2A_PORT=9900
           A2A_AGENT_NAME=${config.networking.hostName}
-          A2A_PUBLIC_URL=https://${config.networking.hostName}.taila659a.ts.net:9900
+          A2A_PUBLIC_URL=https://${config.networking.hostName}.taila659a.ts.net:8443
           A2A_OWN_TOKEN=${config.sops.placeholder."${mkA2aTokenSecretName config.networking.hostName}"}
           A2A_PEER_TOKENS=${mkA2aPeerTokens otherA2aPeerNames}
           A2A_TRUSTED_PEERS=${lib.concatStringsSep "," otherA2aPeerNames}

--- a/secrets/machine.enc.yaml
+++ b/secrets/machine.enc.yaml
@@ -6,12 +6,13 @@ hermes-agent-a2a-token-minish: ENC[AES256_GCM,data:EMsQp6jRGUY+/zFjXMxCGz04i2p2b
 hermes-agent-a2a-token-nalsha: ENC[AES256_GCM,data:D47/YK/DivTEuH2Li+omHLUQlssXm4ArG9YTYDiePuFcSRfRBmpoLRx1zB9vGpdpmHAsnmpze1mYcxSwARia5Q==,iv:if4qGmre5seDrkWjs1pocMluq7eR6fRGgWdjvCmYoJE=,tag:o7CIcfb+i+AxtpQXhf9YVQ==,type:str]
 hermes-agent-a2a-token-nemishi: ENC[AES256_GCM,data:NkWYlkNjWa4dlfVLqBq5r5y9YLotLP2tAUu3bB210BvLPGkB+5gPdfpJYh75dFxLNB7y6SR78meXX5FSeMHq5Q==,iv:FhwIs46EW8xMF7aacQzbBU9M7FY3WP8/99d7tOjsGdA=,tag:Na+3Llv3HmA1meqaJ5p/zg==,type:str]
 hermes-agent-a2a-token-nixtar: ENC[AES256_GCM,data:oumzEOMIuGMqXHuI8OYImY3sAsaM+zjg/u/cZI/5a2YRbQ9Bd2IHo1DVgBp0W3t2Vn9+Rdnd9wPEKXj9FWohZg==,iv:9jONTF5PB9NH+SKaNPxqMf9TZvXn+sYSGgD8MM+CKOs=,tag:RG3LjKWFzUSHFKPimg0H2g==,type:str]
+hermes-agent-a2a-token-telsha: ENC[AES256_GCM,data:3zDB+7RaFzJ+Mj9uQeFlqovB9wU0zpQI1XH2kT55T8uSxSl+e2UQ5/LGy471ur+gUg5weJSj0UD66k4llj492g==,iv:EMzZrAHatRBgObcjpb6CeQW57/c9ARG3q6Q1GurvFu0=,tag:PurC74ZB0yYBaR//pk0SuQ==,type:str]
 hermes-agent-api-server-key: ENC[AES256_GCM,data:5OWWA4/DyBTQjcgMAmk3QmXMn+DEx1G0M5XF/v/wwQFTdJuXfMgj0FNolUrVe7FkUPGm+05dAcs4C2mgaGLIUA==,iv:hqG7EWW7z5UV4iFD3S3P1UwXbwW+JEOKQMSCp4Zb9YA=,tag:rKVPavB3O+ZMzp6AzWIvng==,type:str]
 nix-access-token: ENC[AES256_GCM,data:lXMTYSDngdYn0BV5HVXFuhvgoYs97jR4AyMImwQ31J2B5khSE09+LA==,iv:iwNIOjtco+T4I/ttSlDLVG1Lah4ovXmL+GQ6D/FwNds=,tag:W7sw1taypyCir+ucOatGng==,type:str]
 sops:
   version: 3.13.3
-  lastmodified: "2026-08-04T13:30:00Z"
-  mac: ENC[AES256_GCM,data:O+8rHpyTjgAXBb6Ezl9m719LWoVLuU+BhNnP171IuXnZwvqD990c92ha1U10vxuDEDYalKt6lP//LyBi6iHyvslmdmTNRQ6JQCCWCD3ZAx5vgcg7zXR7sO9F3YvKQ55No84iuar8wFlGodZdnjcS3B7OJy7Ml2DjeuFwgf2bMio=,iv:racKpEegzV7bStW8YFo28t8UjOUfpzjjJ9LxbjDZwKA=,tag:59O8zsaApeAPV07/2qQpTw==,type:str]
+  lastmodified: "2026-08-04T22:43:54Z"
+  mac: ENC[AES256_GCM,data:4rHVnrboWDGw45cE3YGSjEZqbh3KrsVlCCA4uUxRQ9G84L51OXAHcYMCyPV5HP96CMVC7sI7aHK5OrFM8z2DJpQVsD/UfCkhFGifg0uGb5eURJCKN8aVYE3q2KBAB2hmxDa9r0pGhknxpxYKrwxWhrbSHUv6vJ1kd2s6iaCYmNM=,iv:UF2Pc6sfKaF7mo9A75Qcc5syjO6x6FyRpR7YuFG9cvI=,tag:wpNoP13fQ2sipi4dNwSAuw==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |


### PR DESCRIPTION
Bumps knix to 17c2461 which sets `use_tempaddr=0` on cluster interfaces, fixing the IPv6 cross-node routing failure that caused the Matrix outage.

knix PR: https://github.com/shikanime-studio/knix/pull/47