### PR TITLE
Expose Hermes api_server on 8642 via Tailscale

### DIFF
--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -158,7 +158,10 @@ in
     rtk
   ];
 
-  networking.firewall.allowedTCPPorts = [ 9900 ];
+  networking.firewall.allowedTCPPorts = [
+    9900
+    8642
+  ];
 
   services = {
     cua-driver.enable = true;
@@ -417,6 +420,27 @@ in
     };
     script = ''
       ${getExe pkgs.tailscale} serve --yes --bg --https=9900 http://127.0.0.1:9900
+    '';
+  };
+
+  # Expose the Hermes api_server (peer DM target) over Tailscale. It serves
+  # plain HTTP on :8642; `serve --https` terminates TLS and forwards to it.
+  systemd.services.tailscale-serve-api = {
+    description = "Expose Hermes api_server via Tailscale serve";
+    after = [
+      "tailscaled.service"
+      "tailscale-serve.service"
+    ];
+    wants = [ "tailscaled.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    script = ''
+      ${getExe pkgs.tailscale} serve --yes --bg --https=8642 http://127.0.0.1:8642
     '';
   };
 


### PR DESCRIPTION
Adds the api_server ("api") surface (port 8642) to the Hermes agent exposure on ai.nix hosts, mirroring the existing A2A (9900) pattern:

- `networking.firewall.allowedTCPPorts = [ 9900 8642 ]`
- new `systemd.services.tailscale-serve-api` oneshot: `tailscale serve --https=8642 http://127.0.0.1:8642`

`hermes peer add`/`dm` require the api_server REST endpoint (auth `API_SERVER_KEY`, already set in ai.nix via `API_SERVER_ENABLED=true`). Until now 8642 was neither firewalled nor published, so peer DM targets were unreachable (probed: all 7 ai hosts return 000 on :8642).

Verified: `nix eval` of `nixosConfigurations.nalsha` shows `allowedTCPPorts = [22 8642 9900]`, `tailscale-serve-api` Type `oneshot`, script correct; `tailscale-serve-a2a` untouched.

Note: `nix flake check` currently fails on an unrelated `catppuccin-starship` home-manager derivation (user `meika`) — not touched by this change.

Co-authored-by: Automata <automata@shikanime.studio>