### PR TITLE
Bump identities input to yohra-operator rename

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -422,11 +422,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786204206,
-        "narHash": "sha256-Yq3+CpvQF8vlXTVTNvm++FsFlpd/QGjKFA8pa5c4UJU=",
+        "lastModified": 1787426776,
+        "narHash": "sha256-pgqEnM0yiwTb6AK4VgfuuQ41GJgyOzjQ72PC+4+NXAM=",
         "owner": "shikanime-labs",
         "repo": "identities",
-        "rev": "6bc537ecd165b2c59504fa800450e9a55029fdda",
+        "rev": "5a0c0609d30dd56787f11e374481664c782b1b21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bump the identities flake input to pull in the automata GitHub login rename (yorha-automata → yohra-operator).

Scope: flake.lock only. The pre-existing working-copy AGENTS.md edit in this checkout is a separate change and is intentionally not included.

Acceptance criteria:
- [x] flake.lock identities pinned to shikanime-labs/identities@5a0c0609 (post-rename main)
- [x] commit is SSH-signed and verified on GitHub
- [ ] downstream build verified by CI (required_status_checks ruleset)

Related: https://github.com/shikanime-labs/identities/pull/30