### PR TITLE
Add user-level nix access token

### DIFF
--- a/modules/darwin/users/shikanimedeva.nix
+++ b/modules/darwin/users/shikanimedeva.nix
@@ -69,15 +69,21 @@ in
     zsh.enable = true;
   };
 
+  nix.extraOptions = "!include ${config.sops.templates.nix-user-config.path}";
+
   sops = {
     age.keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
     defaultSopsFile = ../../../secrets/shikanime.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets.cachix-token = { };
+    secrets.github-token = { };
     templates.cachix-config.content = toDhall {
       authToken = config.sops.placeholder.cachix-token;
       hostname = "https://cachix.org";
     };
+    templates.nix-user-config.content = ''
+      extra-access-tokens = github.com=${config.sops.placeholder.github-token}
+    '';
   };
 
   xdg.configFile."cachix/cachix.dhall".source =

--- a/modules/nixos/users/shika.nix
+++ b/modules/nixos/users/shika.nix
@@ -51,15 +51,21 @@ in
 
     programs.bash.enable = true;
 
+    nix.extraOptions = "!include ${config.sops.templates.nix-user-config.path}";
+
     sops = {
       age.keyFile = "${config.xdg.configHome}/sops/age/keys.txt";
       defaultSopsFile = ../../../secrets/shikanime.enc.yaml;
       defaultSopsFormat = "yaml";
       secrets.cachix-token = { };
+      secrets.github-token = { };
       templates.cachix-config.content = toDhall {
         authToken = config.sops.placeholder.cachix-token;
         hostname = "https://cachix.org";
       };
+      templates.nix-user-config.content = ''
+        extra-access-tokens = github.com=${config.sops.placeholder.github-token}
+      '';
     };
 
     xdg.configFile."cachix/cachix.dhall".source =

--- a/secrets/shikanime.enc.yaml
+++ b/secrets/shikanime.enc.yaml
@@ -1,8 +1,9 @@
 cachix-token: ENC[AES256_GCM,data:dwXGa5vw/rMwCj2hXQOGR+qxrc29gMKpqATFm4gmIBKJ5A36Hav2Sib8SNU6NwhvHXi79scQLE/wt8Qyn9M1JH+IgoI44Qbde5sWCBtoYHNJFC3Ai1uhYKqWgv4AUAkBndi2PtSguZe1a+sM69QgXnlY8AAkHM/y7CXShBLQ97kGo8ma/+7u+mzHTablMz23Hw==,iv:4wqET0AwsNOSKSZENOwrMnDtL98JXqhSrSDG8DOJoqU=,tag:VI6pUkNx/1Wm0+yEGix6Zg==,type:str]
+github-token: ENC[AES256_GCM,data:Go4qeh7pk3aLDuGStx5P7FCZ79zqjUCk4loGYw4Nev2jdunWb6wWKA==,iv:Bli3zECdAmBPP7oD95YssvCaaw7kYNA+p3/qjDjchSw=,tag:piXnXxaQFYvbNNmke758hA==,type:str]
 sops:
-  version: 3.13.1
-  lastmodified: "2026-07-25T23:45:28Z"
-  mac: ENC[AES256_GCM,data:OnoSFR6Mj6oCGJwLU5UJpFpmPj5F4MH7JWADgNr/XpLb1OT8Jb01RWzU9vnjmocANMjhL0Hmi69CCxDSS+1C/uJBEbntWh8y15Kx22wKYGX0D0JM9UVZL6MjqK2czgleRV8Tw84GncxhrSPTCsXFS6TtRR5vpGYH5M7f7T0wxAY=,iv:HcSoommTPisTDv70BQAZPlVx4AU3Xro1b2wpzj2VRcE=,tag:Pj6Np0b5PrQDzaMA1hNbhQ==,type:str]
+  version: 3.13.3
+  lastmodified: "2026-08-07T11:20:56Z"
+  mac: ENC[AES256_GCM,data:8OIanVJyek9qvLqSNZ4CQ6g8cyrsP4nHb+ixh4BR4GRO+9P3FEBnXliHqQ+rL8lju4aKF8qeGjpkN7Qv1HeP868AluC6jfbeikLJG42s5H6dSDWu7RWP9z2gk44Xsnqkyxvbd0IITaHWhMRNl3CAPEFQvOxa23zth0X00DJzqko=,iv:MgZ/yAblP+ZZIH6TZ1gUMvMttiIOrKrosfqgcX9kzFw=,tag:DQvYzjFrOR52rGd8vbuL0Q==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |


### PR DESCRIPTION
## Summary
- Wire `~/.config/nix/nix.conf` at the HM user level for both `shika` (nixos) and `shikanimedeva` (darwin) via `nix.extraOptions = "!include ..."`.
- Reuse the system-level sops template pattern: `github-token` secret from `secrets/shikanime.enc.yaml` rendered into a `nix-user-config` sops template.
- The token lives in machines, not identities, avoiding the sops secret-name collision when multiple identities are enabled for the same user (telsha).

## Verification
- `nix eval` of `darwinConfigurations.telsha` passes: `nix.extraOptions`, `sops.templates.nix-user-config.content`, and `sops.secrets.github-token` all resolve correctly.