### PR TITLE
Pin nix-containers and migrate app-id to client-id in skaffold workflow

### DIFF
--- a/.github/workflows/skaffold.yaml
+++ b/.github/workflows/skaffold.yaml
@@ -26,7 +26,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OPERATOR_APP_ID }}
+          client-id: ${{ vars.OPERATOR_APP_CLIENT_ID }}
           permission-contents: read
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
       - uses: shikanime-studio/actions/checkout@v9
@@ -83,7 +83,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OPERATOR_APP_ID }}
+          client-id: ${{ vars.OPERATOR_APP_CLIENT_ID }}
           permission-contents: read
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
       - uses: shikanime-studio/actions/checkout@v9
@@ -120,7 +120,7 @@ jobs:
         continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.OPERATOR_APP_ID }}
+          client-id: ${{ vars.OPERATOR_APP_CLIENT_ID }}
           permission-contents: read
           private-key: ${{ secrets.OPERATOR_PRIVATE_KEY }}
       - uses: shikanime-studio/actions/checkout@v9

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,7 +6,7 @@ build:
   artifacts:
     - custom:
         buildCommand:
-          nix run github:shikanime-studio/nix-containers -- skaffold build
+          nix run github:shikanime-studio/nix-containers/29ee036601b500007fb1c30f542a51876536676c -- skaffold build
       image: ghcr.io/shikanime-labs/machines/catbox
   tagPolicy:
     customTemplate:


### PR DESCRIPTION
## What
- Pin the nix-containers invocation in `skaffold.yaml` to a known-good commit instead of tracking upstream `main` unpinned.
- Migrate `actions/create-github-app-token@v3` from the deprecated `app-id` input to `client-id` (`vars.OPERATOR_APP_CLIENT_ID`) across all three jobs in `.github/workflows/skaffold.yaml`.

## Why
- The Skaffold `Build & Render` job failed to push the `catbox` image on `main` (run 31280458585). The image built fine for both platforms; the push failed because nix-containers parsed `docker load` stdout to derive the push ref, and Docker 28 changed that output, yielding an empty ref (`could not parse reference: `). The fleet ran nix-containers unpinned, so it silently tracked upstream `main`.
- Upstream `shikanime-studio/nix-containers@29ee036` removes the docker-load/ref-parse path entirely (pushes the nix tarball directly), which is why a re-run on `main` (32611656225) is green. Pinning freezes that known-good behavior so a future upstream regression cannot silently break the fleet again.
- `create-github-app-token@v3` deprecated `app-id` in favor of `client-id`; it still works with `continue-on-error: true` today but hard-fails on v4. The replacement variable `OPERATOR_APP_CLIENT_ID` already exists in repo settings.

## References
- Upstream fix: https://github.com/shikanime-studio/nix-containers/commit/29ee036601b500007fb1c30f542a51876536676c
- Failing run: https://github.com/shikanime-labs/machines/actions/runs/31280458585
- Verification run: https://github.com/shikanime-labs/machines/actions/runs/32611656225

Related: https://github.com/shikanime-labs/machines/issues/1203
