### PR TITLE
Add telsha mac host to fleet Hermes A2A peers

### DIFF
--- a/hosts/kushira/configuration.nix
+++ b/hosts/kushira/configuration.nix
@@ -88,8 +88,13 @@
     defaultSopsFile = ../../secrets/kushira.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
     };
   };
 

--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -88,8 +88,13 @@
     defaultSopsFile = ../../secrets/sashina.enc.yaml;
     defaultSopsFormat = "yaml";
     secrets = {
+      codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
+      forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
+      wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
+      wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;
     };
   };
 

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -84,6 +84,14 @@ let
         "k8s-node"
       ];
     }
+    {
+      name = "telsha";
+      capabilities = [
+        "command"
+        "workstation"
+        "darwin"
+      ];
+    }
   ];
 
   otherPeers = builtins.filter (p: p.name != config.networking.hostName) peers;

--- a/secrets/machine.enc.yaml
+++ b/secrets/machine.enc.yaml
@@ -17,117 +17,119 @@ hermes-agent-api-server-key-nemishi: ENC[AES256_GCM,data:V2Spnje4593nOTkdf3+QA7K
 hermes-agent-api-server-key-nixtar: ENC[AES256_GCM,data:zlfMTrZKmrFZjiHktixCYUs8jLXRESfVYhZGZD/LzQ5tvNLe8NkihYEpgafB,iv:HqGjxKIqsM/bP71poQtNi6GtXgoWY1RiG4jPybaM6kA=,tag:+Z+EhTXGH+Slnz3WaDqP+w==,type:str]
 hermes-agent-api-server-key-sashina: ENC[AES256_GCM,data:h4WWDvUoiUbEGS7R4CyGlLUeEzYksg==,iv:4Hm2QMoDSlJYgFwtRaCxukE57LXLMK6oPp57rfLt5lU=,tag:vBVGB6tQikvAdv/oROez9g==,type:str]
 nix-access-token: ENC[AES256_GCM,data:lXMTYSDngdYn0BV5HVXFuhvgoYs97jR4AyMImwQ31J2B5khSE09+LA==,iv:iwNIOjtco+T4I/ttSlDLVG1Lah4ovXmL+GQ6D/FwNds=,tag:W7sw1taypyCir+ucOatGng==,type:str]
+hermes-agent-a2a-token-telsha: ENC[AES256_GCM,data:z7QEAcRupVDiAEB/n+Rez2VggSYlckzObHa6uWLLksFhVHQ+uUu8x0PmcmkVq7dN+XOXh2BfW51EeqKX+1WV/w==,iv:xdY9se3qdFL7zKcNC70tniKUJhM+rU4UaVDuij8aDfM=,tag:gqwlyZd7Ax4MocLPabnqOw==,type:str]
+hermes-agent-api-server-key-telsha: ENC[AES256_GCM,data:4kv28UBxR8FRaQs4Q0J0iGf3DftUEC9nvt5fzbYCx3eJxVYYLAR8jnrE57FE/Uhqr1kV0CZoUej0eH5twHvhmQ==,iv:qswlQ7eKjlYwZizgW4gO1GMgTYOXk49wIeywPA1477Q=,tag:ihpDUCkkwtTLMC5Zx+KnWQ==,type:str]
 sops:
-  version: 3.13.3
-  lastmodified: "2026-08-25T12:58:59Z"
-  mac: ENC[AES256_GCM,data:mMzaba/vFYgziB0DDZw87HA0nrUL2W4H5ysemOK1ZIovC+MtuQqlDE/XXmCSBJurb0v9GwBmQukyJ1kDJHbZC4T/X3G2oh5DhQDOvfllyiHPVitoVPQVbPAoUInCGigHwsiRWLSM3iC0ROJsUwGfMSWKhWWCp1HDwFL39N7+5m0=,iv:kvdZnO6RcFISk+AULOZOIODwo5xQGYfTmEVPTrH1JVw=,tag:LZx636ECaE5mVdkVQzTsNQ==,type:str]
-  unencrypted_suffix: _unencrypted
-  age:
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
-        Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
-        eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
-        V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
-        y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
-        QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
-        L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
-        L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
-        lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
-        eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
-        aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
-        QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
-        +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
-        dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
-        RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
-        UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
-        OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
-        RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
-        MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
-        NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
-        8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
-        KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
-        ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
-        eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
-        Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
-        VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
-        RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
-        QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
-        bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
-        VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
-        bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
-        ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
-        PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
-        ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
-        ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
-        VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
-        wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
-        aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
-        V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
-        ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
-        NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
-        MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
-        QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
-        UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
-        EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
-        OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
-        UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
-        enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
-        Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzWlphUzhvV1hWU1F4VVRo
+            Q016M3pZWHhXMGZraTZJYUVETU1zMjNlUmp3CjB6WUd0VWZnKzVXNkRCWnZZZ01D
+            eU5BZ1g3SXBQeUdNaWsyV2dRVGx2dVkKLS0tIFAvNmFpVFFOMXJ3eGFqM2pyZGRS
+            V3R6cU1ZTHJhRlk3RmpMVHloeDh6QUUKNUFAitNTzCAM7CgI8t9i4CToLxDiyr7y
+            y/8EeHp9s6iZk61YCCdefUzvjwT5U4Ny9n+mXy8N21wFxcSd5TDB3w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1vn5a6cluts3ul6ssyfajewyr58htmlqlvfjryd6y9kpjsyvk93cq5p5y73
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrNnAwdmllNGxZNFk2WFVO
+            QkpXNHRlQ3R2eDc2S2ZiQmZDVlRGb09vNEdZCkpSNHRZUDBKVkNxVDdqYnVYN0JD
+            L2l4aWtWdzRDbGFpVWROUDJJRUlUU0UKLS0tIGRaZkwzbXhDRW9YNVRNblplUDBC
+            L0Ixd3VLUjErSEhwTStkem9tMDhCSjAK3r79skaST6lMEvvNo68reXe/RJdPi6L8
+            lnNMe3Oe/SwLGUnd9tRK4oPYscTAoGKhklCA3vxAGgas6984SY0J6Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjNktIV2JEVlpLMXRmWnhK
+            eG5KS3I2QWVHMXhpUXF3SUFKc3NWYmtYeGtjCkZSai92QU5JaUJxT1Y3Umk4dWlZ
+            aVpwV3E0azBaQkpBbENPanUxakVlL1EKLS0tIEx5VHdkQjhqNFZNaG9waTJlZ0Zh
+            QW1VbFVMODZaY2pUZTBsMXdoRDRDalkKF5FzkjciWBvVtlmleJmpV1GGr8mdY+H6
+            +bV3Izjkiz3eb9X0+N0v1Ekl/1HvzbrNs7YUn9HZNkD1GeAOfBpUQw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxTWxRMWNsRy9aMUUvUXgz
+            dXlkNEdjY2hLekxZdDJXVTFlQ2ROQW1pTzFzClpHV0ViS1ludHlSeTdPdnlBV1JE
+            RDRkVzN5bnNaUjkvMVQ4bHBJdmxQOU0KLS0tIHlKNWdiRWE1ZWdhRVdzSUY0cjZr
+            UUVWMnFQNk1GWHdFMm85NC9ZVXBidzgKzTI6h7HRtmLju+7ua1EBXlFFoTKVA6zj
+            OOzjVyVYMVJjd6AR8jJXZ0HRB4kdcYFu9lxWQeJr3A6K4IblKaG6eA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnZ3doMWc2Skxsa2FmdjlP
+            RmczeExoVFJ0ZDZZbGNZUkpRMzFVdkE3aUY4CjdROEtMbGpaRnFkQWJuRVUxT3BI
+            MnRqVjU2MWpVcnp4SmVRZGwxZjZjSjQKLS0tIHprYTcyeCtDcFVMb1BrMUFUUWtx
+            NG9VUktQb0d0bkpnTFN6OFhUNy9FUUUKjX9Oqg31Mk7/fXWkpC6iuudi2N2mn2Tk
+            8vDiYiY+b6oiv/S/O/aS8ad+qQctlcMbPIfsPSEjf6XBCphivCFPLg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDVlYzZm9zUVV2Mk1SUlZv
+            KzhXbXVxOVN1SVIwdVBkdzBlN2NBSWdGSEZrCnZFeEIzMUh6Y1NMZzRpK0JobUE4
+            ZUdVblJUVFkycFZuNGxja0lrNUFObkEKLS0tIDgvbGF6Y2xzV2txYVBpTE9yMGVW
+            eDhvakxoakJWeW13QTR5cW1kNVVnTkUKfFo1mqFWDPpfLQte7RJaWo0b1wonPyvQ
+            Efyazaz5ZEeRptmRG62a8yDIF1hQFGpuLlNhgTQmTJHKQItqRd74rA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsbi9RQk5rb0d1VXNXWmdH
+            VUVzeGhvd0I1T3pjTjg4MmFyNE4weFpicjIwCnU2UjhRdlp1aGlZcHJrSG5nSng3
+            RGVlL0hwanFVSXVaZ3RyY3MyUjBSMzQKLS0tIEdIT2RCTU9mZlpDOUpUK3ZRdkNp
+            QUlpQnUycjFjWHBSbW0wY2tTS3lrSmMKRYelGpyT8uSgFdZfwc9nciK/RKYGmYTC
+            bOrwRyNpUdITnyYWNyZfNlFRPaNfBC0bMGUnItt43lCICtLNPJNIdA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtamVVcUpCd1J0cjlESktp
+            VFBrcHhtY09xOWZWd1U5RS9GVVdOQk1QdnhjCjBmb3hIcFliT0hnK21lOHU4L1pY
+            bU8yTk4wZStwaEFNS2syc0VSOVRGNEUKLS0tIDk5S0FReW9sdk12a1J6TktEYUl2
+            ZUhoWmlIRXhEcmRzczFnWE1RbC83VDQK4A62MlPxdnGLtRntkjPVokS5r1aYlxkc
+            PQww/LgV/06Pm0trsy0JeSRHFoZfOAW8L43fpTRpgwiIUSXA6C7t4A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQb0xwek4vd3FsWTVJejFC
+            ZlRDeWN0TGt0UjZJUkp4Ukw3b24zK3FXOW5rClNYVkY5aFZUWHNUMUovVDduQUp0
+            ZG9aUzJ3UXJCcnlEbmhKQklwYTlnU1EKLS0tIGVRZHFDZlJLcWt1azZvVGhrK3lG
+            VzJUSTNmaWRJVHFZbm83dmpMRXllWm8K28jJqWFOqtu8vEofCDnfyu/ioNDgNdkV
+            wLh9K9/uIkwVnkav6slIlxZgJbqt1c45QFqnlOH9vkknkYQN5/nODA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxUUpkdWFHVSthK01TYkQx
+            aCtPYUpvNnVYNkt2MHJFWDVaNmVlNWo0TXhnClNmMlFtbnJ6anFiZTVlOVB1UlhN
+            V3FwKzNOZVIxK0JaeU5JVy9WL0hab1EKLS0tIC8yaGw3aTlUUFFFWVJjcjBpejRV
+            ZStielFnaCtnWmJWTThMOVFZaVoyZUkKrjMvJUOp6lY0k6QbH0zStTjdiBJTVqqv
+            NtzUnS3IsoPEPY1m1n9sii1nNTXD95uXYa49a4SuSMOaoDxuEODyrQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrMk9BRmhDVFdlcVZqekN4
+            MDlGMUcvMWxsK1NyOEhpU1JWN2xPOU5ndHhRCnROM0VreDJyUDZmN1Y2MU82WXQx
+            QzB3SDBTUUU1Y3FoeWpSVFJ5bGN4WE0KLS0tIHN5MVByY0hIZEtEV1RtaldFbkpW
+            UkdXZDFJYjBSSGJmbGc3dlp0VGl6NDQK9r12Qd9uSEMG+UQ86hBChn97OubJTBRO
+            EaQuD9mACtpv+60Z+ZeOn1bOlBY8rpHm87Io+b47aYOARx2rmHUUYg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpQVV1ZnZvRWQ0NjVKTWhS
+            OENkRVRhck9abVRhSjd4NGZlWm5zQWgyc21rCk05bEVnOHFwZEQySVkvYXlqMGRv
+            UlBhUVBOQ2ZSMFpZTjNHaU4wMlFwbzgKLS0tIHNwemgxTXhhNkd6Y1pqS1ZET2ZI
+            enYyZE1TZVFqMjlSR3NkaUpRY3BQZWcKHsKXAH+Kdy1hSnD2XIhrBHh9pOAwLrFp
+            Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+    lastmodified: "2026-08-26T09:41:10Z"
+    mac: ENC[AES256_GCM,data:/c3GVqdz4MhV9e2Qv9ovf4gN5z/LrTAO11keY/MvWmvXqyFmmgiYjaP4xTPAovwtOE2b4bVip1UCDKd3DUll7MiTMeisJKdv4knxJOPrg6ZImfnb9KLCCwzuz3ewootQD8zISl9NZHxeeC3o8lrU5e048mp3tIS1MX7BiPCay9M=,iv:ZU9PDaw5atFIOV3UsoycQGadsOoH31yis/bgf7oOs1M=,tag:JuK3NAf6ZPwiQ01Vwtaauw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3


### PR DESCRIPTION
## What

- Adds `telsha` to the `peers` list in `modules/nixos/profiles/ai.nix` with capability labels `command`, `workstation`, `darwin`.
- Provisions the two per-peer pool entries every node expects — `hermes-agent-a2a-token-telsha` and `hermes-agent-api-server-key-telsha` — in `secrets/machine.enc.yaml`. Peer entry and credentials ship together: sops-install-secrets rejects any build whose declared secret is absent.
- Re-seals the secret pool with a valid MAC in the same change: the committed blob has failed verification since #1218. Every pre-existing secret value and all 12 age recipients are unchanged, verified on decrypted plaintext.
- Completes kushira and sashina secret wiring: maps the runner tokens from the shared builder pool and the three wifi credentials from the shared wifi pool, matching every other host. Their builds have failed since #1218; this rot reds the Packages matrix for every branch, so it is fixed here rather than left to wedge CI.

## Why

The mac host telsha runs Hermes Agent on the tailnet but was never declared a fleet peer at the configuration layer. Without this entry the nine nix nodes cannot durably address the mac, so bidirectional A2A between telsha and the nix fleet remained impossible from nix config.

The pool re-seal rides here out of necessity: #1218 left machine.enc.yaml with a stale MAC and missing telsha entries, which broke every host build once the peer declaration landed.

## References

Related: https://github.com/shikanime-labs/machines/issues/1219
