### PR TITLE
Fix nixtar buildEnv corepack collision

### DIFF
--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -195,7 +195,6 @@ in
       extraPackages = with pkgs; [
         agent-browser
         curl
-        corepack
         gh
         git
         honcho


### PR DESCRIPTION
## What
Drop the redundant standalone `corepack` from `hermes-agent` `extraPackages` in `modules/nixos/profiles/ai.nix`.

## Why
`nodejs` already ships `/bin/corepack`. Listing both the standalone `corepack` package and `nodejs` put two `/bin/corepack` paths into the home-manager `buildEnv`, which failed with:

```
pkgs.buildEnv error: two given paths contain a conflicting subpath:
  /nix/store/...-corepack-0.35.0/bin/corepack and
  /nix/store/...-nodejs-24.18.0/bin/corepack
```

This broke the `nix / Packages (catbox)` job and the `nixtar` image build on default branch.

## Scope
Single-line removal. No other package or workflow touched.

🤖 Generated with [Hermes](https://hermes-agent.nousresearch.com)