### PR TITLE
Fix home-manager buildEnv corepack collision (catbox/nixtar)

### DIFF
--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -123,7 +123,6 @@ in
     extraPackages = with pkgs; [
       agent-browser
       curl
-      corepack
       gh
       git
       nodejs

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -195,7 +195,6 @@ in
       extraPackages = with pkgs; [
         agent-browser
         curl
-        corepack
         gh
         git
         honcho


### PR DESCRIPTION
## Problem

The Release run for `main` went red across all three `Packages` legs
(catbox x86_64, catbox aarch64, nixtar x86_64) with:

  pkgs.buildEnv error: two given paths contain a conflicting subpath:
    /nix/store/...-corepack-0.35.0/bin/corepack and
    /nix/store/...-nodejs-24.18.0/bin/corepack

nodejs-24.18.0 already ships /bin/corepack, so adding the standalone
corepack package alongside nodejs in services.hermes-agent.extraPackages
produced two different versions of the same path in the home-manager
buildEnv, breaking the disk-image -> containerdisk -> docker publish chain.

## Fix

Remove the redundant standalone corepack from:
- modules/home/workstation.nix (catbox/automata hermes-agent extraPackages)
- modules/nixos/profiles/ai.nix (nixtar/fleet hermes-agent extraPackages)

nodejs provides corepack.

## Verification

- CI Packages legs for catbox + nixtar must build green.
- Re-dispatch Release to republish catbox:latest with a new digest.
- Downstream: delete VMI catbox on nishir, confirm kernel reaches multi-user on serial, sshd answers on catbox.taila659a.ts.net:22 (issue #1207).

Related: #1207