### PR TITLE
Add nishir to fleet Hermes A2A peer mesh

### DIFF
--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -85,6 +85,13 @@ let
       ];
     }
     {
+      name = "nishir";
+      capabilities = [
+        "build-x86"
+        "k8s-leader"
+      ];
+    }
+    {
       name = "telsha";
       capabilities = [
         "command"

--- a/secrets/machine.enc.yaml
+++ b/secrets/machine.enc.yaml
@@ -19,108 +19,110 @@ hermes-agent-api-server-key-nixtar: ENC[AES256_GCM,data:zlfMTrZKmrFZjiHktixCYUs8
 hermes-agent-api-server-key-sashina: ENC[AES256_GCM,data:h4WWDvUoiUbEGS7R4CyGlLUeEzYksg==,iv:4Hm2QMoDSlJYgFwtRaCxukE57LXLMK6oPp57rfLt5lU=,tag:vBVGB6tQikvAdv/oROez9g==,type:str]
 hermes-agent-api-server-key-telsha: ENC[AES256_GCM,data:4kv28UBxR8FRaQs4Q0J0iGf3DftUEC9nvt5fzbYCx3eJxVYYLAR8jnrE57FE/Uhqr1kV0CZoUej0eH5twHvhmQ==,iv:qswlQ7eKjlYwZizgW4gO1GMgTYOXk49wIeywPA1477Q=,tag:ihpDUCkkwtTLMC5Zx+KnWQ==,type:str]
 nix-access-token: ENC[AES256_GCM,data:lXMTYSDngdYn0BV5HVXFuhvgoYs97jR4AyMImwQ31J2B5khSE09+LA==,iv:iwNIOjtco+T4I/ttSlDLVG1Lah4ovXmL+GQ6D/FwNds=,tag:W7sw1taypyCir+ucOatGng==,type:str]
+hermes-agent-a2a-token-nishir: ENC[AES256_GCM,data:SBtRwqlTNf7mfVdwD4nRFPW7QZm5BPLlyHZUNx+H74GtH3+ViGuVUgddNSeo24dT1jQNE9NX4fw2vGMBbeaDHA==,iv:m6H1/fW9QvnzdwHrFVjr0jPcLjK4omHpV1dXam0ok8M=,tag:MA7B3aCrQTD9qAKkUF/1bA==,type:str]
+hermes-agent-api-server-key-nishir: ENC[AES256_GCM,data:YOfIbhagQakNMrCFrjske9unrFzqvopMZTBkUP7ldsgWzSXkHycKtckRLT5j+S2094GNS9yzM8LsOQ+ZAsgvlw==,iv:HJDvU+Gn/QWNzcPqMMyFMaOn1oVCBauhun8htUTq200=,tag:pafpgNpwEppjqeF29NrJWw==,type:str]
 sops:
-  version: 3.13.3
-  lastmodified: "2026-08-26T11:38:10Z"
-  mac: ENC[AES256_GCM,data:7fuBZh+2Krg32gXmCWk347mKliIvgs20gIiuBL+2vD/085YjLjrnrfr7IAqblJA2ZroO76KumuohXDJs7/SvXd59B0qYRGpXOsft35zFmv5SPYSe890I3BTQsRVHSgJuU/Qs2F3D+dsqukdM6oa0OcPBQNgguiRWTDPHPLMlZms=,iv:ycshv4d6Wvdz4/kJQKmOaIsk89b7eSimqQRrfJfGkFg=,tag:C4N9gdx8btoQx/5FP138xg==,type:str]
-  unencrypted_suffix: _unencrypted
-  age:
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1cDhFdmhvKzFBdjM1OFdX
-        M3hYb2x4M3FkL0IzelU5SzFSSnczMmFJSVg0ClJvd1UvaG5pRVRVYmxxTjQ2UVJx
-        UnllNC9zMWdmRW9HMFVQQVBSNExWVjAKLS0tIDRRQnh2V0hDOVl3UmsyeVd1OTls
-        N3FQMmZMdnluaDlGdndVQlN6UDduYVkKtLjWYmcdOpevxZb2B27Lg1IfQFsguVIg
-        /MauJzVHUua1W7WGCFlyauPa7tNnrqt3px0TrRZ4fnAsd3Vak8xDbw==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOTDcwZzlQViswTW8xQUhV
-        alhVRDlMQTNVb2RPS1M5QlF1b09oWWExeVNJCmdaVkxOcmNDaWVkZ24zbWpPUEM3
-        MGtkdHJHTUR5VmhYRXduM2x5cTlOaDAKLS0tIDlsK3U5VXNmdGxtQVc2anNRNHFF
-        SmFraGVySUFkTlhNQXZBMFgxQ3ZmOGMKZK55qoKg5qYoxsDwFK8I85dCs/Bhsime
-        RVwYX+6T+Y684xTBDeOS/IMykpGAgK9C7aaNaUnDjz9tFpx8NomyNw==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGOTFjakwyK2doTUhzN0xz
-        OExocEd4bW8waEVFdEl4WlU0NnVTRUt1RFcwCjlIa3dCMVNtaHpVTFpIS2Q0N0RU
-        Wnl0YjU1aktxYWNDUEZNMEo3THZPOVkKLS0tIFpYTHZMRFk0V2h5Vk53cS9TTTRV
-        SG5vRUErOE9YekpobUJaWFFBNkFHb00K/7tHeezzL1Sh3fbZ0e2kACVahCQcSxcZ
-        tHnysa1PQYREMxyg6C8x4pdqyVnAu7xH8au5xWO5Z0VEKBJBVDbKGA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGK0VHb2pPQWhFaEwxakxa
-        YnU1U3AyWkVrNUdkbHhTclhOUFpxVnhkKzA0CnJmOXFVdEJyc1hQeVJFUjVtK0Zp
-        czd3bHRabklSTGhuM0NyTjFEWGFTZkkKLS0tIDkvTWF0SWF5TzhaNzZrcmlwMVFl
-        K1NDVUxTYWxQZHppUlhFUHhub3A2T1EK6mPnH4KDHUirPWoO0O/CiHdpEXvkh5DB
-        zPz18e4c9prKFiEQPnJQ4Gr4LcKCLmljeHblGaH3H0yUWP7SZUgC6w==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBTml3YmZYcGhTcTdZblJJ
-        d0JIVWVPNDVLMlJ0QnRWSkgzNXZZSCtXblRrCllyekJtVElGUzhpRElVNUdGQjJz
-        UXhXaWFyRmdZRHRUOHloM1dPWTJ1SGcKLS0tIHJVNkl1V2RHejdialZvWk1YL21n
-        R00wN21scnpVdUY0aXFUdTNiNnhaUWsK/tXMAQlWdD4VyQ5JNO09dsNz/7gTp2jB
-        tsPoR2YBeMhsXzntLg5ajqCzphNFk4erlGc1LoksSfnAe4Ck/UyfZA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWdjhOZDdSUktoWmtMUFNT
-        NExpejdNd0tid09sRjYwUXM1MGQxaHBvb3pBCmxkb1YvdVErc3REVUNUL280VEQ1
-        RjJFT1hnRnpTMG5IMkMrbnlwN0xvakEKLS0tIGVKMTQxeG1CVnFiRzFwVVZCREU4
-        WjBEWnljQklTWXJYT21wYXNJVTk2V1UK2R5EKdeYg6/0vfoIL1ZgxqJL3qx+kHVU
-        C7voiKwd1k8GQqx6Pt2I7GTAXPmfQ2tMeQ4Xv8QUTWE8u4M2U6XKWA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHZ3hkZklNV3VVNWEyRTNI
-        YmY3QWU5Mmw2TDcvdXUwT2lTZFkvU3NWazBVCm00TnlrZ29GY3dtVjZqS29INmh5
-        cjBBMlFrS2EzTnhESWdwNzJvQU5CS28KLS0tIE1mQWpleGV1MjIyNWh6ZUxKMUFS
-        UEpHMitOS1JsMWpsOVN0cWsxZW1kYzQKxVw6d5smliqTG9/lZzkLo5LU+6add/dM
-        7FDa8OLLLPbijRR66/bMgEJIQRkgq0A5o8nY0qZaTbEfl2aW8dJjVg==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmSTdmeWluQTNvK1lHbjZD
-        OEt6d3pVcmJyWEhXVExGOEw3Tytsd1FKQTBBCm5GVmFIWFAweElNUmtLRmllQWR3
-        cEQ4bm15K0pWYTB6Yy9GeXlobkhqdncKLS0tIExZckJYYnF3V3krcjF2UDVEWWVj
-        aTlJNzFWdkhCUVJXcGk5bWZiRm9zTDAKrBuSJr643hBQRV4NvvO1WdpF1wJAiCKY
-        Hp8LHSoo5VwoI5nhJ4SbptsG/8I3i+wUdwobYibtD9vrzYWAmxsc2g==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUTm1ZbHFVQlQrK1N0ZzJk
-        YTlLanF2RVJpQTU2aVFxUFBMaFF2Y1d5NHpJCjc4aS8yaitzaDRKTHlGU2RzeEJr
-        Znd5RXNFOTdRQzh1QkQvUjA1c09zQnMKLS0tIEJVUkZkQm9GQmsvNmVCWWRRN21x
-        YjNuY0JDUGlGc2d3eEJaelUvVGxlUWsKTDrA9a7/fNIp8ExuhiDp6jG3gPRg0f4n
-        cn1HlNnvfB6VMi3NM5GXjI6Nys2BIq+KHTUlQVIG2XAQAbkI+XLMtw==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1m2z62rwhkldycej2ljggv9zfgp79xzzhdvkv7z8ajfhkrepxyvxsr3pgea
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlaGJra2xPdW5MMi9Jd1F4
-        TnlRUTJtNncxT1RENzl3V1duMGpXNE9EdDBzCklhS01nQmVUb0g4dHczQms2LzZs
-        dVlCUTZBVHpmV1FURXNjdDkyUGRxbncKLS0tIExZd1YyMzNlUVliOXlSVDRnQmc4
-        eTNsTFYzdU9SWVp5bWFBYUh5S2o1TFkKztDUXVQDKc1n9m/MbdFMursVpnkHpkLf
-        uz9uu7YP3Ipd72++FIj/AqDZh8b0jfoGioSXamKaULYDtZ8Zs5xU5w==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRZFdMSUFyRDBKaUx3Zm9q
-        WFIyUXN6Ly9GZ09pVmpIclBmSkcxc0J6VlJvCmxmL1d0R1Z6N2JWc1VJY053WnBq
-        UEhFckhReFJzb3p5OUxTbzJVRWxHSzQKLS0tIGVPZ3R4UUxkTTdXWHlNaVlOV2FH
-        a29uRG4xbFRzZ1lMa3YwRG1XUUMxQW8K6W3l6VfjSZmfixbnih+oP92hLMCIglo9
-        QnqgjILwViSiJpunyXD2uApwI/grv1Dh4QHYubaVyvyulMAOWraBkw==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1cDhFdmhvKzFBdjM1OFdX
+            M3hYb2x4M3FkL0IzelU5SzFSSnczMmFJSVg0ClJvd1UvaG5pRVRVYmxxTjQ2UVJx
+            UnllNC9zMWdmRW9HMFVQQVBSNExWVjAKLS0tIDRRQnh2V0hDOVl3UmsyeVd1OTls
+            N3FQMmZMdnluaDlGdndVQlN6UDduYVkKtLjWYmcdOpevxZb2B27Lg1IfQFsguVIg
+            /MauJzVHUua1W7WGCFlyauPa7tNnrqt3px0TrRZ4fnAsd3Vak8xDbw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOTDcwZzlQViswTW8xQUhV
+            alhVRDlMQTNVb2RPS1M5QlF1b09oWWExeVNJCmdaVkxOcmNDaWVkZ24zbWpPUEM3
+            MGtkdHJHTUR5VmhYRXduM2x5cTlOaDAKLS0tIDlsK3U5VXNmdGxtQVc2anNRNHFF
+            SmFraGVySUFkTlhNQXZBMFgxQ3ZmOGMKZK55qoKg5qYoxsDwFK8I85dCs/Bhsime
+            RVwYX+6T+Y684xTBDeOS/IMykpGAgK9C7aaNaUnDjz9tFpx8NomyNw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGOTFjakwyK2doTUhzN0xz
+            OExocEd4bW8waEVFdEl4WlU0NnVTRUt1RFcwCjlIa3dCMVNtaHpVTFpIS2Q0N0RU
+            Wnl0YjU1aktxYWNDUEZNMEo3THZPOVkKLS0tIFpYTHZMRFk0V2h5Vk53cS9TTTRV
+            SG5vRUErOE9YekpobUJaWFFBNkFHb00K/7tHeezzL1Sh3fbZ0e2kACVahCQcSxcZ
+            tHnysa1PQYREMxyg6C8x4pdqyVnAu7xH8au5xWO5Z0VEKBJBVDbKGA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGK0VHb2pPQWhFaEwxakxa
+            YnU1U3AyWkVrNUdkbHhTclhOUFpxVnhkKzA0CnJmOXFVdEJyc1hQeVJFUjVtK0Zp
+            czd3bHRabklSTGhuM0NyTjFEWGFTZkkKLS0tIDkvTWF0SWF5TzhaNzZrcmlwMVFl
+            K1NDVUxTYWxQZHppUlhFUHhub3A2T1EK6mPnH4KDHUirPWoO0O/CiHdpEXvkh5DB
+            zPz18e4c9prKFiEQPnJQ4Gr4LcKCLmljeHblGaH3H0yUWP7SZUgC6w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBTml3YmZYcGhTcTdZblJJ
+            d0JIVWVPNDVLMlJ0QnRWSkgzNXZZSCtXblRrCllyekJtVElGUzhpRElVNUdGQjJz
+            UXhXaWFyRmdZRHRUOHloM1dPWTJ1SGcKLS0tIHJVNkl1V2RHejdialZvWk1YL21n
+            R00wN21scnpVdUY0aXFUdTNiNnhaUWsK/tXMAQlWdD4VyQ5JNO09dsNz/7gTp2jB
+            tsPoR2YBeMhsXzntLg5ajqCzphNFk4erlGc1LoksSfnAe4Ck/UyfZA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWdjhOZDdSUktoWmtMUFNT
+            NExpejdNd0tid09sRjYwUXM1MGQxaHBvb3pBCmxkb1YvdVErc3REVUNUL280VEQ1
+            RjJFT1hnRnpTMG5IMkMrbnlwN0xvakEKLS0tIGVKMTQxeG1CVnFiRzFwVVZCREU4
+            WjBEWnljQklTWXJYT21wYXNJVTk2V1UK2R5EKdeYg6/0vfoIL1ZgxqJL3qx+kHVU
+            C7voiKwd1k8GQqx6Pt2I7GTAXPmfQ2tMeQ4Xv8QUTWE8u4M2U6XKWA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHZ3hkZklNV3VVNWEyRTNI
+            YmY3QWU5Mmw2TDcvdXUwT2lTZFkvU3NWazBVCm00TnlrZ29GY3dtVjZqS29INmh5
+            cjBBMlFrS2EzTnhESWdwNzJvQU5CS28KLS0tIE1mQWpleGV1MjIyNWh6ZUxKMUFS
+            UEpHMitOS1JsMWpsOVN0cWsxZW1kYzQKxVw6d5smliqTG9/lZzkLo5LU+6add/dM
+            7FDa8OLLLPbijRR66/bMgEJIQRkgq0A5o8nY0qZaTbEfl2aW8dJjVg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmSTdmeWluQTNvK1lHbjZD
+            OEt6d3pVcmJyWEhXVExGOEw3Tytsd1FKQTBBCm5GVmFIWFAweElNUmtLRmllQWR3
+            cEQ4bm15K0pWYTB6Yy9GeXlobkhqdncKLS0tIExZckJYYnF3V3krcjF2UDVEWWVj
+            aTlJNzFWdkhCUVJXcGk5bWZiRm9zTDAKrBuSJr643hBQRV4NvvO1WdpF1wJAiCKY
+            Hp8LHSoo5VwoI5nhJ4SbptsG/8I3i+wUdwobYibtD9vrzYWAmxsc2g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUTm1ZbHFVQlQrK1N0ZzJk
+            YTlLanF2RVJpQTU2aVFxUFBMaFF2Y1d5NHpJCjc4aS8yaitzaDRKTHlGU2RzeEJr
+            Znd5RXNFOTdRQzh1QkQvUjA1c09zQnMKLS0tIEJVUkZkQm9GQmsvNmVCWWRRN21x
+            YjNuY0JDUGlGc2d3eEJaelUvVGxlUWsKTDrA9a7/fNIp8ExuhiDp6jG3gPRg0f4n
+            cn1HlNnvfB6VMi3NM5GXjI6Nys2BIq+KHTUlQVIG2XAQAbkI+XLMtw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1m2z62rwhkldycej2ljggv9zfgp79xzzhdvkv7z8ajfhkrepxyvxsr3pgea
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlaGJra2xPdW5MMi9Jd1F4
+            TnlRUTJtNncxT1RENzl3V1duMGpXNE9EdDBzCklhS01nQmVUb0g4dHczQms2LzZs
+            dVlCUTZBVHpmV1FURXNjdDkyUGRxbncKLS0tIExZd1YyMzNlUVliOXlSVDRnQmc4
+            eTNsTFYzdU9SWVp5bWFBYUh5S2o1TFkKztDUXVQDKc1n9m/MbdFMursVpnkHpkLf
+            uz9uu7YP3Ipd72++FIj/AqDZh8b0jfoGioSXamKaULYDtZ8Zs5xU5w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRZFdMSUFyRDBKaUx3Zm9q
+            WFIyUXN6Ly9GZ09pVmpIclBmSkcxc0J6VlJvCmxmL1d0R1Z6N2JWc1VJY053WnBq
+            UEhFckhReFJzb3p5OUxTbzJVRWxHSzQKLS0tIGVPZ3R4UUxkTTdXWHlNaVlOV2FH
+            a29uRG4xbFRzZ1lMa3YwRG1XUUMxQW8K6W3l6VfjSZmfixbnih+oP92hLMCIglo9
+            QnqgjILwViSiJpunyXD2uApwI/grv1Dh4QHYubaVyvyulMAOWraBkw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
+    lastmodified: "2026-08-27T20:22:58Z"
+    mac: ENC[AES256_GCM,data:JzfZsKH1FkzAIGG28IcOOV4Nt9dWn+LVZdwxycX02iL/usxYWcs11cWTHMpt7CzLOfrlEdWDsF72UaAERMTsTqUM5o+fP4XSDlcywNSQdzPm0m6TKm4ecsUi59phMkecnPREvrg8CKZ/Bh4N8HrT7CsjBJQmyIjV++S+G/FRNDo=,iv:gqAo927M7R9JIlhKvfHPCBFt+Mf1H1u6qNcXdry6Ug8=,tag:nv+XRwNmyv7xDJYW8EbGYA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3


### PR DESCRIPTION
## Description

Registers the nishir Kubernetes cluster in the fleet Hermes A2A peer mesh, mirroring how telsha (#1220) joined.

### Changes
- Add `nishir` to the `peers` list in `modules/nixos/profiles/ai.nix` (capabilities: build-x86, k8s-leader)
- Add `hermes-agent-a2a-token-nishir` and `hermes-agent-api-server-key-nishir` to `secrets/machine.enc.yaml`

### Design
Every fleet host derives its outbound `bot_peers` roster and per-peer `HERMES_PEER_*_KEY` sops secrets from the `peers` list, so registering nishir makes the whole fleet dial `https://nishir.taila659a.ts.net:8642` on the next deploy. The cluster side (ingress, bot_peers, peer keys) lands in shikanime-labs/manifests #1822.

### Related
Closes #1821 (together with manifests #1822)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `nishir` AI agent peer with build and Kubernetes leadership capabilities.
  - Added the required encrypted authentication credentials for the new peer.

- **Chores**
  - Updated encrypted secret metadata and integrity information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->