### PR TITLE
Switch Stack Workflow docs from ghstack to gh stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,11 +42,20 @@ full directory layout.
 
 ## Stack Workflow
 
-- Open a PR; land it by commenting `.land` (or `.force-land`). Never
-  `gh pr merge`. Never force-push the PR branch.
-- `.rebase` rebase on base, `.backport` backport, `.close` abort, `.run` trigger
-  CI.
-- `main` is protected: requires a passing status check and a PR; linear history.
+- Install the official GitHub extension once: `gh extension install github/gh-stack`
+  (requires GitHub CLI ≥ 2.0; `gh stack` is in public preview and may change).
+- Keep one logical change per PR; split large work into a stack of PRs.
+- Create a stack: `gh stack init`, then `gh stack add` for each new branch, and
+  commit on the active branch. `gh stack view` lists the stack.
+- Submit/update: `gh stack submit` (add `--open` to open PRs, `--auto` to skip
+  prompts). Resubmit after each change to refresh titles, bodies, and branches.
+- Pull down an existing stack: `gh stack checkout <PR_NUMBER>` (also accepts a
+  stack number, PR URL, or branch name).
+- Rebase onto updated trunk: `gh stack rebase` (cascading), then `gh stack submit`.
+- Land a stack: `gh stack merge` (interactive) or
+  `gh stack merge <PR_NUMBER> --yes --squash` to merge up to a PR.
+- Never `gh pr merge` on a stacked PR — only `gh stack merge` lands stacks.
+- Never force-push stack branches; `gh stack` owns the branch pointers.
 
 ## Gotchas
 


### PR DESCRIPTION
Migrate the Stack Workflow section from ezyang/ghstack (.land, ghstack) to GitHub's first-party gh stack extension.

Related: https://github.com/shikanime-labs/machines/issues/1184