### PR TITLE
Serve Syncthing GUI on HTTPS 443 instead of HTTP 80

### DIFF
--- a/modules/nixos/profiles/nishir.nix
+++ b/modules/nixos/profiles/nishir.nix
@@ -87,7 +87,7 @@ with lib;
       RestartSec = "5s";
     };
     script = ''
-      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --http=80 https+insecure://127.0.0.1:443
+      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --https=443 https+insecure://127.0.0.1:443
     '';
   };
 


### PR DESCRIPTION
## What
Syncthing is a tailvip canary: each nishir worker publishes the Syncthing GUI (node-local Traefik `:443`, Host `syncthing.taila659a.ts.net`) under `svc:syncthing` Tailscale Services via the `tailscale-serve-syncthing` oneshot. The oneshot registered `--http=80` against the `:443` backend, so no `:443` HTTPS Web entry existed for the tailvip and `syncthing.taila659a.ts.net` resolved only to the stale serve relay VIP and timed out.

## Why
Chrome/operators hit `https://syncthing.taila659a.ts.net:443`; with only an HTTP 80 handler there was no live endpoint on the tailvip. Fix: register `--https=443` so the GUI is served on the port operators actually use. The cluster path (Gateway `nishir` HTTPRoute `syncthing:8384`, cert `syncthing-tls`) was already healthy — verified locally on `nemishi`: `curl -H "Host: syncthing.taila659a.ts.net" https://127.0.0.1:443/` returns 200, and after the fix `tailscale serve status` shows `syncthing.taila659a.ts.net:443 → https+insecure://127.0.0.1:443`.

## Scope
One-line port change in `modules/nixos/profiles/nishir.nix`. No manifest, secret, or cluster change.

## Residual gate
`svc:syncthing` shows `approval from an admin is required` — this is the intended canary gate, not a defect. Off-node reachability depends on that approval; the config defect is fixed by this PR.

Related: https://github.com/shikanime-labs/machines/issues/1199
