### PR TITLE
Add virtio initrd modules to containerDisk module

### DIFF
--- a/modules/nixos/virtualisation/containerdisk.nix
+++ b/modules/nixos/virtualisation/containerdisk.nix
@@ -34,6 +34,13 @@ in
   # sends output to invisible VGA and panic=1 reboots silently.
   config.boot.kernelParams = [ "console=ttyS0" ];
 
+  # KubeVirt exposes containerDisks as virtio (/dev/vda); without these the
+  # initrd cannot see the root disk and boot times out into a panic=1 loop.
+  config.boot.initrd.availableKernelModules = [
+    "virtio_pci"
+    "virtio_blk"
+  ];
+
   config.system.build.containerdiskImage = pkgs.dockerTools.buildImage {
     inherit (cfg) name;
 


### PR DESCRIPTION
## What

Adds `virtio_pci` and `virtio_blk` to `boot.initrd.availableKernelModules` in the
containerDisk module so every KubeVirt containerdisk boots on the virtio bus.

## Why

KubeVirt exposes containerDisks as virtio (`/dev/vda`). The catbox configuration
ships no `hardware-configuration.nix`, so its initrd had zero virtio modules:
OVMF firmware read the ESP fine, but the Linux initrd could not see the root disk
and boot timed out into a panic=1 loop. Boot was only recovered by switching the
VM disks to SATA as a stopgap. Fixing it in the shared module covers every
containerdisk consumer.

Verified via `nix eval .#nixosConfigurations.catbox.config.boot.initrd.availableKernelModules` — both modules present.

## References

Related: https://github.com/shikanime-labs/machines/issues/1207