### PR TITLE
feat: provision sashina & kushira secrets

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -32,7 +32,8 @@ GPU/ROCm acceleration lives entirely in
 
 - `hardware.enableRedistributableFirmware = true` — Radeon 8060S (gfx1151)
   microcode so the compute stack reaches `/dev/dri/renderD128`.
-- `hardware.graphics.enable = true` + `enable32Bit` (inherited from nixos-hardware `common-gpu-amd`) — Mesa/ROCm userspace.
+- `hardware.graphics.enable = true` + `enable32Bit` (inherited from
+  nixos-hardware `common-gpu-amd`) — Mesa/ROCm userspace.
 - `boot.kernelParams = [ "amdgpu.gttsize=98304" "ttm.pages_limit=25165824" ]` —
   96 GiB GTT carve-out for the unified-memory iGPU.
 

--- a/hosts/kushira/configuration.nix
+++ b/hosts/kushira/configuration.nix
@@ -85,7 +85,7 @@
   };
 
   sops = {
-    defaultSopsFile = ../../secrets/nishir.enc.yaml;
+    defaultSopsFile = ../../secrets/kushira.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets = {
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;

--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -85,7 +85,7 @@
   };
 
   sops = {
-    defaultSopsFile = ../../secrets/nishir.enc.yaml;
+    defaultSopsFile = ../../secrets/sashina.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets = {
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;

--- a/secrets/kushira.enc.yaml
+++ b/secrets/kushira.enc.yaml
@@ -1,0 +1,45 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:d4B+CqOkEy2fcLea1gK/9zdfnIWubXAVklcMgGEf6enPgjbb19vb3P5rvX/Y,iv:hhD86Rf1S7JttvO39xR/4/uP982aFe8lpYfOePm1EGE=,tag:3dcM9WuVqCAvqnTuGbNk2g==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:k42N9MukFOuYklZlgKtkrEHrwgbhaCFIR6qmhAHA+G2Xl1Mo3nCtvYZwlTDa,iv:8puLqi9MTghuVfFMiZu+nUD30ZoDdDjwiosIiiRHO5c=,tag:JUdxqHbNkKuYDExUXwfMaQ==,type:str]
+sops:
+  version: 3.13.3
+  lastmodified: "2026-08-25T12:59:46Z"
+  mac: ENC[AES256_GCM,data:V5dTXUNg2bhmjmscYqgWkM4SR7z1sbpRlQCWcxrqX3OAKHlDJ2a0tRqGakxF+N1PAvtMz9bmL++WJKVQH8qTsYVstyPYwiacMoo6cuVZzxi16O2f3uJ1TU7Q4ZmHAmDq5gOmYiVq3NiS0i58di2Uhqyr3iq4ohwnlzvLEjK+ZMQ=,iv:voPkGkyWF0WL5+OzXUn/GLh4zcJRtV3e2EzmxAsaVXM=,tag:qXp2+B65BikFQANYsFQG5A==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBhWmVIOFh2UmhJRDlyV0dt
+        REE0NUVQc25sNnVJNEFyd0Fza1M0MjE0blFRCkR1clFFSytaMm1HenJRaFM5SzNC
+        ZVhzUHlHRStkekJPaUprNk5oVE1VTHcKLS0tIE1GZCtCTWtWRWJXYS94MjdDT2Yw
+        N2phNmtEVk5rWDE4UG84QitNQjBsNXcKeXnEd4VWVHb8U6Sc5C1+SfSBXUgor0G4
+        mh7DabTcSNGq4PnRthkegf6Kc13pGk/zAk0+GMtrMfvjagA1SeYNfA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxQUFtT25qR3lUMDMxOWoz
+        Y3VLNFlMb21LMXVDWVl4d0I2ZEI3a0VMUlRVCi9iRDh0dHk1UGxNZUVPazBoTEY1
+        OVJuZkVDZXhsZUZmQkVDODRwYno1MnMKLS0tIG0zUVFhL0R2cDEweWxlYmlmQ1Iw
+        aks4VVBlcW1Rc1VqcWVTeUUyRlpEWnMKxUDqhZGO6KROBmeSCZK2K0xqKF06SdsK
+        2aQDMzb5T4k1nQ/nMqZTv+1M1gHZwLqT7bJQRHCpAsq8wXYNIAsk5Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBSVUI1dndzU3RIM21odDlU
+        RnV5ZnJSMERaRVRGbTc5OENPSldxQ2dab3hzCjB4UXBxT3U2ZXlCbEY5RkVKMGhn
+        aXUwdm8wRlVtMTUrYXpRZ1B6bE5WTzQKLS0tIEo5T0RnaUw5RUxHbndqS1lCbnBU
+        QnJ3STNEc2JLV2Fya1E0WmRXbVQ1dzgKusEMKtZIqfgdjHKtC9WYgcyA3twZ8/qU
+        Lbw0CZzZJRj52JJV5E1saZtt6g6zqVi9K9y3ffjqDti0djaj0UrSbQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwV0F4T2o4RzVpdXRLMm81
+        NkxWUHRtb0NlQzkzdFlhYWh4UkxEd3RseEc0CkIrK1BvTHA5NWhFY04xRXpLbEc2
+        Z3VUUDZHaitNbEtYcTY4K044WVUxRXcKLS0tIEsreS9NY2xSZUw1cWlETUVKYloy
+        aUpkS1RYUklwV2dZUGpabXpCb1g5djAKTxLk98YHpOu3q6FLLvBYwrewrHOk23S4
+        ZK1ZS0zPs1jOGQyNPzOHWKkrxBdkQR6WNZ/6UnoEgy/QTw45DkMbbw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+tailscale-authkey: ENC[AES256_GCM,data:Btg2yl8z4DSZ96VH1a8J9PeFobR9pWKMrJO+J1VMPa7fAFo/cQuPWip6HAQ=,iv:qpuyoypCBlrXPPXoKVAD9XUotcHI2lhARd6mbVPjszs=,tag:AipJrdBGp/RRzWORiFTjag==,type:str]

--- a/secrets/machine.enc.yaml
+++ b/secrets/machine.enc.yaml
@@ -1,22 +1,26 @@
 hermes-agent-a2a-token-ashira: ENC[AES256_GCM,data:QvcLohFuI9KQ+PuIcZ3bfiRSLxN7jiAf09vcKp/bJQnKmirqmp1DV7Chg31AJrhR6fmv8XiwaVm3wFcWaHe4DQ==,iv:owh13fZC1wDZQ+T+MB2CS8kcqE08HDS6BayCulNxk3E=,tag:no7chacFnt5zY3ZWeD4OnA==,type:str]
 hermes-agent-a2a-token-fushi: ENC[AES256_GCM,data:EA9OFaNseFTZKVMWrPFuPzz+momBqP1P+Tydx36UrRaany4zRNXnBUAkp4rKBE/QJL7Z7shvKB8GOBSy6yxoOw==,iv:5O1r8bA4Le0FgQHyFx8zuxExuTQXDBILXlwJf4smbh0=,tag:VIw/XBbhNsRnTogXko65DQ==,type:str]
+hermes-agent-a2a-token-kushira: ENC[AES256_GCM,data:RDs++ihC5rE2PQVoqPU/u1yf87LHkeppXGxVvrtWCsuCQ8aTHLPU6HtP+EEIrGOPsC4MJEHO21t3Ayb9rvXCgw==,iv:V4zeURmM8TS38JlL6R40zQYvZsTJSIVOUKNiQHn9SmU=,tag:U9/m3Cpwin3K7eTphuUNZQ==,type:str]
 hermes-agent-a2a-token-manash: ENC[AES256_GCM,data:bYfmIWPG4cMhQlWLfVW+YL/wuwzEhmEMVvKlMfnVcFDic+SD+l2d4zavSkwaqoOVoqfG/zDYks3I4tALQdvnzQ==,iv:N0Q4Pxb7nFDOSE1Lg3cFhb/M7bPqRzZ1mfUjpHvGCnQ=,tag:kCdd2UMGcy6mab0iEdXmzw==,type:str]
 hermes-agent-a2a-token-minish: ENC[AES256_GCM,data:EMsQp6jRGUY+/zFjXMxCGz04i2p2bW1RQcgt4MQNPsUrCE/ICOT56GGbgEJxVnzSRpdoGLe30VxJZuf/yTFyhQ==,iv:dGfhw5OvYmon4lgTohi56pdgLW7ntvAtDDxdzYY/EUE=,tag:8PgRQCXXWfBBSPbLnYh7iA==,type:str]
 hermes-agent-a2a-token-nalsha: ENC[AES256_GCM,data:D47/YK/DivTEuH2Li+omHLUQlssXm4ArG9YTYDiePuFcSRfRBmpoLRx1zB9vGpdpmHAsnmpze1mYcxSwARia5Q==,iv:if4qGmre5seDrkWjs1pocMluq7eR6fRGgWdjvCmYoJE=,tag:o7CIcfb+i+AxtpQXhf9YVQ==,type:str]
 hermes-agent-a2a-token-nemishi: ENC[AES256_GCM,data:NkWYlkNjWa4dlfVLqBq5r5y9YLotLP2tAUu3bB210BvLPGkB+5gPdfpJYh75dFxLNB7y6SR78meXX5FSeMHq5Q==,iv:FhwIs46EW8xMF7aacQzbBU9M7FY3WP8/99d7tOjsGdA=,tag:Na+3Llv3HmA1meqaJ5p/zg==,type:str]
 hermes-agent-a2a-token-nixtar: ENC[AES256_GCM,data:c9XiJGNZlp0nLVMeV/DVa0a6QzbzOim1to7L0VdMueIX0bEG8QK+lyy2jgMw0aqNr1pUpdHVxECSsFORuORUyg==,iv:8keD6ZFh9tSPtN1WBSUWAOvYaTArQVc6kGEHew1Kut4=,tag:Ak8EWfbw+QPxf7lG83hMCA==,type:str]
+hermes-agent-a2a-token-sashina: ENC[AES256_GCM,data:7lVkGkhLFw4z7A44RTJllVTkc0FwcDrg/obMz7l/Lqzwu94roPC5Bxk3Q2w2wdEx0TVK45jF4fSzTHWXiYnP8A==,iv:NFNdzmxzovXjxDc9IETQ25uJJtQe7FBxTtsBv+mIdJc=,tag:Y9BUs+0bBXPo69pA8JoJog==,type:str]
 hermes-agent-api-server-key-ashira: ENC[AES256_GCM,data:lAJMRqH3fPhGJMkIxGBN+WwyFrGZK2DS4l5HGW5HaaH/qZ88F0RyexX58G0Rzmg2,iv:mb/63r2ChLiKAxUWBvIbl7BGb4fql3hfoPSK7g1rPgs=,tag:vDGyfaRTopJHWn2CbRdzzA==,type:str]
 hermes-agent-api-server-key-fushi: ENC[AES256_GCM,data:vXgmR7wjh+uLwCUIAHeVxE/SYoCw6P2Zn77MTphcj/oXd0Osl8XYaGbBo+7zDtc=,iv:AxZ+beakugvWpDrBfFiDVHyctoHbru+7rBO+XbUlO6E=,tag:EJoTF8R8zPZPdIfYkCVMtQ==,type:str]
+hermes-agent-api-server-key-kushira: ENC[AES256_GCM,data:ogbZCnh6+TFqOVmcktDzX6QREEHSTQ==,iv:e0M+4sMr6WYNHw8RCnLH2pOStDk6aCC0o1Tcw275c7U=,tag:JhxpzGCzHh2irvP5UTt8YQ==,type:str]
 hermes-agent-api-server-key-manash: ENC[AES256_GCM,data:1E0gqZZ0DG3z+50A//SWjiNx6pkUgN3sAY9uUnOqBw4ZI832o/r+dSkaZpiuyA==,iv:4rAoEdxCSH0/9C1B9f2ihr/hYodhMrCRd3iCMoFttak=,tag:Usznj3y1ybJ3rG9Dj1Tzpg==,type:str]
 hermes-agent-api-server-key-minish: ENC[AES256_GCM,data:MbNKt2I9/CYC7K0qbRTw17wBUFPmmFAeLHubjt3s/Limh+o4OXTIdVJlQILbkA==,iv:Tas8kDmmI6W7hwvly0uRNvQB5hOa4ogp1oy6ukRei6g=,tag:nR37jj58H7UAgC/VNDs5zg==,type:str]
 hermes-agent-api-server-key-nalsha: ENC[AES256_GCM,data:3dz0KqqCWC446/qPIaJ41XKMTsh+dp26+UiTCGM9PXf3FmowEqWXdThOhAR6aQ8=,iv:dHK4gWPYHhBESqbgNpyUqIjBted8Z6n/9g8Mw0lzEd4=,tag:65GSKse0wYpmPu5TfKOyvA==,type:str]
 hermes-agent-api-server-key-nemishi: ENC[AES256_GCM,data:V2Spnje4593nOTkdf3+QA7Ku+jzFO4rywIACFNUeRJndR/41wAqfzm0qEYRoPg==,iv:sRu9pWOujPcsP4JYTjmKQbxi5tGJt/5Gd8A0oDIVYjQ=,tag:shcVHaW9HMiQfE6lbgQ4VA==,type:str]
 hermes-agent-api-server-key-nixtar: ENC[AES256_GCM,data:zlfMTrZKmrFZjiHktixCYUs8jLXRESfVYhZGZD/LzQ5tvNLe8NkihYEpgafB,iv:HqGjxKIqsM/bP71poQtNi6GtXgoWY1RiG4jPybaM6kA=,tag:+Z+EhTXGH+Slnz3WaDqP+w==,type:str]
+hermes-agent-api-server-key-sashina: ENC[AES256_GCM,data:h4WWDvUoiUbEGS7R4CyGlLUeEzYksg==,iv:4Hm2QMoDSlJYgFwtRaCxukE57LXLMK6oPp57rfLt5lU=,tag:vBVGB6tQikvAdv/oROez9g==,type:str]
 nix-access-token: ENC[AES256_GCM,data:lXMTYSDngdYn0BV5HVXFuhvgoYs97jR4AyMImwQ31J2B5khSE09+LA==,iv:iwNIOjtco+T4I/ttSlDLVG1Lah4ovXmL+GQ6D/FwNds=,tag:W7sw1taypyCir+ucOatGng==,type:str]
 sops:
   version: 3.13.3
-  lastmodified: "2026-08-23T15:39:47Z"
-  mac: ENC[AES256_GCM,data:W8dAb/bmUsa4Hk636qJgXf7PHOXqfToADQ9jjdIC0/UiRh9EoqDTEacMbJefe0gX0VLUaKnHUsxs1CAd4Bd7qFfRf5noxhH3J6Sdve+RpLCU1Yj0Mhvpeqizcp7eA6Px8b0ivS+5gh/dBUAcTRUgY6p0rdTN9HmjXar1TTzyKEs=,iv:xRgXf1UYGchDII2H+htG0m7y5fSE8BPokBHC6PchtWs=,tag:/Nob6CtiJbcm2VLKB9HP/A==,type:str]
+  lastmodified: "2026-08-25T12:58:59Z"
+  mac: ENC[AES256_GCM,data:mMzaba/vFYgziB0DDZw87HA0nrUL2W4H5ysemOK1ZIovC+MtuQqlDE/XXmCSBJurb0v9GwBmQukyJ1kDJHbZC4T/X3G2oh5DhQDOvfllyiHPVitoVPQVbPAoUInCGigHwsiRWLSM3iC0ROJsUwGfMSWKhWWCp1HDwFL39N7+5m0=,iv:kvdZnO6RcFISk+AULOZOIODwo5xQGYfTmEVPTrH1JVw=,tag:LZx636ECaE5mVdkVQzTsNQ==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |

--- a/secrets/sashina.enc.yaml
+++ b/secrets/sashina.enc.yaml
@@ -1,0 +1,45 @@
+hermes-agent-matrix-access-token: ENC[AES256_GCM,data:MXQi2mH0T5uRVMtFLCNWCvgD9z/pr+eQ8oS7nU7BsdNCTZ1XKZkrfGhxP2lU,iv:S+90G0kPqdfgHyPRLzi0/dxD9ynMASBtfEtOlENqsNo=,tag:vJtA+ogPRDq4kOae5Lzo4w==,type:str]
+hermes-agent-matrix-recovery-key: ENC[AES256_GCM,data:tOJse2taNTQ34h8JibVzB5cqROMlFC8aUXu3caz/TV6G5PVC9o7MOjvX1R+a,iv:HuJGaw4XFoS/q7ldjWqLsO6MDEwM4k39wgWPxf/dG9A=,tag:xrUA2Cs68Zm0INkZMnMoFA==,type:str]
+sops:
+  version: 3.13.3
+  lastmodified: "2026-08-25T12:59:46Z"
+  mac: ENC[AES256_GCM,data:Gdz4uoJRKMwpH0tqsb9rJwHbKrNox0YbZDd2KKlyiocSr58c4CUW4iZwNz7PzYidiz0SDnijxUXzbZfqo0hwDcbSgw5SeJ4xXb51/KcP47lv/18LLKaqhl9BmQBsXZGscaW0+xFd/MeDqJ7/5294fhHVhol8zQeKwjt1yxf7h6k=,iv:xfhLFTEOD5aXbditHPtkZXyZmupJtPRPTxjzG6KkaqE=,tag:y7tYZIWs9/STJAHdH+XCzQ==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnNHRqQUlPbThsemVmbUpq
+        SmdpTERPUkRjQlJFdU4vZlVvT25vc1kySVcwCkJpWUQ0Rlp2QkFwVVBYS1NTL3k2
+        ZHljclg5dVJJNWY2eTU4Vlk0V1oydDgKLS0tIEZSb3prVmFrOEZjbzFlZjA0UEFF
+        dVp2WmNCZTAvYTNhU1dZTVU2WThaTXMK6u6HgeWTmSMfDD5AgCuVKhwL6942oCsp
+        sllXGo9+DfBgfeafaCdjS/HzU2LU7vYVceV5os5a2Mwb1SNpykawhA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOYVZvY0Z4M3QvMmppK2dj
+        N0JCRUhaMXlndXJLd1NOa0dyZnJnNDY4SGdRCnlFOXJiNXUveTlMeGxFOExONG0x
+        NGhsZEgrWGtiWDZlYzg0emYvNmlGcDgKLS0tIEJCK0l0UzlFaEF3dklOWkU5S3Nj
+        UFZVQnhtYlR4K2toTjJ6N3hWU1VoNVkKWuch9XraNJz7P9nuxODltQwOXEYEmJJq
+        m9XHjDA9+InlyUd3GYhdye9daz2bXwuDKP7MDL0cr0bMXLKK3d82NA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDcUxycVplK0wrNFk4K0dz
+        K1phbFU5N3FvSktMdHFlMjV5eEZyb2Q2VkdzCkNKNSs3SFc1WFBUdDNRaldqcUJs
+        MUlNUzgza2VMY3cwaXV0TSswREQzWUUKLS0tIDY4aEx4R2I4WFF2dXNURjBRVGxw
+        cENYMGdwTXk0aWdVcDB5Z3V0QnRiUGsKHewwqCRDZrBWwCiLZ5l4qpVc0BzUFAeq
+        6O69bTHpsrP55p6hyaRGliq5xClFmw0/JeNGCXrLz7LbuiCUgv/A7Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBER3IzUzhlSDNIUDZSb3pT
+        emc3a0V3TGkvQkI5NWVRNS8xcVErcFhaSUd3Ckg0THBXR2lVbEp3SjF0VCt6bmpW
+        U1Q3TjFOUW5uV0llWExFb3dadXltb1kKLS0tIGtXWng4MzFTNWUwWXVpVkxRa05J
+        S1BMNS9oMlhMamVrNzMzZkxWd3U4SlEKFTm0IXu+RQPyfOvEvzJjVmOFfCbw6Ezu
+        p3ST7yTPkXdr3K5IGsCTMgBx3GBvTl0Xy5Ti0BmooDB/T6l0NaBekg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+tailscale-authkey: ENC[AES256_GCM,data:wP19ffmp/JUa/h+kbAMYHpkwDPXh8J84V+4WbAnApaBsLTdtN2w/P3Iy2CA=,iv:mzFy+Pq7Wiypok/ikbr5CVaRW8go3oYlKl3f1p4bjJ8=,tag:VtrLX4LKGNLDhjyvZby2GA==,type:str]


### PR DESCRIPTION
Provision sops secrets for the two new MS-S1 ROCm workers.

## Changes
- `secrets/machine.enc.yaml`: added generated `hermes-agent-a2a-token-{sashina,kushira}` and `hermes-agent-api-server-key-{sashina,kushira}` (random, operator-decryptable).
- `secrets/sashina.enc.yaml`, `secrets/kushira.enc.yaml`: created, encrypted to the existing 4-recipient operator set. Hold **placeholders** for `hermes-agent-matrix-access-token`, `hermes-agent-matrix-recovery-key`, `tailscale-authkey` (server-provisioned).
- `hosts/{sashina,kushira}/configuration.nix`: `defaultSopsFile` repointed from `nishir.enc.yaml` to each host's own file (matches the ashira pattern).

## Placeholders to fill (operator action, not in this PR)
- matrix access-token + recovery-key: provision on the matrix server, then `sops edit secrets/<host>.enc.yaml`.
- tailscale authkey: generate in the admin console.

Required for eval because `ai.nix` gates the matrix tokens on `role = "operator-21o"`.

## Verification
- `nix eval` confirms every sops secret resolves to an existing file; `stateVersion = "26.05"`.
- `nix flake check` could not complete on this Mac (no `x86_64-linux` remote builder reachable); CI on x86_64 runners covers it. `OPERATOR_APP_CLIENT_ID` is now set.