### PR TITLE
Add Hermes Agent CLI + declarative config to Home Manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -358,6 +358,7 @@
         "flake-parts": [
           "flake-parts"
         ],
+        "home-manager": "home-manager",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -367,11 +368,11 @@
         "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1785834290,
-        "narHash": "sha256-EZvO85PFZHngMlSUQjSMuT0j29wsGelku9zI8LSWBvc=",
+        "lastModified": 1787492217,
+        "narHash": "sha256-sRxPAHNr8MNMjpbqTSugDbA5NMMf5H2duHEBk0die/I=",
         "owner": "NousResearch",
         "repo": "hermes-agent",
-        "rev": "e05eba26a3af1313d304799ffb85a11b8c2b0988",
+        "rev": "f293e7206b4ddd66042329442c6afebc19a8808d",
         "type": "github"
       },
       "original": {
@@ -381,6 +382,27 @@
       }
     },
     "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "hermes-agent",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786487128,
+        "narHash": "sha256-ad60hrRVhH/bo3Jl1YLzO+QcS3mUNZr9LNJdzhMO2P4=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "f404edbfa4117810c96b97048299242fc50e5362",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -747,7 +769,7 @@
         "flake-parts": "flake-parts",
         "git-hooks": "git-hooks",
         "hermes-agent": "hermes-agent",
-        "home-manager": "home-manager",
+        "home-manager": "home-manager_2",
         "identities": "identities",
         "knix": "knix",
         "nix-darwin": "nix-darwin",

--- a/flake.nix
+++ b/flake.nix
@@ -168,6 +168,7 @@
       {
         imports = [
           ./modules/flake/devenv.nix
+          ./modules/flake/packages.nix
           devenv.flakeModule
           devlib.flakeModule
           darwinFlakeModule

--- a/modules/flake/darwin.nix
+++ b/modules/flake/darwin.nix
@@ -18,6 +18,7 @@
             inputs.catppuccin.homeModules.default
             inputs.colemak.homeModules.default
             inputs.devlib.homeModules.default
+            inputs.hermes-agent.homeManagerModules.default
             inputs.identities.homeModules.default
             inputs.sops-nix.homeModules.default
           ];

--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -11,6 +11,7 @@ let
       home-manager.sharedModules = [
         inputs.catppuccin.homeModules.default
         inputs.colemak.homeModules.default
+        inputs.hermes-agent.homeManagerModules.default
         inputs.sops-nix.homeModules.default
       ];
     }

--- a/modules/flake/packages.nix
+++ b/modules/flake/packages.nix
@@ -1,0 +1,8 @@
+{
+  perSystem = { pkgs, ... }: {
+    packages = {
+      hermes-plugin-lcm = import ../../pkgs/hermes-plugin-lcm { inherit pkgs; };
+      hermes-plugin-rtk-rewrite = import ../../pkgs/hermes-plugin-rtk-rewrite { inherit pkgs; };
+    };
+  };
+}

--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -18,6 +18,9 @@ let
     User = user;
     SetEnv.TERM = "xterm-256color";
   };
+
+  hermesLcmPlugin = import ../../pkgs/hermes-plugin-lcm { inherit pkgs; };
+  rtkRewritePlugin = import ../../pkgs/hermes-plugin-rtk-rewrite { inherit pkgs; };
 in
 {
   catppuccin = {
@@ -61,6 +64,8 @@ in
 
     gpg.enable = true;
 
+    hermes-agent.enable = true;
+
     jujutsu.settings."merge-tools".mergiraf."merge-tool-edits-conflict-markers" = true;
 
     mergiraf = {
@@ -100,6 +105,194 @@ in
     };
 
     zoxide.enable = true;
+  };
+
+  # Hermes Agent — declarative config ported from modules/nixos/profiles/ai.nix,
+  # minus the fleet/gateway/automation surface (matrix, a2a, bot_peers,
+  # platforms, platform_toolsets, honcho memory, sops environmentFiles).
+  # backend.mode defaults to "none" and gateway.enable defaults to false, so
+  # enabling the service writes config.yaml without launching any daemon.
+  services.hermes-agent = {
+    enable = true;
+
+    extraPlugins = [
+      hermesLcmPlugin
+      rtkRewritePlugin
+    ];
+
+    extraPackages = with pkgs; [
+      agent-browser
+      curl
+      corepack
+      gh
+      git
+      nodejs
+      rtk
+      yarn
+    ];
+
+    extraDependencyGroups = [
+      "anthropic"
+      "computer-use"
+    ];
+
+    settings = {
+      context.engine = "lcm";
+
+      custom_providers = [
+        {
+          name = "aperture-anthropic";
+          base_url = "https://ai.taila659a.ts.net/v1";
+          api_mode = "anthropic_messages";
+          model = "glm-4.7";
+          models = [
+            "glm-4.7"
+            "glm-5.2"
+          ];
+        }
+        {
+          name = "aperture-openai";
+          base_url = "https://ai.taila659a.ts.net/v1";
+          api_mode = "chat_completions";
+          model = "tencent/hy3:free";
+          models = [
+            "deepseek/deepseek-v4-flash"
+            "gemini-2.5-flash"
+            "gemini-2.5-flash-lite"
+            "gemini-2.5-pro"
+            "gemini-3-flash-preview"
+            "google/gemma-4-e2b"
+            "inclusionai/ling-3.0-flash:free"
+            "labs-leanstral-1-5"
+            "nvidia/nemotron-3-ultra-550b-a55b:free"
+            "openrouter/openrouter/free"
+            "poolside/laguna-xs-2.1:free"
+            "qwen/qwen3-8b"
+            "stepfun/step-3.7-flash:free"
+            "tencent/hy3:free"
+          ];
+        }
+      ];
+
+      fallback_providers = [
+        {
+          api_mode = "chat_completions";
+          model = "inclusionai/ling-3.0-flash:free";
+          provider = "custom:aperture-openai";
+        }
+        {
+          api_mode = "chat_completions";
+          model = "poolside/laguna-s-2.1:free";
+          provider = "custom:aperture-openai";
+        }
+        {
+          api_mode = "chat_completions";
+          model = "labs-leanstral-1-5";
+          provider = "custom:aperture-openai";
+        }
+        {
+          api_mode = "chat_completions";
+          model = "stepfun/step-3.7-flash:free";
+          provider = "custom:aperture-openai";
+        }
+        {
+          api_mode = "chat_completions";
+          model = "tencent/hy3:free";
+          provider = "custom:aperture-openai";
+        }
+      ];
+
+      model = {
+        default = "tencent/hy3:free";
+        provider = "custom:aperture-openai";
+        base_url = "https://ai.taila659a.ts.net/v1";
+      };
+
+      auxiliary = {
+        vision = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        web_extract = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        compression = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        skills_hub = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        approval = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        mcp = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        title_generation = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        memory_query_rewrite = {
+          provider = "custom:aperture-anthropic:openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        tts_audio_tags = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        triage_specifier = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        kanban_decomposer = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        profile_describer = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+        curator = {
+          provider = "custom:aperture-openai";
+          model = "tencent/hy3:free";
+          base_url = "https://ai.taila659a.ts.net/v1";
+        };
+      };
+
+      mcp_servers.aperture = {
+        url = "https://ai.taila659a.ts.net/v1/mcp";
+        enabled = true;
+      };
+
+      display = {
+        interface = "tui";
+        streaming = true;
+      };
+
+      plugins.enabled = [
+        "disk-cleanup"
+        "hermes-lcm"
+        "rtk-rewrite"
+        "security-guidance"
+      ];
+    };
   };
 
   xdg.enable = true;

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -148,40 +148,8 @@ let
       ) peers
     );
 
-  # Hermes scans each extraPlugins entry for plugin.yaml at the derivation
-  # root, so wrap the source in symlinkJoin rather than passing it bare.
-  hermesLcmPlugin = pkgs.symlinkJoin {
-    name = "hermes-lcm";
-    paths =
-      let
-        lcm = pkgs.fetchFromGitHub {
-          owner = "stephenschoettler";
-          repo = "hermes-lcm";
-          rev = "v0.18.1";
-          hash = "sha256-+1661BVi2XmqIaPYzNuUtrEfKvK9xQ8B4zedclIYuYA=";
-        };
-      in
-      [
-        "${lcm}/."
-      ];
-  };
-
-  # rtk ships the hook nested under hooks/hermes/, so join that subdirectory.
-  rtkRewritePlugin = pkgs.symlinkJoin {
-    name = "rtk-rewrite";
-    paths =
-      let
-        rtk = pkgs.fetchFromGitHub {
-          owner = "rtk-ai";
-          repo = "rtk";
-          rev = "v0.44.0";
-          hash = "sha256-Ev6w0Gi2y48DYi55GSciCoPgkUFaX44aH3UWGhs1OGk=";
-        };
-      in
-      [
-        "${rtk}/hooks/hermes/rtk-rewrite"
-      ];
-  };
+  hermesLcmPlugin = import ../../../pkgs/hermes-plugin-lcm { inherit pkgs; };
+  rtkRewritePlugin = import ../../../pkgs/hermes-plugin-rtk-rewrite { inherit pkgs; };
 
   # Generate sops secret entries for all peer tokens.
   mkA2aTokenSecrets =

--- a/pkgs/hermes-plugin-lcm/default.nix
+++ b/pkgs/hermes-plugin-lcm/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+pkgs.symlinkJoin {
+  name = "hermes-lcm";
+  paths = [
+    "${
+      pkgs.fetchFromGitHub {
+        owner = "stephenschoettler";
+        repo = "hermes-lcm";
+        rev = "v0.18.1";
+        hash = "sha256-+1661BVi2XmqIaPYzNuUtrEfKvK9xQ8B4zedclIYuYA=";
+      }
+    }/."
+  ];
+}

--- a/pkgs/hermes-plugin-rtk-rewrite/default.nix
+++ b/pkgs/hermes-plugin-rtk-rewrite/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+pkgs.symlinkJoin {
+  name = "rtk-rewrite";
+  paths = [
+    "${
+      pkgs.fetchFromGitHub {
+        owner = "rtk-ai";
+        repo = "rtk";
+        rev = "v0.44.0";
+        hash = "sha256-Ev6w0Gi2y48DYi55GSciCoPgkUFaX44aH3UWGhs1OGk=";
+      }
+    }/hooks/hermes/rtk-rewrite"
+  ];
+}


### PR DESCRIPTION
## Summary
- Wire `hermes-agent.homeManagerModules.default` into both flake entrypoints (`modules/flake/nixos.nix`, `modules/flake/darwin.nix`).
- Bump `hermes-agent` flake input to `f293e720` (the rev that adds the Home Manager module).
- Enable `programs.hermes-agent.enable = true` in `modules/home/workstation.nix` → every HM user gets the hermes CLI.
- Port the declarative Hermes config from `modules/nixos/profiles/ai.nix` into `services.hermes-agent.settings` (providers, fallback providers, model, auxiliaries, mcp_servers, display, plugins), plus the agent tool packages.

## Plugin derivations
`hermes-lcm` and `rtk-rewrite` plugin derivations now live in `pkgs/hermes-plugin-*/default.nix` and are imported by both the fleet profile (`modules/nixos/profiles/ai.nix`) and the HM module (`modules/home/workstation.nix`) — single source of truth.

## Scope
Per-user tool only. `services.hermes-agent.backend.mode` defaults to `"none"` and `gateway.enable` defaults to `false`, so this writes `~/.hermes/config.yaml` **without launching any daemon** (verified: no systemd user units on nixtar, no launchd agents on telsha).

Intentionally omitted (the fleet/gateway/automation surface that is non-portable to a single-user HM install and references `config.networking.hostName` / `config.sops` which don't exist in this module):
- matrix, a2a, bot_peers, platforms, platform_toolsets
- honcho memory + honcho.json document
- sops `environmentFiles` (the `*.taila659a.ts.net` env templates)

## Test plan
- `nix eval .#nixosConfigurations.nixtar.config.home-manager.users.shika.services.hermes-agent.settings.model.default` → `tencent/hy3:free`
- backend.mode = `none`, gateway.enable = `false`, zero hermes systemd user units.
- `extraPlugins` resolve to `[hermes-lcm rtk-rewrite]` from the shared `pkgs/` derivations.
- `nix eval .#darwinConfigurations.telsha.config.home-manager.users.shikanimedeva.services.hermes-agent.backend.mode` → `none`; no hermes launchd agents.
- Resolved config.yaml is valid JSON containing the full ported key set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)