### PR TITLE
Wire fleet Hermes peer mesh and retire shared api_server key (part 2/2)

### DIFF
--- a/hosts/ashira/configuration.nix
+++ b/hosts/ashira/configuration.nix
@@ -108,7 +108,6 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/fushi/configuration.nix
+++ b/hosts/fushi/configuration.nix
@@ -112,7 +112,6 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -109,7 +109,6 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
       wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/minish/configuration.nix
+++ b/hosts/minish/configuration.nix
@@ -112,7 +112,6 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/nalsha/configuration.nix
+++ b/hosts/nalsha/configuration.nix
@@ -107,7 +107,6 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/nemishi/configuration.nix
+++ b/hosts/nemishi/configuration.nix
@@ -112,7 +112,6 @@
     secrets = {
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/nixtar/configuration.nix
+++ b/hosts/nixtar/configuration.nix
@@ -93,7 +93,6 @@
     defaultSopsFile = ../../secrets/nixtar.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets = {
-      hermes-agent-api-server-key.sopsFile = ../../secrets/machine.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
     };
   };

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -103,6 +103,51 @@ let
   # Generate secret key name
   mkA2aTokenSecretName = peer: "hermes-agent-a2a-token-${peer}";
 
+  # Per-host api_server key name for the Hermes peer mesh. Each fleet host
+  # runs its own api_server with a distinct API_SERVER_KEY and dials peers
+  # using HERMES_PEER_<NAME>_KEY (that peer's key).
+  mkPeerApiServerKeyName = peer: "hermes-agent-api-server-key-${peer}";
+
+  # Render the bot_peers roster (name + tailnet URL) for the other hosts.
+  mkBotPeers =
+    peers:
+    builtins.listToAttrs (
+      map (
+        peer:
+        lib.nameValuePair peer.name {
+          url = "https://${peer.name}.taila659a.ts.net:8642";
+        }
+      ) peers
+    );
+
+  # Generate "HERMES_PEER_<NAME>_KEY=<placeholder>" lines for every other peer.
+  mkPeerKeyEnv =
+    peers:
+    lib.concatStringsSep "\n" (
+      map (
+        peer:
+        let
+          secretName = mkPeerApiServerKeyName peer.name;
+        in
+        "HERMES_PEER_${lib.toUpper peer.name}_KEY=${config.sops.placeholder.${secretName}}"
+      ) peers
+    );
+
+  # Sops secret definitions for every host's per-host api_server key.
+  mkPeerApiServerKeySecrets =
+    peers:
+    builtins.listToAttrs (
+      map (
+        peer:
+        lib.nameValuePair (mkPeerApiServerKeyName peer.name) {
+          sopsFile = ../../../secrets/machine.enc.yaml;
+          group = "hermes";
+          owner = "hermes";
+          restartUnits = [ "hermes-agent.service" ];
+        }
+      ) peers
+    );
+
   # Hermes scans each extraPlugins entry for plugin.yaml at the derivation
   # root, so wrap the source in symlinkJoin rather than passing it bare.
   hermesLcmPlugin = pkgs.symlinkJoin {
@@ -173,6 +218,7 @@ in
         config.sops.templates.hermes-agent-env.path
         config.sops.templates.hermes-agent-matrix-env.path
         config.sops.templates.hermes-agent-a2a-env.path
+        config.sops.templates.hermes-agent-peer-keys-env.path
       ];
       extraPackages = with pkgs; [
         agent-browser
@@ -364,6 +410,10 @@ in
         platforms.a2a.enabled = true;
         # Outbound: every peer addressable via tailnet; presents own token.
         a2a_agents = mkA2aAgents otherA2aPeers;
+        # Bot-mode peer mesh (hermes peer): each fleet host exposes its own
+        # api_server and dials the others. Names/URLs here; keys via
+        # HERMES_PEER_<NAME>_KEY (hermes-agent-peer-keys-env template).
+        bot_peers = mkBotPeers otherA2aPeers;
         # The `a2a` toolset ships off by default — enable it on every surface
         # that must reach the fleet, or the a2a_* tools never register.
         platform_toolsets = {
@@ -446,11 +496,6 @@ in
 
   sops = {
     secrets = {
-      hermes-agent-api-server-key = {
-        group = "hermes";
-        owner = "hermes";
-        restartUnits = [ "hermes-agent.service" ];
-      };
       hermes-agent-matrix-access-token = {
         group = "hermes";
         owner = "hermes";
@@ -463,13 +508,20 @@ in
         mode = "0600";
       };
     }
-    // (mkA2aTokenSecrets a2aPeers);
+    // (mkA2aTokenSecrets a2aPeers)
+    // (mkPeerApiServerKeySecrets a2aPeers);
     templates = {
       hermes-agent-env = {
         content = ''
           API_SERVER_ENABLED=true
-          API_SERVER_KEY=${config.sops.placeholder.hermes-agent-api-server-key}
+          API_SERVER_KEY=${config.sops.placeholder."${mkPeerApiServerKeyName config.networking.hostName}"}
         '';
+      };
+      hermes-agent-peer-keys-env = {
+        content = ''
+          ${mkPeerKeyEnv otherA2aPeers}
+        '';
+        restartUnits = [ "hermes-agent.service" ];
       };
       hermes-agent-matrix-env = {
         content = ''

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -12,7 +12,7 @@ let
   # Hosts resolve each other over the Tailscale tailnet (*.taila659a.ts.net).
   # Capability labels per fleet member — drive a2a_orchestrate(capability=…)
   # routing. Reflects each host's actual role: build arch, k8s plane tier, GPU.
-  a2aPeers = [
+  peers = [
     {
       name = "ashira";
       capabilities = [
@@ -72,7 +72,7 @@ let
     }
   ];
 
-  otherA2aPeers = builtins.filter (p: p.name != config.networking.hostName) a2aPeers;
+  otherPeers = builtins.filter (p: p.name != config.networking.hostName) peers;
 
   # Generate trusted peer names
   mkA2aTrustedPeers = peers: lib.concatStringsSep "," (map (p: p.name) peers);
@@ -121,7 +121,7 @@ let
     );
 
   # Generate "HERMES_PEER_<NAME>_KEY=<placeholder>" lines for every other peer.
-  mkPeerKeyEnv =
+  mkPeerKeyEnvs =
     peers:
     lib.concatStringsSep "\n" (
       map (
@@ -409,11 +409,11 @@ in
         # tokens (A2A_PEER_TOKENS) authenticate each fleet member by name.
         platforms.a2a.enabled = true;
         # Outbound: every peer addressable via tailnet; presents own token.
-        a2a_agents = mkA2aAgents otherA2aPeers;
+        a2a_agents = mkA2aAgents otherPeers;
         # Bot-mode peer mesh (hermes peer): each fleet host exposes its own
         # api_server and dials the others. Names/URLs here; keys via
         # HERMES_PEER_<NAME>_KEY (hermes-agent-peer-keys-env template).
-        bot_peers = mkBotPeers otherA2aPeers;
+        bot_peers = mkBotPeers otherPeers;
         # The `a2a` toolset ships off by default — enable it on every surface
         # that must reach the fleet, or the a2a_* tools never register.
         platform_toolsets = {
@@ -508,8 +508,8 @@ in
         mode = "0600";
       };
     }
-    // (mkA2aTokenSecrets a2aPeers)
-    // (mkPeerApiServerKeySecrets a2aPeers);
+    // (mkA2aTokenSecrets peers)
+    // (mkPeerApiServerKeySecrets peers);
     templates = {
       hermes-agent-env = {
         content = ''
@@ -518,9 +518,7 @@ in
         '';
       };
       hermes-agent-peer-keys-env = {
-        content = ''
-          ${mkPeerKeyEnv otherA2aPeers}
-        '';
+        content = toString (mkPeerKeyEnvs otherPeers);
         restartUnits = [ "hermes-agent.service" ];
       };
       hermes-agent-matrix-env = {
@@ -540,8 +538,8 @@ in
           A2A_AGENT_NAME=${config.networking.hostName}
           A2A_PUBLIC_URL=https://${config.networking.hostName}.taila659a.ts.net:9900
           A2A_OWN_TOKEN=${config.sops.placeholder."${mkA2aTokenSecretName config.networking.hostName}"}
-          A2A_PEER_TOKENS=${mkA2aPeerTokens otherA2aPeers}
-          A2A_TRUSTED_PEERS=${mkA2aTrustedPeers otherA2aPeers}
+          A2A_PEER_TOKENS=${mkA2aPeerTokens otherPeers}
+          A2A_TRUSTED_PEERS=${mkA2aTrustedPeers otherPeers}
         '';
         restartUnits = [ "hermes-agent.service" ];
       };

--- a/secrets/machine.enc.yaml
+++ b/secrets/machine.enc.yaml
@@ -4,127 +4,126 @@ hermes-agent-a2a-token-manash: ENC[AES256_GCM,data:bYfmIWPG4cMhQlWLfVW+YL/wuwzEh
 hermes-agent-a2a-token-minish: ENC[AES256_GCM,data:EMsQp6jRGUY+/zFjXMxCGz04i2p2bW1RQcgt4MQNPsUrCE/ICOT56GGbgEJxVnzSRpdoGLe30VxJZuf/yTFyhQ==,iv:dGfhw5OvYmon4lgTohi56pdgLW7ntvAtDDxdzYY/EUE=,tag:8PgRQCXXWfBBSPbLnYh7iA==,type:str]
 hermes-agent-a2a-token-nalsha: ENC[AES256_GCM,data:D47/YK/DivTEuH2Li+omHLUQlssXm4ArG9YTYDiePuFcSRfRBmpoLRx1zB9vGpdpmHAsnmpze1mYcxSwARia5Q==,iv:if4qGmre5seDrkWjs1pocMluq7eR6fRGgWdjvCmYoJE=,tag:o7CIcfb+i+AxtpQXhf9YVQ==,type:str]
 hermes-agent-a2a-token-nemishi: ENC[AES256_GCM,data:NkWYlkNjWa4dlfVLqBq5r5y9YLotLP2tAUu3bB210BvLPGkB+5gPdfpJYh75dFxLNB7y6SR78meXX5FSeMHq5Q==,iv:FhwIs46EW8xMF7aacQzbBU9M7FY3WP8/99d7tOjsGdA=,tag:Na+3Llv3HmA1meqaJ5p/zg==,type:str]
-hermes-agent-api-server-key: ENC[AES256_GCM,data:5OWWA4/DyBTQjcgMAmk3QmXMn+DEx1G0M5XF/v/wwQFTdJuXfMgj0FNolUrVe7FkUPGm+05dAcs4C2mgaGLIUA==,iv:hqG7EWW7z5UV4iFD3S3P1UwXbwW+JEOKQMSCp4Zb9YA=,tag:rKVPavB3O+ZMzp6AzWIvng==,type:str]
-nix-access-token: ENC[AES256_GCM,data:lXMTYSDngdYn0BV5HVXFuhvgoYs97jR4AyMImwQ31J2B5khSE09+LA==,iv:iwNIOjtco+T4I/ttSlDLVG1Lah4ovXmL+GQ6D/FwNds=,tag:W7sw1taypyCir+ucOatGng==,type:str]
 hermes-agent-a2a-token-nixtar: ENC[AES256_GCM,data:c9XiJGNZlp0nLVMeV/DVa0a6QzbzOim1to7L0VdMueIX0bEG8QK+lyy2jgMw0aqNr1pUpdHVxECSsFORuORUyg==,iv:8keD6ZFh9tSPtN1WBSUWAOvYaTArQVc6kGEHew1Kut4=,tag:Ak8EWfbw+QPxf7lG83hMCA==,type:str]
 hermes-agent-api-server-key-ashira: ENC[AES256_GCM,data:lAJMRqH3fPhGJMkIxGBN+WwyFrGZK2DS4l5HGW5HaaH/qZ88F0RyexX58G0Rzmg2,iv:mb/63r2ChLiKAxUWBvIbl7BGb4fql3hfoPSK7g1rPgs=,tag:vDGyfaRTopJHWn2CbRdzzA==,type:str]
-hermes-agent-api-server-key-nemishi: ENC[AES256_GCM,data:V2Spnje4593nOTkdf3+QA7Ku+jzFO4rywIACFNUeRJndR/41wAqfzm0qEYRoPg==,iv:sRu9pWOujPcsP4JYTjmKQbxi5tGJt/5Gd8A0oDIVYjQ=,tag:shcVHaW9HMiQfE6lbgQ4VA==,type:str]
-hermes-agent-api-server-key-manash: ENC[AES256_GCM,data:1E0gqZZ0DG3z+50A//SWjiNx6pkUgN3sAY9uUnOqBw4ZI832o/r+dSkaZpiuyA==,iv:4rAoEdxCSH0/9C1B9f2ihr/hYodhMrCRd3iCMoFttak=,tag:Usznj3y1ybJ3rG9Dj1Tzpg==,type:str]
 hermes-agent-api-server-key-fushi: ENC[AES256_GCM,data:vXgmR7wjh+uLwCUIAHeVxE/SYoCw6P2Zn77MTphcj/oXd0Osl8XYaGbBo+7zDtc=,iv:AxZ+beakugvWpDrBfFiDVHyctoHbru+7rBO+XbUlO6E=,tag:EJoTF8R8zPZPdIfYkCVMtQ==,type:str]
-hermes-agent-api-server-key-nixtar: ENC[AES256_GCM,data:zlfMTrZKmrFZjiHktixCYUs8jLXRESfVYhZGZD/LzQ5tvNLe8NkihYEpgafB,iv:HqGjxKIqsM/bP71poQtNi6GtXgoWY1RiG4jPybaM6kA=,tag:+Z+EhTXGH+Slnz3WaDqP+w==,type:str]
-hermes-agent-api-server-key-nalsha: ENC[AES256_GCM,data:3dz0KqqCWC446/qPIaJ41XKMTsh+dp26+UiTCGM9PXf3FmowEqWXdThOhAR6aQ8=,iv:dHK4gWPYHhBESqbgNpyUqIjBted8Z6n/9g8Mw0lzEd4=,tag:65GSKse0wYpmPu5TfKOyvA==,type:str]
+hermes-agent-api-server-key-manash: ENC[AES256_GCM,data:1E0gqZZ0DG3z+50A//SWjiNx6pkUgN3sAY9uUnOqBw4ZI832o/r+dSkaZpiuyA==,iv:4rAoEdxCSH0/9C1B9f2ihr/hYodhMrCRd3iCMoFttak=,tag:Usznj3y1ybJ3rG9Dj1Tzpg==,type:str]
 hermes-agent-api-server-key-minish: ENC[AES256_GCM,data:MbNKt2I9/CYC7K0qbRTw17wBUFPmmFAeLHubjt3s/Limh+o4OXTIdVJlQILbkA==,iv:Tas8kDmmI6W7hwvly0uRNvQB5hOa4ogp1oy6ukRei6g=,tag:nR37jj58H7UAgC/VNDs5zg==,type:str]
+hermes-agent-api-server-key-nalsha: ENC[AES256_GCM,data:3dz0KqqCWC446/qPIaJ41XKMTsh+dp26+UiTCGM9PXf3FmowEqWXdThOhAR6aQ8=,iv:dHK4gWPYHhBESqbgNpyUqIjBted8Z6n/9g8Mw0lzEd4=,tag:65GSKse0wYpmPu5TfKOyvA==,type:str]
+hermes-agent-api-server-key-nemishi: ENC[AES256_GCM,data:V2Spnje4593nOTkdf3+QA7Ku+jzFO4rywIACFNUeRJndR/41wAqfzm0qEYRoPg==,iv:sRu9pWOujPcsP4JYTjmKQbxi5tGJt/5Gd8A0oDIVYjQ=,tag:shcVHaW9HMiQfE6lbgQ4VA==,type:str]
+hermes-agent-api-server-key-nixtar: ENC[AES256_GCM,data:zlfMTrZKmrFZjiHktixCYUs8jLXRESfVYhZGZD/LzQ5tvNLe8NkihYEpgafB,iv:HqGjxKIqsM/bP71poQtNi6GtXgoWY1RiG4jPybaM6kA=,tag:+Z+EhTXGH+Slnz3WaDqP+w==,type:str]
+nix-access-token: ENC[AES256_GCM,data:lXMTYSDngdYn0BV5HVXFuhvgoYs97jR4AyMImwQ31J2B5khSE09+LA==,iv:iwNIOjtco+T4I/ttSlDLVG1Lah4ovXmL+GQ6D/FwNds=,tag:W7sw1taypyCir+ucOatGng==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
-            Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
-            eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
-            V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
-            y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
-            QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
-            L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
-            L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
-            lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
-            eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
-            aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
-            QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
-            +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
-            dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
-            RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
-            UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
-            OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
-            RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
-            MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
-            NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
-            8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
-            KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
-            ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
-            eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
-            Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
-            VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
-            RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
-            QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
-            bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
-            VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
-            bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
-            ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
-            PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
-            ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
-            ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
-            VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
-            wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
-            aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
-            V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
-            ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
-            NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
-            MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
-            QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
-            UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
-            EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
-            OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
-            UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
-            enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
-            Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
-    lastmodified: "2026-08-22T01:04:48Z"
-    mac: ENC[AES256_GCM,data:GLwhUC4p/AuCCb8Ip21AIsFzCqIbdPbIgB3saiJLqexKQJ6N3hy2hwZ+yI1ZaUOK6safsJ0rhCoZ8CU7VwBUWpBcFDwOjWhNPJnCpOJwS9XOwhfFpnWa0qHl9EgGqfvex7P4SuMGMURdHX+bAmwD9eLMCaQRsQTj7/GhiXo+Dvo=,iv:UofZn7cCH01i1CDnjtqlYKx5bOtgHdICFmEQJ+sFopo=,tag:uOluWnv8q2w697yIxfEX1A==,type:str]
-    unencrypted_suffix: _unencrypted
-    version: 3.13.3
+  version: 3.13.3
+  lastmodified: "2026-08-22T01:06:33Z"
+  mac: ENC[AES256_GCM,data:zLRFpRdaokeTLaza2TxgwQ1p0pVhoOe6tNCEUZOiKwDX7U6+WeYrMyf+nSgTnWJr2QsYbdVA6AS6+L0qt3CrAxL0vOPBGLpOcTejS64zeiIfT+/gKXK9YQ4fJPbFH9GlAY3PKulXCGcB7yOT3n5xMMAMKuhQ7JtwsZ+iqjAMSRw=,iv:gK57n4LTRogOSEQAGKFuUxDrc6qfVx8S0ouSxQzqIL0=,tag:rsh7aIwkXPzFe2+rtVJ6+g==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
+        Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
+        eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
+        V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
+        y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
+        QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
+        L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
+        L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
+        lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
+        eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
+        aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
+        QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
+        +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
+        dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
+        RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
+        UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
+        OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
+        RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
+        MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
+        NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
+        8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
+        KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
+        ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
+        eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
+        Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
+        VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
+        RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
+        QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
+        bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
+        VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
+        bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
+        ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
+        PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
+        ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
+        ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
+        VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
+        wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
+        aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
+        V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
+        ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
+        NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
+        MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
+        QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
+        UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
+        EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
+        OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
+        UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
+        enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
+        Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d


### PR DESCRIPTION
The fleet Hermes peer mesh is wired into `ai.nix` and the shared api_server key is retired.

This is part 2 of 2 (depends on part 1).

## What changes
- Each host runs its own api_server with its distinct `hermes-agent-api-server-key-<host>` (`API_SERVER_KEY` now reads the per-host key by hostname).
- `HERMES_PEER_<NAME>_KEY` env lines are rendered for the other six hosts via the new `hermes-agent-peer-keys-env` sops template, mounted into the hermes-agent service.
- `bot_peers` renders the roster of the other fleet hosts (name + tailnet URL) into `services.hermes-agent.settings`.
- The legacy shared `hermes-agent-api-server-key` and its sops definition are removed; the seven host `sops.secrets.<name>.sopsFile` overrides are dropped because `ai.nix` now declares the per-host secrets.

## Verification
- `nix eval` of `nixosConfigurations.<host>.config.services.hermes-agent` passes for all seven hosts (ashira, nemishi, manash, fushi, nixtar, nalsha, minish).
- `bot_peers` resolves to the six other hosts and self-excludes the current host.
- `sops.secrets` no longer contains the legacy `hermes-agent-api-server-key`; all seven per-host keys are defined.

## Stack
- Part 1: `feat/peer-mesh-secrets` (adds the per-host keys to the secrets file).
- Part 2 (this PR): module wiring + shared-key retirement.

Related: #1193

## Stack dependency
This PR builds on #1194 (secrets). Land #1194 first.

The two PRs cannot be a GitHub fork-stack (base must be `main` for fork PRs), so the ordering is enforced via review, not base chaining.
