### PR TITLE
feat(ishtar): openrazer group, NVDEC + fine-grained NVIDIA PM, Hermes shared state

### DIFF
--- a/hosts/ishtar/configuration.nix
+++ b/hosts/ishtar/configuration.nix
@@ -102,5 +102,48 @@
   # pkexec (gparted, etc.) can gain root from a non-root desktop session.
   security.polkit.enablePkexecWrapper = true;
 
+  # Fix permissions on shared Hermes state directory — the upstream
+  # hermes-agent NixOS module only pre-creates cron/sessions/logs/memories/plugins
+  # subdirs, but runtime code also creates kanban/, pastes/, skills/, lsp/,
+  # desktop/, etc.  Ensure ALL subdirectories are group-writable (2770) so
+  # interactive users in the 'hermes' group (like shika) can read/write.
+  system.activationScripts.hermes-permissions = {
+    text = ''
+      mkdir -p /var/lib/hermes/.hermes
+      chown -h hermes:hermes /var/lib/hermes /var/lib/hermes/.hermes
+      chmod 2770 /var/lib/hermes /var/lib/hermes/.hermes
+
+      for _subdir in cron sessions logs memories plugins kanban kanban/boards \
+                     pastes skills lsp desktop sandboxes scripts state \
+                     cache images platforms pending_messages; do
+        mkdir -p "/var/lib/hermes/.hermes/$_subdir"
+        chown hermes:hermes "/var/lib/hermes/.hermes/$_subdir"
+        chmod 2770 "/var/lib/hermes/.hermes/$_subdir"
+        find "/var/lib/hermes/.hermes/$_subdir" -type f -exec chmod g+rw {} + 2>/dev/null || true
+        if [ "$_subdir" = "skills" ]; then
+          find "/var/lib/hermes/.hermes/$_subdir" -type d -exec chmod 2770 {} + 2>/dev/null || true
+        fi
+      done
+
+      # Fix kanban board directories
+      for _board in /var/lib/hermes/.hermes/kanban/boards/*/; do
+        if [ -d "$_board" ]; then
+          chmod 2775 "$_board"
+          chown hermes:hermes "$_board"
+          find "$_board" -type f -exec chmod 664 {} + 2>/dev/null || true
+        fi
+      done
+
+      # Fix file permissions for shared state files
+      find /var/lib/hermes/.hermes -maxdepth 1 -name '*.db' -exec chmod 664 {} + 2>/dev/null || true
+      find /var/lib/hermes/.hermes -maxdepth 1 -name '*.lock' -exec chmod 664 {} + 2>/dev/null || true
+      find /var/lib/hermes/.hermes -maxdepth 1 -name '*.yaml' -exec chmod 664 {} + 2>/dev/null || true
+      find /var/lib/hermes/.hermes -maxdepth 1 -name '*.json' -exec chmod 664 {} + 2>/dev/null || true
+      find /var/lib/hermes/.hermes -maxdepth 1 -name '*.env' -exec chmod 664 {} + 2>/dev/null || true
+      find /var/lib/hermes/.hermes -maxdepth 1 -name '*.toml' -exec chmod 664 {} + 2>/dev/null || true
+      find /var/lib/hermes/.hermes -maxdepth 1 -name '*.md' -exec chmod 664 {} + 2>/dev/null || true
+    '';
+  };
+
   system.stateVersion = "26.05";
 }

--- a/modules/nixos/hardware/razer-blade.nix
+++ b/modules/nixos/hardware/razer-blade.nix
@@ -7,7 +7,13 @@
   };
 
   # Razer Blade 17 peripherals: daemon + udev rules.
-  hardware.openrazer.enable = true;
+  hardware.openrazer = {
+    enable = true;
+    # The openrazer module creates an `openrazer` group whose members come ONLY
+    # from this list; without it the daemon exits 1 ("User is not a member of
+    # the openrazer group") and the user service hits start-limit-hit at boot.
+    users = [ "shika" ];
+  };
 
   # CPU/device power management + suspend-on-lid-close.
   powerManagement.enable = true;

--- a/modules/nixos/profiles/graphical.nix
+++ b/modules/nixos/profiles/graphical.nix
@@ -70,12 +70,20 @@
     graphics = {
       enable = true;
       enable32Bit = true; # Gaming: 32-bit for Wine/Proton
+      # NVDEC hardware video decode (browser/media players) on the dGPU.
+      extraPackages = with pkgs; [ nvidia-vaapi-driver ];
     };
     bluetooth.enable = true;
     nvidia = {
       open = false; # proprietary/closed kernel module, per explicit request
       modesetting.enable = true;
-      powerManagement.enable = true;
+      powerManagement = {
+        enable = true;
+        # Fine-grained RTD3 for the Max-Q dGPU: per-frame power-state transitions
+        # instead of a coarse on/off switch. Valid because prime.offload.enable
+        # is set (assertion: finegrained -> offload).
+        finegrained = true;
+      };
       prime.offload = {
         enable = true;
         enableOffloadCmd = true; # provides `nvidia-offload` wrapper

--- a/modules/nixos/users/shika.nix
+++ b/modules/nixos/users/shika.nix
@@ -23,6 +23,11 @@ in
 
     home.sessionVariables.SSH_AUTH_SOCK = "${config.home.homeDirectory}/.bitwarden-ssh-agent.sock";
 
+    # Use the same HERMES_HOME as the gateway service so interactive
+    # shells share state (sessions, skills, cron, kanban) with the
+    # system-wide hermes-agent.service.
+    home.sessionVariables.HERMES_HOME = "/var/lib/hermes/.hermes";
+
     identities = {
       enable = true;
 


### PR DESCRIPTION
## Summary

Ports the verified ishtar peripheral / GPU / Hermes-state fixes onto the real
`machines` repo (the working copy at `~/Source/Repos/...`), split into focused
commits.

- **openrazer**: add `shika` to `hardware.openrazer.users` so
  `openrazer-daemon.service` can start (it exits 1 and hits start-limit-hit at
  boot when the user is not in the `openrazer` group).
- **NVIDIA**: enable `nvidia-vaapi-driver` for NVDEC hardware video decode, and
  switch `powerManagement` to fine-grained RTD3 (valid because
  `prime.offload.enable` is already set). Note: deliberately kept
  `nvidia.open = false` (proprietary module, intentionally requested upstream).
- **Hermes shared state**: a `hermes-permissions` activation script makes all
  `/var/lib/hermes/.hermes` subdirs group-writable (2770, group `hermes`) so
  interactive users in the `hermes` group can read/write shared state; and set
  `HERMES_HOME` for shika's shells to the gateway's state dir so interactive
  sessions share state with `hermes-agent.service`.

## Commits

1. `fix(ishtar)`: add shika to openrazer group
2. `feat(ishtar)`: NVDEC VA-API driver + fine-grained NVIDIA PM
3. `feat(ishtar)`: make shared Hermes state dir group-writable
4. `feat(shika)`: point HERMES_HOME at the shared state dir

## Verification

Each edited `.nix` file parses cleanly and the flake options resolve:

- `hardware.openrazer.users` → `[ "shika" ]`
- `hardware.nvidia.powerManagement.finegrained` → `true`
- `hardware.graphics.extraPackages` includes `nvidia-vaapi-driver`
- `home-manager.users.shika.home.sessionVariables.HERMES_HOME` →
  `/var/lib/hermes/.hermes`

A full `nixos-rebuild build` is not run here (it hangs ~30min+ on the unrelated
catppuccin `whiskers` cargo-vendor fetch); this PR is validated by option
resolution only.

## Not included (flagged)

Two edits present in the prior `/tmp/machines` working tree were **not** ported,
as they are risky / already handled upstream and need your call:

- **Tailscale `--ssh` removal** (in `profiles/machine.nix`): removing it
  disables Tailscale SSH for the host. Left as-is.
- **Element Flatpak `org.freedesktop.secrets=talk` override**: the target already
  ships `gnome-keyring` + `xdg.portal`, so this may be redundant. Left out.
