### PR TITLE
Install the qmd optional skill declaratively on fleet Hermes agents

### DIFF
--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -183,6 +183,15 @@ let
       ];
   };
 
+  # Optional skills ship inside the hermes-agent package (share/hermes-agent/
+  # optional-skills) but are not active until installed, and `hermes skills
+  # install` is imperative. Expose just this one through skills.external_dirs,
+  # which the skill scanner reads as <dir>/<skill>/SKILL.md.
+  qmdSkill = pkgs.runCommand "hermes-skill-qmd" { } ''
+    mkdir -p $out
+    ln -s ${config.services.hermes-agent.package}/share/hermes-agent/optional-skills/research/qmd $out/qmd
+  '';
+
   # Generate sops secret entries for all peer tokens.
   mkA2aTokenSecrets =
     peers:
@@ -233,6 +242,7 @@ in
         honcho
         nodejs
         rtk
+        sqlite
         yarn
       ];
       extraPlugins = [
@@ -442,6 +452,10 @@ in
           "rtk-rewrite"
           "security-guidance"
         ];
+        # Optional skills are opt-in and normally installed imperatively.
+        # external_dirs keeps the install declarative — qmd needs nodejs >= 22
+        # and sqlite with extension support, both in extraPackages.
+        skills.external_dirs = [ "${qmdSkill}" ];
       };
       extraDependencyGroups = [
         "anthropic"


### PR DESCRIPTION
Install the `qmd` optional skill declaratively on every host importing
`modules/nixos/profiles/ai.nix`, so fleet agents get hybrid local search
(BM25 + vector + LLM reranking) over notes, docs, and transcripts.

Optional skills ship inside the `hermes-agent` package under
`share/hermes-agent/optional-skills` but stay inactive until installed, and the
documented install path (`hermes skills install official/research/qmd`) is
imperative — it drifts across `nixos-rebuild switch` and does not hold fleet-wide.
The module at the pinned input rev exposes no declarative skills option, so this
wires the skill through `settings.skills.external_dirs`, which the skill scanner
reads as `<dir>/<skill>/SKILL.md` (it walks with `followlinks=True`, so the
store symlink resolves).

The skill is symlinked out of the pinned package rather than vendored or fetched
separately, so it stays in lockstep with the `hermes-agent` input.

`sqlite` joins `extraPackages` for the extension-loading requirement; `nodejs`
(24.18.0 in the pinned nixpkgs, >= 22 as required) was already present.

Verification: `nixfmt-rfc-style --check` clean, and
`nixosConfigurations.manash.config.system.build.toplevel` builds on an x86_64
fleet builder (this change cannot be built on the x86_64-darwin workstation —
the Linux Python/npm derivations are a pre-existing platform mismatch on `main`
too).

Related: https://github.com/shikanime-labs/machines/issues/1214
