### PR TITLE
Enable EFI boot variables for catbox containerDisk

### DIFF
--- a/hosts/catbox/configuration.nix
+++ b/hosts/catbox/configuration.nix
@@ -12,6 +12,10 @@
     ../../modules/nixos/users/automata.nix
   ];
 
+  # Fresh OVMF NVRAM each boot: write the systemd-boot entry as a real EFI
+  # Boot variable instead of relying on fallback-path detection.
+  boot.loader.efi.canTouchEfiVariables = true;
+
   containerdisk = {
     name = "ghcr.io/shikanime-labs/machines/catbox";
     settings.LABELS = {


### PR DESCRIPTION
## What
Set `boot.loader.efi.canTouchEfiVariables = true` in `hosts/catbox/configuration.nix` so the catbox containerDisk image registers systemd-boot as a persisted EFI Boot variable.

## Why
The catbox image already builds systemd-boot into an ESP (`image.efiSupport` defaults true, `boot.loader.systemd-boot.enable` resolves true, grub disabled). On KubeVirt with q35/OVMF and a fresh NVRAM each boot, the default `canTouchEfiVariables=false` left boot-entry persistence dependent on firmware fallback-path detection, which looped at the EDK2 boot manager. Aligning catbox with the repo's hardware-host pattern (beelink-eq sets the same option) makes the entry stick.

## References

The change mirrors the working hardware modules, e.g. `modules/nixos/hardware/beelink-eq.nix`.

Related: https://github.com/shikanime-labs/machines/issues/1207