### PR TITLE
Remove dead model and fix provider in ai.nix

### DIFF
--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -214,7 +214,6 @@ in
               "inclusionai/ling-3.0-flash:free"
               "labs-leanstral-1-5"
               "nvidia/nemotron-3-ultra-550b-a55b:free"
-              "openrouter/openrouter/free"
               "poolside/laguna-xs-2.1:free"
               "qwen/qwen3-8b"
               "stepfun/step-3.7-flash:free"
@@ -316,7 +315,7 @@ in
             base_url = "https://ai.taila659a.ts.net/v1";
           };
           memory_query_rewrite = {
-            provider = "custom:aperture-anthropic:openai";
+            provider = "custom:aperture-openai";
             model = "tencent/hy3:free";
             base_url = "https://ai.taila659a.ts.net/v1";
           };


### PR DESCRIPTION
## What
- Removed `"openrouter/openrouter/free"` from the `custom:aperture-openai` provider `models` catalog in `modules/nixos/profiles/ai.nix`.
- Corrected `memory_query_rewrite.provider` from the malformed `"custom:aperture-anthropic:openai"` to `"custom:aperture-openai"`.

## Why
The catalog entry returned HTTP 404 ("No allowed providers are available") from the gateway, and the double-colon provider id did not exist — both broke Hermes agent model/provider resolution on fleet nodes built from this profile.

Related: https://github.com/shikanime-labs/machines/issues/1180