### PR TITLE
Add serial console to catbox containerDisk

### DIFF
--- a/modules/nixos/virtualisation/containerdisk.nix
+++ b/modules/nixos/virtualisation/containerdisk.nix
@@ -30,6 +30,10 @@ in
   };
 
   # Reference: https://github.com/kubevirt/kubevirt/blob/main/docs/container-register-disks.md
+  # KubeVirt q35 exposes the guest console on ttyS0; without it the kernel
+  # sends output to invisible VGA and panic=1 reboots silently.
+  config.boot.kernelParams = [ "console=ttyS0" ];
+
   config.system.build.containerdiskImage = pkgs.dockerTools.buildImage {
     inherit (cfg) name;
 


### PR DESCRIPTION
The KubeVirt q35 guest exposes its console on ttyS0. Without
`console=ttyS0` the kernel binds to the invisible VGA console, so a
`panic=1` early-boot failure reboots silently and the VM loops at the
EDK2/systemd-boot menu with no kernel output on the serial console.

Prior #1208 (`canTouchEfiVariables=true`) is confirmed present in the
running image but did not fix the loop — the guest still never prints a
single kernel line, which is itself the tell: output was going to VGA.

Apply `console=ttyS0` in the shared `containerdisk.nix` module so every
containerDisk host inherits it, not just catbox.

Related: #1207