### PR TITLE
Sort machine.enc.yaml pool keys alphabetically

### DIFF
--- a/secrets/machine.enc.yaml
+++ b/secrets/machine.enc.yaml
@@ -7,6 +7,7 @@ hermes-agent-a2a-token-nalsha: ENC[AES256_GCM,data:D47/YK/DivTEuH2Li+omHLUQlssXm
 hermes-agent-a2a-token-nemishi: ENC[AES256_GCM,data:NkWYlkNjWa4dlfVLqBq5r5y9YLotLP2tAUu3bB210BvLPGkB+5gPdfpJYh75dFxLNB7y6SR78meXX5FSeMHq5Q==,iv:FhwIs46EW8xMF7aacQzbBU9M7FY3WP8/99d7tOjsGdA=,tag:Na+3Llv3HmA1meqaJ5p/zg==,type:str]
 hermes-agent-a2a-token-nixtar: ENC[AES256_GCM,data:c9XiJGNZlp0nLVMeV/DVa0a6QzbzOim1to7L0VdMueIX0bEG8QK+lyy2jgMw0aqNr1pUpdHVxECSsFORuORUyg==,iv:8keD6ZFh9tSPtN1WBSUWAOvYaTArQVc6kGEHew1Kut4=,tag:Ak8EWfbw+QPxf7lG83hMCA==,type:str]
 hermes-agent-a2a-token-sashina: ENC[AES256_GCM,data:7lVkGkhLFw4z7A44RTJllVTkc0FwcDrg/obMz7l/Lqzwu94roPC5Bxk3Q2w2wdEx0TVK45jF4fSzTHWXiYnP8A==,iv:NFNdzmxzovXjxDc9IETQ25uJJtQe7FBxTtsBv+mIdJc=,tag:Y9BUs+0bBXPo69pA8JoJog==,type:str]
+hermes-agent-a2a-token-telsha: ENC[AES256_GCM,data:z7QEAcRupVDiAEB/n+Rez2VggSYlckzObHa6uWLLksFhVHQ+uUu8x0PmcmkVq7dN+XOXh2BfW51EeqKX+1WV/w==,iv:xdY9se3qdFL7zKcNC70tniKUJhM+rU4UaVDuij8aDfM=,tag:gqwlyZd7Ax4MocLPabnqOw==,type:str]
 hermes-agent-api-server-key-ashira: ENC[AES256_GCM,data:lAJMRqH3fPhGJMkIxGBN+WwyFrGZK2DS4l5HGW5HaaH/qZ88F0RyexX58G0Rzmg2,iv:mb/63r2ChLiKAxUWBvIbl7BGb4fql3hfoPSK7g1rPgs=,tag:vDGyfaRTopJHWn2CbRdzzA==,type:str]
 hermes-agent-api-server-key-fushi: ENC[AES256_GCM,data:vXgmR7wjh+uLwCUIAHeVxE/SYoCw6P2Zn77MTphcj/oXd0Osl8XYaGbBo+7zDtc=,iv:AxZ+beakugvWpDrBfFiDVHyctoHbru+7rBO+XbUlO6E=,tag:EJoTF8R8zPZPdIfYkCVMtQ==,type:str]
 hermes-agent-api-server-key-kushira: ENC[AES256_GCM,data:ogbZCnh6+TFqOVmcktDzX6QREEHSTQ==,iv:e0M+4sMr6WYNHw8RCnLH2pOStDk6aCC0o1Tcw275c7U=,tag:JhxpzGCzHh2irvP5UTt8YQ==,type:str]
@@ -16,9 +17,8 @@ hermes-agent-api-server-key-nalsha: ENC[AES256_GCM,data:3dz0KqqCWC446/qPIaJ41XKM
 hermes-agent-api-server-key-nemishi: ENC[AES256_GCM,data:V2Spnje4593nOTkdf3+QA7Ku+jzFO4rywIACFNUeRJndR/41wAqfzm0qEYRoPg==,iv:sRu9pWOujPcsP4JYTjmKQbxi5tGJt/5Gd8A0oDIVYjQ=,tag:shcVHaW9HMiQfE6lbgQ4VA==,type:str]
 hermes-agent-api-server-key-nixtar: ENC[AES256_GCM,data:zlfMTrZKmrFZjiHktixCYUs8jLXRESfVYhZGZD/LzQ5tvNLe8NkihYEpgafB,iv:HqGjxKIqsM/bP71poQtNi6GtXgoWY1RiG4jPybaM6kA=,tag:+Z+EhTXGH+Slnz3WaDqP+w==,type:str]
 hermes-agent-api-server-key-sashina: ENC[AES256_GCM,data:h4WWDvUoiUbEGS7R4CyGlLUeEzYksg==,iv:4Hm2QMoDSlJYgFwtRaCxukE57LXLMK6oPp57rfLt5lU=,tag:vBVGB6tQikvAdv/oROez9g==,type:str]
-nix-access-token: ENC[AES256_GCM,data:lXMTYSDngdYn0BV5HVXFuhvgoYs97jR4AyMImwQ31J2B5khSE09+LA==,iv:iwNIOjtco+T4I/ttSlDLVG1Lah4ovXmL+GQ6D/FwNds=,tag:W7sw1taypyCir+ucOatGng==,type:str]
-hermes-agent-a2a-token-telsha: ENC[AES256_GCM,data:z7QEAcRupVDiAEB/n+Rez2VggSYlckzObHa6uWLLksFhVHQ+uUu8x0PmcmkVq7dN+XOXh2BfW51EeqKX+1WV/w==,iv:xdY9se3qdFL7zKcNC70tniKUJhM+rU4UaVDuij8aDfM=,tag:gqwlyZd7Ax4MocLPabnqOw==,type:str]
 hermes-agent-api-server-key-telsha: ENC[AES256_GCM,data:4kv28UBxR8FRaQs4Q0J0iGf3DftUEC9nvt5fzbYCx3eJxVYYLAR8jnrE57FE/Uhqr1kV0CZoUej0eH5twHvhmQ==,iv:qswlQ7eKjlYwZizgW4gO1GMgTYOXk49wIeywPA1477Q=,tag:ihpDUCkkwtTLMC5Zx+KnWQ==,type:str]
+nix-access-token: ENC[AES256_GCM,data:lXMTYSDngdYn0BV5HVXFuhvgoYs97jR4AyMImwQ31J2B5khSE09+LA==,iv:iwNIOjtco+T4I/ttSlDLVG1Lah4ovXmL+GQ6D/FwNds=,tag:W7sw1taypyCir+ucOatGng==,type:str]
 sops:
     age:
         - enc: |
@@ -129,7 +129,7 @@ sops:
             Yt1fnPqzdSc0gkkdxzisk0ScZG2idqx66bYeb+D7g+oGDeYI1mMVfA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
-    lastmodified: "2026-08-26T09:41:10Z"
-    mac: ENC[AES256_GCM,data:/c3GVqdz4MhV9e2Qv9ovf4gN5z/LrTAO11keY/MvWmvXqyFmmgiYjaP4xTPAovwtOE2b4bVip1UCDKd3DUll7MiTMeisJKdv4knxJOPrg6ZImfnb9KLCCwzuz3ewootQD8zISl9NZHxeeC3o8lrU5e048mp3tIS1MX7BiPCay9M=,iv:ZU9PDaw5atFIOV3UsoycQGadsOoH31yis/bgf7oOs1M=,tag:JuK3NAf6ZPwiQ01Vwtaauw==,type:str]
+    lastmodified: "2026-08-26T11:38:10Z"
+    mac: ENC[AES256_GCM,data:7fuBZh+2Krg32gXmCWk347mKliIvgs20gIiuBL+2vD/085YjLjrnrfr7IAqblJA2ZroO76KumuohXDJs7/SvXd59B0qYRGpXOsft35zFmv5SPYSe890I3BTQsRVHSgJuU/Qs2F3D+dsqukdM6oa0OcPBQNgguiRWTDPHPLMlZms=,iv:ycshv4d6Wvdz4/kJQKmOaIsk89b7eSimqQRrfJfGkFg=,tag:C4N9gdx8btoQx/5FP138xg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
## What

Re-orders machine.enc.yaml into alphabetical key order and re-seals it with a valid MAC. No secret values change; all 12 age recipients are preserved, verified on decrypted plaintext.

The re-seal rides here because re-layout cannot preserve the previous MAC.

## Why

Recent provisioning commits appended new peers at the bottom of the pool instead of their sorted position, making every future single-key secret diff noisy and inviting accidental duplicate-key appends.

## References

Related: $ISSUE_URL
