### PR TITLE
Generate individual Hermes api_server key for each machine

### DIFF
--- a/hosts/ashira/configuration.nix
+++ b/hosts/ashira/configuration.nix
@@ -108,7 +108,7 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/ashira.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/fushi/configuration.nix
+++ b/hosts/fushi/configuration.nix
@@ -112,7 +112,7 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/fushi.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/ishtar/configuration.nix
+++ b/hosts/ishtar/configuration.nix
@@ -93,7 +93,7 @@
     defaultSopsFile = ../../secrets/ishtar.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets = {
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/ishtar.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
     };
   };

--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -109,7 +109,7 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/manash.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
       wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/minish/configuration.nix
+++ b/hosts/minish/configuration.nix
@@ -112,7 +112,7 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/minish.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/nalsha/configuration.nix
+++ b/hosts/nalsha/configuration.nix
@@ -107,7 +107,7 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/nalsha.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/nemishi/configuration.nix
+++ b/hosts/nemishi/configuration.nix
@@ -112,7 +112,7 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
+      hermes-agent-api-server-key.sopsFile = ../../secrets/nemishi.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/secrets/ashira.enc.yaml
+++ b/secrets/ashira.enc.yaml
@@ -1,10 +1,11 @@
+hermes-agent-api-server-key: ENC[AES256_GCM,data:ZPaweq5bfZANefM+QWtzZ8fxgnZkD38j1YpwQAwBfzrE5LzcEkiBW4bDEl/8nPg=,iv:GRcDYFiIXH4nRFtLKp51w2Q4LKBSxp65TZiTTcOdJ5k=,tag:+j3jS8y+o3aK/q1QuKDLUw==,type:str]
 hermes-agent-matrix-access-token: ENC[AES256_GCM,data:bkZbtYiQMqPwPtSQRS7yp0DcMlBFqo19mYAGAQqEF6S3j5qf3okjDyaig1iQgS8=,iv:TF9l3sc4GZMDqMviLcwbec/3ZwW/31LGjm+sN3BNddo=,tag:AHXmz82qDWB/AJLexg3AIw==,type:str]
 hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:R5xFpFiK9dC62N9z7f3P/vxHe0oaDYurmd3zSnPccg1pk7v7WN+bt72qaMfADpmzzdhcjg1SWTcjxSQ=,iv:bGbmEG9S6RbbeHfZCxcpgRo/YRod0vsSrfRkNMAZ1Go=,tag:DD7fuG6pPHDRBevvHE7P5Q==,type:str]
 rke2-token: ENC[AES256_GCM,data:ZhjHnX2cGo1fKoo2GoJa4xshr+8nMo1SwJ8UdVWYc4a2FbV/ehDTSlaEz8DbE9J9aLvEiJ3oJCFBBD8SqitfTxo5S1JpbJy0kYKrse6a5D/fvHcZVFjWE6g10ONS/v8NDJywhe4yb9cxMMsr,iv:E2x2yMigVlgH/Rb0uaNYQ/x2Qk/dJe2uIf+EFRxHTTI=,tag:LlVJN6KAqlUcoeg9/fnKWg==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-07-04T23:16:56Z"
-  mac: ENC[AES256_GCM,data:IQZlaopB1rbqovdLcrqwUeHnh3AcGarPlR+vP5LUxJZ0kGBSGLIoHKT1/E2dZsRF8nQgS7oGzerbUcIbIwrd/dM64FBBfvRh7uA81d+BrPMGlGsQ8Vphr7OUZKj83zAYrJRL6shVNYLhfsP15mA7Jk2WAP3lygq4whWnyiPhalI=,iv:tudWaflVADz3gvwnzC87ddYqpQb3Ubu9D+wK1gEeIR0=,tag:f2tT/BQGbOmLeou7OZKfyA==,type:str]
+  lastmodified: "2026-08-21T23:12:44Z"
+  mac: ENC[AES256_GCM,data:7aBiWte91IcA6UU1p2UJomGwgZF43tkgp4olyiBb65nbak5n2IDI/bSyEgQPNN5phZiUDMT+75I/4RgdTmknncz0/PxNpROjQF9UbrPxqfnDqqixVmDXazCspndZUe7KJ5p1ju6gdECE5/xAEoRb0RsYXi/1TzOLDQqeDfW6zgk=,iv:AQD4JKpuiZ396ZHMkDyFRrFW0zvVFzggD6aULfTLWrU=,tag:jy2sc8PTgbLsaRQfelgKIw==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/fushi.enc.yaml
+++ b/secrets/fushi.enc.yaml
@@ -1,9 +1,10 @@
+hermes-agent-api-server-key: ENC[AES256_GCM,data:F3NbmawnhXxLtXOfUb3gjsTE2XB/T7zPZ2ELY2NFtzOanDzuI4mQ7Br3A5ksnqQ=,iv:3cevDb0agBG6kjrnaMxubNtShfGFTWWFU2BgCLojyWs=,tag:fP4VT/wBUYuIGP/Y4gy3YQ==,type:str]
 hermes-agent-matrix-access-token: ENC[AES256_GCM,data:3FV3y8ElvePApyX/uqMo3xy5Pt66YtbNc/e6dEGpJZ7nTWF1z/nJdWQS+GlhwtnA,iv:/ljlAwygMaMm7jQEzhanb23DwcHcxQc9B1yW4DdsrYI=,tag:23Ac8PYQG05bOB59iiJL6A==,type:str]
 hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:Ou7lVgiGZz2/oF2gsdeQao/qwX0qsCbxElCbP3FyKGDrBQy8ePjDWIXW2fMGVVV8i6+OMGJPQTVKrGs=,iv:5OHFZRMaxQgd/uyMsH7LTPiSsK46UriJEuY6ozMND3M=,tag:I/nYVqw6I4ieUqdRw0Erlw==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-07-04T23:17:39Z"
-  mac: ENC[AES256_GCM,data:Y257wW8/3h/624yfXz803LBR0wyNjqxYpajlqo0UsCL4X8yDoI/2w7vfgQMCTDvp4pA97n/UXy0CUpxXd78JpuFBrQlZTxFs94eTun30AYbkx5BOOQsGhHh5biq6gMTYnzl0FG7Mneef33IiMpNhOZ+W6wkCaXMaTK3bN5AUGkQ=,iv:XKtysKpR+G+z/sgNswnzpuAsu1voFM765wqZT+4jYRA=,tag:uRYv9T0Xa+01oaohznLwEA==,type:str]
+  lastmodified: "2026-08-21T23:12:44Z"
+  mac: ENC[AES256_GCM,data:xqzf+ON6xCbe0H7d/3/Sv3ROSIjAjGwMyLQTQbjsdNj8LqF5Bj3n/mODAeu8xBDRKKhPmLnUZXkXF+smxWoEUSaP3KNbE4nTL43miE/lUuX/fXQ9uX91InxLJzEzFT91rnrMB+s3IIZodYwq8I0M3ioCT33gbkmEGuIQaBRMwsQ=,iv:y9hRvkHHF1KqvmHHWRhceNNaV2deE3PTZch9Z7HvnIc=,tag:PsAlPrqziQQMvZVBb8iUGQ==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/ishtar.enc.yaml
+++ b/secrets/ishtar.enc.yaml
@@ -1,9 +1,10 @@
+hermes-agent-api-server-key: ENC[AES256_GCM,data:958YOFMD1cdBDgnzLXqo9nBhCCNV1ViLD5EO8s7u23yYxxURqkz5gwgQQo4q,iv:7wYbZbD94vXSLBlOLROyvezYkVz+No0mplqVki8alws=,tag:69uHlT5lbAtu+G0fb4EINw==,type:str]
 hermes-agent-matrix-access-token: ""
 hermes-agent-matrix-recovery-key: ""
 sops:
   version: 3.13.3
-  lastmodified: "2026-07-31T15:09:11Z"
-  mac: ENC[AES256_GCM,data:vaj4gEJjidyQfrpED2OtF7YXcBCLXPfPB+rMiz0+y+hpsAM4oi55tj+ONvCxr6Ro2V6EVbzyRgqkLuEq0Q744GvVVbNuGgqOmLLD4hF+DbktwvQquHXjPKeLbUxQhxun8ruvic5+OZqKvSbHkKs65I6c+45lBJKyKdMGtzIjQPs=,iv:IJs5hE0boNwtMGsqs/sSE2uPli1dfS3iOhfIYcw/FKE=,tag:Ivk2o8JegFmGZ1vpSKg+Ig==,type:str]
+  lastmodified: "2026-08-21T23:12:44Z"
+  mac: ENC[AES256_GCM,data:7WnCQrEQ3e+QlokItx/Y38uNmLZNVd5zTn0rrhu7T+wAFRar8uut/lkZMHUTOlRlvAMlQjcngC0mJN9lCi1pLIManx2K0FcWAkFaOQ5TJC2ZyY+eivCvxD4QMXPW8qu3TlYBOK/CPvTVUZKrj+Vo7jHxrG2cwiEW9Eq/iNbWTC0=,iv:zdVwjkJdPPlOWFNYiZjBvFl1PUp0EE4OlGZIPkU9Eoc=,tag:tRU2jp/8FULLFJ5il82EWA==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/machine.enc.yaml
+++ b/secrets/machine.enc.yaml
@@ -6,119 +6,118 @@ hermes-agent-a2a-token-minish: ENC[AES256_GCM,data:EMsQp6jRGUY+/zFjXMxCGz04i2p2b
 hermes-agent-a2a-token-nalsha: ENC[AES256_GCM,data:D47/YK/DivTEuH2Li+omHLUQlssXm4ArG9YTYDiePuFcSRfRBmpoLRx1zB9vGpdpmHAsnmpze1mYcxSwARia5Q==,iv:if4qGmre5seDrkWjs1pocMluq7eR6fRGgWdjvCmYoJE=,tag:o7CIcfb+i+AxtpQXhf9YVQ==,type:str]
 hermes-agent-a2a-token-nemishi: ENC[AES256_GCM,data:NkWYlkNjWa4dlfVLqBq5r5y9YLotLP2tAUu3bB210BvLPGkB+5gPdfpJYh75dFxLNB7y6SR78meXX5FSeMHq5Q==,iv:FhwIs46EW8xMF7aacQzbBU9M7FY3WP8/99d7tOjsGdA=,tag:Na+3Llv3HmA1meqaJ5p/zg==,type:str]
 hermes-agent-a2a-token-nixtar: ENC[AES256_GCM,data:oumzEOMIuGMqXHuI8OYImY3sAsaM+zjg/u/cZI/5a2YRbQ9Bd2IHo1DVgBp0W3t2Vn9+Rdnd9wPEKXj9FWohZg==,iv:9jONTF5PB9NH+SKaNPxqMf9TZvXn+sYSGgD8MM+CKOs=,tag:RG3LjKWFzUSHFKPimg0H2g==,type:str]
-hermes-agent-api-server-key: ENC[AES256_GCM,data:5OWWA4/DyBTQjcgMAmk3QmXMn+DEx1G0M5XF/v/wwQFTdJuXfMgj0FNolUrVe7FkUPGm+05dAcs4C2mgaGLIUA==,iv:hqG7EWW7z5UV4iFD3S3P1UwXbwW+JEOKQMSCp4Zb9YA=,tag:rKVPavB3O+ZMzp6AzWIvng==,type:str]
 nix-access-token: ENC[AES256_GCM,data:lXMTYSDngdYn0BV5HVXFuhvgoYs97jR4AyMImwQ31J2B5khSE09+LA==,iv:iwNIOjtco+T4I/ttSlDLVG1Lah4ovXmL+GQ6D/FwNds=,tag:W7sw1taypyCir+ucOatGng==,type:str]
 sops:
-  version: 3.13.3
-  lastmodified: "2026-08-04T13:30:00Z"
-  mac: ENC[AES256_GCM,data:O+8rHpyTjgAXBb6Ezl9m719LWoVLuU+BhNnP171IuXnZwvqD990c92ha1U10vxuDEDYalKt6lP//LyBi6iHyvslmdmTNRQ6JQCCWCD3ZAx5vgcg7zXR7sO9F3YvKQ55No84iuar8wFlGodZdnjcS3B7OJy7Ml2DjeuFwgf2bMio=,iv:racKpEegzV7bStW8YFo28t8UjOUfpzjjJ9LxbjDZwKA=,tag:59O8zsaApeAPV07/2qQpTw==,type:str]
-  unencrypted_suffix: _unencrypted
-  age:
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
-        Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
-        eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
-        V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
-        y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
-        QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
-        L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
-        L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
-        lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
-        eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
-        aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
-        QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
-        +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
-        dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
-        RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
-        UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
-        OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
-        RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
-        MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
-        NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
-        8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
-        KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
-        ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
-        eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
-        Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
-        VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
-        RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
-        QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
-        bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
-        VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
-        bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
-        ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
-        PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
-        ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
-        ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
-        VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
-        wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
-        aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
-        V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
-        ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
-        NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
-        MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
-        QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
-        UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
-        EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
-        OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
-        UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
-        enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
-        Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
+            Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
+            eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
+            V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
+            y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
+            QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
+            L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
+            L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
+            lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
+            eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
+            aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
+            QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
+            +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
+            dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
+            RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
+            UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
+            OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
+            RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
+            MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
+            NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
+            8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
+            KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
+            ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
+            eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
+            Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
+            VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
+            RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
+            QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
+            bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
+            VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
+            bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
+            ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
+            PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
+            ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
+            ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
+            VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
+            wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
+            aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
+            V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
+            ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
+            NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
+            MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
+            QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
+            UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
+            EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
+            OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
+            UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
+            enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
+            Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+    lastmodified: "2026-08-22T00:39:08Z"
+    mac: ENC[AES256_GCM,data:BOWc1WcWnbSeKtFbCq9jvKfVFtso6fNHb/Bs7OQM1dMgIfnNsl8PPVJ4bR1JYuSRldNzrkV6Z35QCB3bj5mHEACRJQtttYRoI/M4O2tOjHEf0xJl8+Ht6+zEsOdrw4SHo8OGDddXD997sjFaMzElGlzIDx7pVKtOfKp3jnoZSws=,iv:CRdYq5XcZbGzmeqSXivSVCBymjANIJIKi2HKOvxUBhA=,tag:ip1kY0zkPdtvKHgvXtTFug==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3

--- a/secrets/manash.enc.yaml
+++ b/secrets/manash.enc.yaml
@@ -1,9 +1,10 @@
+hermes-agent-api-server-key: ENC[AES256_GCM,data:KQUy+PMjZCDXjRPdO1SdFjHflP/j80O7sTrufWGsNTOmw3WuP2YZHyt9y0YUHQJ2,iv:BpQz69h0722CVyYxV4x/99Azi1vWBeXgTJDCkmOEjEI=,tag:l8AY2zcePkJjQcm7xzrpuw==,type:str]
 hermes-agent-matrix-access-token: ENC[AES256_GCM,data:7nXFjGr+JEn8UsIs4omppTF6Tw5xihebJQzlu31ZEFyIxCl9fCPgOQK429weIwY=,iv:4bLASEe8v0XUf2NEQBHvhsXggk/oKv4oIj60RsVR/b8=,tag:UWtc9GIQnmEjvi/UL5rtWA==,type:str]
 hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:dk14TvqJ5rL4lIaRbbpoDx9odEoK9Xzozh2cugcPqJMih+RnqBmm4xqq5Q6inHd5P/aDW2MWKmVUsTg=,iv:7zEvuOGjTEp1K7QjmXkj1oc3WyqjESiqQTXfq3IH4uU=,tag:CjXivh7qKWx9LHO7yTvI1w==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-07-04T23:18:10Z"
-  mac: ENC[AES256_GCM,data:f1+JQ9sBCpeqscBOvsqYqknAckhGiVef59wWWn8/5uujqOY6op/4Zv8IHkhmzxMAqWL3In0IiuR3z2Vxlcg/vx1CalJYCBp9g9wusVh4LJYUlOHgRg+3PkggjKtt0Gk4FQp6xDFEpYUb6tYwvI3ZQQZqXOM0N5Fr0bUlZrrAcFs=,iv:z32EVTDnWYoRk328seltQ27Zsk+S26sQ+33mPRA5rFM=,tag:KbjThtF5rF+7bwK0UJFQfg==,type:str]
+  lastmodified: "2026-08-21T23:12:44Z"
+  mac: ENC[AES256_GCM,data:LvMsrOpnPi+MVZ69aV4Jk4Lro0HscGiNFKg1/YV5nYNmsbPxfC2lkMu4TtBGIPiI9lklI05vNoHd5iT0LWOEC6V1GYbMr8WTlvbTQ65xQ5UagPwjOhKJcynzAoQVMfa86MDD9CTYwwM/l0EToaUUW9+PJF1LR8dpmAMssbSrLNo=,iv:6YitlUBVwb51rA8hRNDg352lCIt74mo7tmuYSHUzO4g=,tag:FTxPGJIz65EX2tBt8V5NVQ==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/minish.enc.yaml
+++ b/secrets/minish.enc.yaml
@@ -1,9 +1,10 @@
+hermes-agent-api-server-key: ENC[AES256_GCM,data:8GMPLXBO7L9nrVqoWyAKpdBS0F7ZvveQidKOF9jhV9We+e+1psvLpYHsZA==,iv:umyNREQR3VdHcEAYSELGohl94dgOXBIaGnFJpp3z2VA=,tag:ZAQg/OnGJ0puKaU++6lgsg==,type:str]
 hermes-agent-matrix-access-token: ENC[AES256_GCM,data:t/6TKQa5ADbuXqKu5OZYFoL+INArb8S86mxFRSPnr25ip1EqQsPPHSrZJDL0CZ6O,iv:WWeJhWX2vrWPLQFw41ZAbdszjDqvmMVHVv1xyVOxp0Q=,tag:jEHodqzhI20aoqTYz8UwCg==,type:str]
 hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:baIGapTb1ZxNFM+0Brpkk30osUGAm0D6/1OuidEp5gg0113Q8VcsEixILICW84v5av70wGGpwr5eOxM=,iv:uu8GsQOY082GaKhSCIdtHwqLHab5ovyGHX4Guilr8e8=,tag:bNUTvmpnviwmHCvVpOl0fg==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-07-04T23:18:42Z"
-  mac: ENC[AES256_GCM,data:HPX7PRSCZm50WAWtIgYafxZvcZn5Q/jiyRFLjIPsMesQmFuOWHM7S9IUu/D5YFVxCjxP3ban9fbGSRbWhNMZmM4s/pdbpqmOk7+85EkwPCcgzBimZDgNz8yAtEta9UcIs6na3MKCNhAHOEkHdckgMR2g5wNK3/0OVdpuZ+rb5qE=,iv:qZPm0NCs4HWFbtRhMdDglQEl13Ki9st03ckRtPyI6MQ=,tag:9hNM+EteFFbyJdpJWH/2Kg==,type:str]
+  lastmodified: "2026-08-21T23:12:44Z"
+  mac: ENC[AES256_GCM,data:bLhUFdttdxE8m6i1FADCQB/ekgLTxH4/n3+sbjxBrbxMZCzMc9rHoMfsszUpdYJ0KQ4P0w5jmOpbI4aOKqnzoq83bEt+0duPD9O/ASPayrsy1woSih0H/Sopff3SM1aJO0UwHDoMMxWOcuf1+y1Lbb89BHyujNi5M5H8Fb2Rmsk=,iv:XS/vMHnAiAKPw64fQ7deEiGRjOFxEcpos7Bz51zKdhw=,tag:gq4kR9x1ZxnBOKm/SYa7vg==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/nalsha.enc.yaml
+++ b/secrets/nalsha.enc.yaml
@@ -1,10 +1,11 @@
+hermes-agent-api-server-key: ENC[AES256_GCM,data:y+qMQoQfrln09ACEfm2gn3vs3YHI4teeNbaVdwsLbzaybZdcOHCJLoj565uvBnPI,iv:25dMqTd+IfmJB+VGz/N4qdylP0/E61suamTnyssneY0=,tag:GM5ZQ4tsbiQLL3zDk1Fsjw==,type:str]
 hermes-agent-matrix-access-token: ENC[AES256_GCM,data:snW3Mss2JXZLy533H36PA6iKA6GgPpN4c+h/pocvvyJHNH7heJq/0+Nodw2VSI/a,iv:yTRhmH5anA5ZmthhbGgFZcbgSOsJ3MXWHB7Jupt0XHw=,tag:o4srWprcFEI91OblmyCXWQ==,type:str]
 hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:19Im7ckaD/nWE/HaMlmoVpgUlnxBs04emF280l7r8U3U0ll93yTmYvesGH/2S6d62gHH1GIOAQTycZM=,iv:9rqUZp/qd81P7uB7/H6pvw5lJswN9FagZi6WedRJKzs=,tag:yJ6VBVpvMGgoddOzxG8oJQ==,type:str]
 rke2-token: ENC[AES256_GCM,data:g/AJcEXEFsdCvQVrXEhPjR5ZIrWPXRW3bmLjqD1UifvjAC9wpJ/xZKsA0Au+ssA2JUy0P+Rei0jOoSWYA6SWiflXTVbAOI5ILfa/KABnifxcTqJYgyHGM1hXdfcDC4UO9x1JG+Pa5FFisZqe,iv:2DecG6Y2IDS6Cj36B4TjGaHTjyyCh2wuh9Lwc0BgLEs=,tag:YubnDbaHkGrv2mFhlTfNag==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-07-04T23:19:06Z"
-  mac: ENC[AES256_GCM,data:CjUzO/g//T9VeJKuw18xifslkVEXYsXuManGX6/jwfJXhAzTIhvrPnVETBugYc0y5TdzApALOCN1RWSlp8o/yHMx2FKJ5VvJF1Sox35YwG6EIAq+dr7VcHiMiyXBl/6Ng5Vp098X+uc6W7M0doZR2csBpbUZ6DvkVuwkXbBlGPg=,iv:GnfJGaFRuIy5dDqhHiYld2gvdFjA/1mDPJQBjKYarh0=,tag:UjcCq5XmwAdiGtXOx5Q9WA==,type:str]
+  lastmodified: "2026-08-21T23:12:44Z"
+  mac: ENC[AES256_GCM,data:30ZcO7NQBraSUtPGaQx4FjiBhtzCYqIEeMkOPQLNDuNF4Syb6yBm17Jo+s1bIL61iR600XHFpeqNf1Dty+0pY2XjRhQvkMUWnbmmTSGPPD2gOrMrLX2Kk8ZjBMdHvqUbcYxDHkiHTTLl2g0nH8w+4gqt/Pu0FPj3paKp8HUg0xQ=,iv:gazhJjsdjPYDjzchGyVxfZvh2yY+ppa6nCJksN3fMB4=,tag:Q1Bw6J0ECQyzZrBgYgwPTQ==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/nemishi.enc.yaml
+++ b/secrets/nemishi.enc.yaml
@@ -1,10 +1,11 @@
+hermes-agent-api-server-key: ENC[AES256_GCM,data:LHspEd380THByZXpnXUJNfuUiwehasyjfqT3JmRNySLFN7XQxW32j+59dknWqQKN,iv:jLerFInAdWUuCTCqZbUtoqTi2S3qgVbnBnzNu1efFTE=,tag:ZpadrDRq3ajkYRpw2pKHPQ==,type:str]
 hermes-agent-matrix-access-token: ENC[AES256_GCM,data:waGWq5I2MZEmHYUQzNu53lj9/D8FAhnmwTSpPnz3+BaMsYhZe5qe/Xf7e5Fifhrq,iv:/lQmN5UrwDNwlIFAhGky4BkHL5RfaQsYVdjF2TYm+ZM=,tag:me2eFvJMSqXE8OJ0h2ETcQ==,type:str]
 hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:rw+peVbm/oTOVhfMUrmAQI31EAYcLp+XH7WBeL6ae3CtUSb8ZP0xeVO2nFXDa0yIP4ygVYE7AHEXyv4=,iv:ogXQ9rysIiFbB5YEaiOEYcdyLBwT+3KXmIPeITsVgyw=,tag:8EWoTDQXDdIfuUADjlXulA==,type:str]
 rke2-token: ENC[AES256_GCM,data:jr3FAFEMjcJYp5GEZ2QiNA4FOlc79Ebg3isbIF8zyiGq2CJM4LnKV4LrrqAhoW/J0uG5WtEszZVGrET5umR4oohcwxIcRwxzNZ8v2ZlqboxUyjHO23eyKUw7HKdq53DIv5Xr2baxs4996S0b,iv:nyn6F2MxQehUVoQF5IA/BP/RK5PRnf7Hq2z4+B/DdTg=,tag:EC+B433pMRQzs3UhHgZQKQ==,type:str]
 sops:
   version: 3.13.1
-  lastmodified: "2026-07-18T00:13:15Z"
-  mac: ENC[AES256_GCM,data:vIgUr98wab8yZwvwks8gFoFRBcuTP66ILb4DM6Gj950a1QZdm+eos9mWf5GXFDarT/MGXxax8WTTIQGuAdtRXIyOiTmNqljxJsPusYhGEGkcGpUdoCMqCumEEl/7qr9oaxJo2LcGVO2cCL3fpygJnzr4xl/DE80JpR34saGoD9A=,iv:1IF46VBM9kBmKfKcZ7Us5XyySBdxVxXRQ0YvOj4e7ZQ=,tag:L7Kpqf3wAYv1swYyL3tH1w==,type:str]
+  lastmodified: "2026-08-21T23:12:44Z"
+  mac: ENC[AES256_GCM,data:nyhYtY9L5h0hObQfQ6wjDZErsaBNhQsPyxIyJkaslAz+/5Xg6s+kYwXpxNW6QXmR2+pAIm6FyiMmr1yQzU9CJRiDvGxCMD2o3Yyr97PmsiEP/4a+ioP3q4M5+Qo6Nak00LapYjHx/EIlgJaQj7qpNODuPP8dfDkUkIjbtsRRanM=,iv:xNYrC50To9xEUsnSWKkv8uquHEqvcK76xccPow7srO0=,tag:iq0HpPUOGFIA7Di1dBKS+g==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |


### PR DESCRIPTION
## What

Each NixOS host now has its own hermes-agent-api-server-key in secrets/<host>.enc.yaml. Each host's hermes-agent-api-server-key.sopsFile points at its own file instead of the shared machine.enc.yaml. The now-unused shared key was removed from machine.enc.yaml.

Affected hosts: ashira, fushi, ishtar, manash, minish, nalsha, nemishi.

## Why

All fleet hosts previously shared one hermes-agent-api-server-key from secrets/machine.enc.yaml, so a single host compromise exposed the fleet-wide credential with no per-host rotation or revocation.

## References

Related: https://github.com/shikanime-labs/machines/issues/1191
