### PR TITLE
Fix catbox skaffold CI: resilient Operator token and ghcr login fallback

### DIFF
--- a/.github/workflows/skaffold.yaml
+++ b/.github/workflows/skaffold.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           app-id: ${{ vars.OPERATOR_APP_ID }}
           permission-contents: read
+          permission-packages: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
       - uses: shikanime-studio/actions/checkout@v9
         with:
@@ -36,9 +37,10 @@ jobs:
             }}
       - uses: docker/login-action@v4
         with:
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
       - uses: shikanime-studio/actions/nix/setup@v9
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -86,6 +88,7 @@ jobs:
         with:
           app-id: ${{ vars.OPERATOR_APP_ID }}
           permission-contents: read
+          permission-packages: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
       - uses: shikanime-studio/actions/checkout@v9
         with:
@@ -94,9 +97,10 @@ jobs:
             }}
       - uses: docker/login-action@v4
         with:
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password:
+            ${{ steps.createGithubAppToken.outputs.token || secrets.GITHUB_TOKEN }}
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
       - uses: shikanime-studio/actions/nix/setup@v9
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -124,6 +128,7 @@ jobs:
         with:
           app-id: ${{ vars.OPERATOR_APP_ID }}
           permission-contents: read
+          permission-packages: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
       - uses: shikanime-studio/actions/checkout@v9
         with:

--- a/.github/workflows/skaffold.yaml
+++ b/.github/workflows/skaffold.yaml
@@ -17,6 +17,9 @@ permissions:
 jobs:
   build-render:
     name: Build & Render
+    if: >-
+      ${{ github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,7 +29,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OPERATOR_APP_ID }}
+          client-id: ${{ vars.OPERATOR_APP_ID }}
           permission-contents: read
           permission-packages: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
@@ -70,7 +73,10 @@ jobs:
           path: artifacts/skaffold-manifest.yaml
   build-render-profile:
     name: Build & Render (Profile)
-    if: ${{ needs['setup-profiles-jobs'].outputs.continue == 'true' }}
+    if: >-
+      ${{ (github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      needs['setup-profiles-jobs'].outputs.continue == 'true' }}
     runs-on: ubuntu-latest
     needs:
       - setup-profiles-jobs
@@ -86,7 +92,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OPERATOR_APP_ID }}
+          client-id: ${{ vars.OPERATOR_APP_ID }}
           permission-contents: read
           permission-packages: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
@@ -126,7 +132,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OPERATOR_APP_ID }}
+          client-id: ${{ vars.OPERATOR_APP_ID }}
           permission-contents: read
           permission-packages: write
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}


### PR DESCRIPTION
## Problem
The catbox image build/push (`.github/workflows/skaffold.yaml`, invoked by the
`Integration` workflow) fails on CI runs originating from a **fork PR**:

```
Error: The 'client-id' (or deprecated 'app-id') input must be set to a non-empty string.
...
multi-platform build requires pushing images to a valid container registry.
```

Root cause: on fork-PR runs GitHub withholds the base repo's `vars`/`secrets`
from the called reusable workflow, so `actions/create-github-app-token` mints
an empty token. Without the Operator token, the ghcr login falls back to
`GITHUB_TOKEN`, which cannot push **org-scoped** packages
(`DENIED: installation not allowed to Write organization package`). And skaffold's
catbox build is multi-platform (amd64+arm64), which requires pushing to a
registry — it cannot build-and-not-push.

## Fix
Skip the skaffold `Build & Render` job on fork PRs (where publishing can never
succeed); it still runs on `main`/release and same-repo PRs where the Operator
token mints and the push proceeds. Also modernize `app-id` → `client-id` and
grant the token `permission-packages: write`. The catbox image is already built
and validated on every PR by the `nix / Packages` job (Nix dockerTools), so only
the publish step is skipped on forks.

## Validation
A green `Integration` run for this PR (skaffold publish skipped, no failure)
proves the fork-PR path no longer errors.

Related: https://github.com/shikanime-labs/machines/issues/1190

Co-authored-by: Automata <automata@shikanime.studio>
