### PR TITLE
Move NVIDIA dGPU config into the Razer Blade module + add shika to openrazer group

### DIFF
--- a/hosts/ishtar/configuration.nix
+++ b/hosts/ishtar/configuration.nix
@@ -102,5 +102,12 @@
   # pkexec (gparted, etc.) can gain root from a non-root desktop session.
   security.polkit.enablePkexecWrapper = true;
 
+  # The openrazer module creates an `openrazer` group whose members come ONLY
+  # from hardware.openrazer.users. Without shika listed, openrazer-daemon.service
+  # exits 1 ("User is not a member of the openrazer group") and the user service
+  # hits start-limit-hit at boot. Host-specific, so set it here rather than the
+  # shared hardware module.
+  hardware.openrazer.users = [ "shika" ];
+
   system.stateVersion = "26.05";
 }

--- a/modules/nixos/hardware/razer-blade.nix
+++ b/modules/nixos/hardware/razer-blade.nix
@@ -1,3 +1,5 @@
+{ pkgs, ... }:
+
 {
   # UEFI laptop bootloader (Razer Blade 17, 2019). Windows dual-boot via systemd-boot.
   # Windows entry is automatically detected by systemd-boot.
@@ -11,6 +13,26 @@
 
   # CPU/device power management + suspend-on-lid-close.
   powerManagement.enable = true;
+
+  # NVIDIA GeForce RTX (Max-Q) dGPU — Razer Blade 17 specific.
+  hardware.nvidia = {
+    open = false; # proprietary/closed kernel module, per explicit request
+    modesetting.enable = true;
+    powerManagement = {
+      enable = true;
+      # Fine-grained RTD3: per-frame power-state transitions instead of a coarse
+      # on/off switch. Valid because prime.offload.enable is set (assertion:
+      # finegrained -> offload).
+      finegrained = true;
+    };
+    prime.offload = {
+      enable = true;
+      enableOffloadCmd = true; # provides `nvidia-offload` wrapper
+    };
+  };
+
+  # NVDEC hardware video decode (browser/media players) on the dGPU.
+  hardware.graphics.extraPackages = with pkgs; [ nvidia-vaapi-driver ];
 
   services = {
     fstrim.enable = true;


### PR DESCRIPTION
## Summary
- **Razer Blade hardware isolation**: move the Razer-Blade-specific NVIDIA dGPU configuration (RTD3 fine-grained power management + NVDEC vaapi driver) out of the shared `graphical.nix` profile into `modules/nixos/hardware/razer-blade.nix`, so the generic profile only carries graphics/firmware/Bluetooth.
- **OpenRazer daemon fix**: add `shika` to `hardware.openrazer.users` in the `ishtar` host config so `openrazer-daemon.service` can start (it was exiting 1 — *"User is not a member of the openrazer group"* — and hitting `start-limit-hit` at boot).

## Changes
| File | Change |
|------|--------|
| `modules/nixos/hardware/razer-blade.nix` | Add `hardware.nvidia.powerManagement.finegrained = true` and `hardware.graphics.extraPackages = [ nvidia-vaapi-driver ]`. |
| `modules/nixos/profiles/graphical.nix` | Remove the NVIDIA option block (kept only generic graphics/firmware/Bluetooth + the gamemode/steam `nvidia-settings` timer refs). |
| `hosts/ishtar/configuration.nix` | Add `hardware.openrazer.users = [ "shika" ];`. |

## Notes
- `nvidia.open` stays `false` (proprietary module, intentionally requested).
- `finegrained` is valid because `hardware.nvidia.prime.offload.enable` is already set.
- Hermes-related workarounds were intentionally dropped from this change set.
- Commits are DCO-signed (`Signed-off-by`) per repo convention.

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)

Co-Authored-By: Hermes Agent <hermes-agent@shikanime-labs.local>
