### PR TITLE
Generate individual Hermes api_server key for each machine (part 1/2)

### DIFF
--- a/secrets/machine.enc.yaml
+++ b/secrets/machine.enc.yaml
@@ -7,6 +7,13 @@ hermes-agent-a2a-token-nemishi: ENC[AES256_GCM,data:NkWYlkNjWa4dlfVLqBq5r5y9YLot
 hermes-agent-api-server-key: ENC[AES256_GCM,data:5OWWA4/DyBTQjcgMAmk3QmXMn+DEx1G0M5XF/v/wwQFTdJuXfMgj0FNolUrVe7FkUPGm+05dAcs4C2mgaGLIUA==,iv:hqG7EWW7z5UV4iFD3S3P1UwXbwW+JEOKQMSCp4Zb9YA=,tag:rKVPavB3O+ZMzp6AzWIvng==,type:str]
 nix-access-token: ENC[AES256_GCM,data:lXMTYSDngdYn0BV5HVXFuhvgoYs97jR4AyMImwQ31J2B5khSE09+LA==,iv:iwNIOjtco+T4I/ttSlDLVG1Lah4ovXmL+GQ6D/FwNds=,tag:W7sw1taypyCir+ucOatGng==,type:str]
 hermes-agent-a2a-token-nixtar: ENC[AES256_GCM,data:c9XiJGNZlp0nLVMeV/DVa0a6QzbzOim1to7L0VdMueIX0bEG8QK+lyy2jgMw0aqNr1pUpdHVxECSsFORuORUyg==,iv:8keD6ZFh9tSPtN1WBSUWAOvYaTArQVc6kGEHew1Kut4=,tag:Ak8EWfbw+QPxf7lG83hMCA==,type:str]
+hermes-agent-api-server-key-ashira: ENC[AES256_GCM,data:lAJMRqH3fPhGJMkIxGBN+WwyFrGZK2DS4l5HGW5HaaH/qZ88F0RyexX58G0Rzmg2,iv:mb/63r2ChLiKAxUWBvIbl7BGb4fql3hfoPSK7g1rPgs=,tag:vDGyfaRTopJHWn2CbRdzzA==,type:str]
+hermes-agent-api-server-key-nemishi: ENC[AES256_GCM,data:V2Spnje4593nOTkdf3+QA7Ku+jzFO4rywIACFNUeRJndR/41wAqfzm0qEYRoPg==,iv:sRu9pWOujPcsP4JYTjmKQbxi5tGJt/5Gd8A0oDIVYjQ=,tag:shcVHaW9HMiQfE6lbgQ4VA==,type:str]
+hermes-agent-api-server-key-manash: ENC[AES256_GCM,data:1E0gqZZ0DG3z+50A//SWjiNx6pkUgN3sAY9uUnOqBw4ZI832o/r+dSkaZpiuyA==,iv:4rAoEdxCSH0/9C1B9f2ihr/hYodhMrCRd3iCMoFttak=,tag:Usznj3y1ybJ3rG9Dj1Tzpg==,type:str]
+hermes-agent-api-server-key-fushi: ENC[AES256_GCM,data:vXgmR7wjh+uLwCUIAHeVxE/SYoCw6P2Zn77MTphcj/oXd0Osl8XYaGbBo+7zDtc=,iv:AxZ+beakugvWpDrBfFiDVHyctoHbru+7rBO+XbUlO6E=,tag:EJoTF8R8zPZPdIfYkCVMtQ==,type:str]
+hermes-agent-api-server-key-nixtar: ENC[AES256_GCM,data:zlfMTrZKmrFZjiHktixCYUs8jLXRESfVYhZGZD/LzQ5tvNLe8NkihYEpgafB,iv:HqGjxKIqsM/bP71poQtNi6GtXgoWY1RiG4jPybaM6kA=,tag:+Z+EhTXGH+Slnz3WaDqP+w==,type:str]
+hermes-agent-api-server-key-nalsha: ENC[AES256_GCM,data:3dz0KqqCWC446/qPIaJ41XKMTsh+dp26+UiTCGM9PXf3FmowEqWXdThOhAR6aQ8=,iv:dHK4gWPYHhBESqbgNpyUqIjBted8Z6n/9g8Mw0lzEd4=,tag:65GSKse0wYpmPu5TfKOyvA==,type:str]
+hermes-agent-api-server-key-minish: ENC[AES256_GCM,data:MbNKt2I9/CYC7K0qbRTw17wBUFPmmFAeLHubjt3s/Limh+o4OXTIdVJlQILbkA==,iv:Tas8kDmmI6W7hwvly0uRNvQB5hOa4ogp1oy6ukRei6g=,tag:nR37jj58H7UAgC/VNDs5zg==,type:str]
 sops:
     age:
         - enc: |
@@ -117,7 +124,7 @@ sops:
             Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
-    lastmodified: "2026-08-21T23:27:26Z"
-    mac: ENC[AES256_GCM,data:/4P3NNUGU1yKVB/LRcSLPLEHA6RCwwYG7NVdP0usqmbrWlKdT+gAafynn86Rkt+kCijWogzJVbammbM9P4BuF/ttnZxY3DoKuH1z52wH/46zD5cngbS0raGzsXQgTx8NfxWTRpe4IOFMIj0WJW4mKzxGCn8AW7+wJkkjuN5ImV4=,iv:vie6jHFVHhBDMgb40QEOzQhtlFU8paotp9zxXnwOI9E=,tag:xCgchBvero0zBdTi41J6KA==,type:str]
+    lastmodified: "2026-08-22T01:04:48Z"
+    mac: ENC[AES256_GCM,data:GLwhUC4p/AuCCb8Ip21AIsFzCqIbdPbIgB3saiJLqexKQJ6N3hy2hwZ+yI1ZaUOK6safsJ0rhCoZ8CU7VwBUWpBcFDwOjWhNPJnCpOJwS9XOwhfFpnWa0qHl9EgGqfvex7P4SuMGMURdHX+bAmwD9eLMCaQRsQTj7/GhiXo+Dvo=,iv:UofZn7cCH01i1CDnjtqlYKx5bOtgHdICFmEQJ+sFopo=,tag:uOluWnv8q2w697yIxfEX1A==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
Per-host Hermes api_server keys are added to `secrets/machine.enc.yaml` for the fleet peer mesh.

This is part 1 of 2.

## What changes
- Seven distinct `hermes-agent-api-server-key-<host>` values are added (one per fleet host: ashira, nemishi, manash, fushi, nixtar, nalsha, minish).
- The legacy shared `hermes-agent-api-server-key` is retained in this change so every host stays deployable until the module flip in part 2.

## Why
A single shared api_server key meant any one host compromise exposed the fleet credential, with no per-host rotation or revocation. Per-host keys let each host run its own api_server and dial peers with isolated credentials.

## Stack
- Part 1 (this PR): secrets only, hosts untouched.
- Part 2: `ai.nix` consumes the per-host keys, renders the `bot_peers` roster, and retires the shared key.

Related: #1193
