### PR TITLE
Reconfigure Hermes Matrix home to #automata room

### DIFF
--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -316,7 +316,7 @@ in
           }
         ];
         matrix = {
-          allowed_rooms = [ "!QUaAaCBlSIBcYyOyLb:matrix.taila659a.ts.net" ];
+          allowed_rooms = [ "#automata:matrix.taila659a.ts.net" ];
           allowed_users = [
             "@admin:matrix.taila659a.ts.net"
             "@shikanime:matrix.taila659a.ts.net"
@@ -526,7 +526,7 @@ in
           MATRIX_HOMESERVER=https://matrix.taila659a.ts.net/
           MATRIX_ACCESS_TOKEN=${config.sops.placeholder.hermes-agent-matrix-access-token}
           MATRIX_E2EE_MODE=required
-          MATRIX_HOME_ROOM=!QUaAaCBlSIBcYyOyLb:matrix.taila659a.ts.net
+          MATRIX_HOME_ROOM=#automata:matrix.taila659a.ts.net
           MATRIX_RECOVERY_KEY_FILE=${config.sops.secrets.hermes-agent-matrix-recovery-key.path}
         '';
         restartUnits = [ "hermes-agent.service" ];


### PR DESCRIPTION
## What
Repoint the gateway Hermes Matrix home and allowed room from the legacy internal room ID `!QUaAaCBlSIBcYyOyLb:matrix.taila659a.ts.net` to the shared channel alias `#automata:matrix.taila659a.ts.net`, in `modules/nixos/profiles/ai.nix` only (both `matrix.allowed_rooms` and the `MATRIX_HOME_ROOM` sops env template).

## Why
Single shared `#automata` home channel across the fleet, replacing the prior per-room internal ID. Local `~/.hermes/.env` and darwin configs are intentionally untouched.

## References
Module change is self-contained; validated against gateway alias form (`#` prefix required for Matrix room aliases).