### PR TITLE
Fix catbox image push: use Operator app token for ghcr login

### DIFF
--- a/.github/workflows/skaffold.yaml
+++ b/.github/workflows/skaffold.yaml
@@ -23,11 +23,11 @@ jobs:
       packages: write
     steps:
       - id: createGithubAppToken
-        continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OPERATOR_APP_ID }}
+          client-id: ${{ vars.OPERATOR_APP_CLIENT_ID }}
           permission-contents: read
+          permission-packages: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
       - uses: shikanime-studio/actions/checkout@v9
         with:
@@ -36,7 +36,7 @@ jobs:
             }}
       - uses: docker/login-action@v4
         with:
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ steps.createGithubAppToken.outputs.token }}
           registry: ghcr.io
           username: ${{ github.actor }}
       - uses: shikanime-studio/actions/nix/setup@v9
@@ -81,11 +81,11 @@ jobs:
         include: ${{ fromJSON(needs['setup-profiles-jobs'].outputs.matrix) }}
     steps:
       - id: createGithubAppToken
-        continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OPERATOR_APP_ID }}
+          client-id: ${{ vars.OPERATOR_APP_CLIENT_ID }}
           permission-contents: read
+          permission-packages: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
       - uses: shikanime-studio/actions/checkout@v9
         with:
@@ -94,7 +94,7 @@ jobs:
             }}
       - uses: docker/login-action@v4
         with:
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ steps.createGithubAppToken.outputs.token }}
           registry: ghcr.io
           username: ${{ github.actor }}
       - uses: shikanime-studio/actions/nix/setup@v9
@@ -119,11 +119,11 @@ jobs:
       matrix: ${{ steps.setup-profiles-jobs.outputs.matrix }}
     steps:
       - id: createGithubAppToken
-        continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OPERATOR_APP_ID }}
+          client-id: ${{ vars.OPERATOR_APP_CLIENT_ID }}
           permission-contents: read
+          permission-packages: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
       - uses: shikanime-studio/actions/checkout@v9
         with:


### PR DESCRIPTION
## Problem
The `catbox` skaffold build compiled successfully but the push to `ghcr.io/shikanime-labs/machines/catbox` was denied:

```
Error: check push permission failed: .../catbox/blobs/uploads/:
  DENIED: installation not allowed to Write organization package
```

Root cause (in `.github/workflows/skaffold.yaml`):
- `docker/login-action` authenticated to ghcr with `secrets.GITHUB_TOKEN` (the Actions robot), which cannot write **org-scoped** packages.
- The Operator GitHub App token step passed the renamed `app-id` input (now `client-id`), so it errored; with `continue-on-error: true` the error was swallowed and the build silently fell back to `GITHUB_TOKEN`. That mask hid the real cause.

## Fix
- Repoint the app-token step to `client-id` and add `permission-packages: write`.
- Drop `continue-on-error` so a failed token mint fails loudly instead of falling back.
- Log into ghcr with the Operator token (`steps.createGithubAppToken.outputs.token`).

## Validation
This PR triggers Integration → the `build-render` job builds `machines/catbox` (multi-arch amd64+arm64) and pushes it. A green run proves the push denial is resolved. The running `catbox` VM image tag in `shikanime-labs/manifests` will then be updated to the freshly published tag.

Related: catbox KubeVirt conversion (manifests repo)

Co-authored-by: Automata <automata@shikanime.studio>