### PR TITLE
Rename builder profile to forgejo

### DIFF
--- a/hosts/ashira/configuration.nix
+++ b/hosts/ashira/configuration.nix
@@ -1,7 +1,7 @@
 {
   imports = [
     ../../modules/nixos/profiles/ai.nix
-    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/forgejo.nix
     ../../modules/nixos/profiles/distributed.nix
     ../../modules/nixos/profiles/follower.nix
     ../../modules/nixos/profiles/nishir.nix

--- a/hosts/fushi/configuration.nix
+++ b/hosts/fushi/configuration.nix
@@ -4,7 +4,7 @@
   imports = [
     ../../modules/nixos/profiles/ai.nix
     ../../modules/nixos/profiles/agent.nix
-    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/forgejo.nix
     ../../modules/nixos/profiles/distributed.nix
     ../../modules/nixos/profiles/nishir.nix
     ../../modules/nixos/profiles/server.nix

--- a/hosts/kushira/configuration.nix
+++ b/hosts/kushira/configuration.nix
@@ -2,7 +2,7 @@
   imports = [
     ../../modules/nixos/profiles/ai.nix
     ../../modules/nixos/profiles/agent.nix
-    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/forgejo.nix
     ../../modules/nixos/profiles/distributed.nix
     ../../modules/nixos/profiles/nishir.nix
     ../../modules/nixos/profiles/server.nix

--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -1,7 +1,7 @@
 {
   imports = [
     ../../modules/nixos/profiles/ai.nix
-    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/forgejo.nix
     ../../modules/nixos/profiles/distributed.nix
     ../../modules/nixos/profiles/leader.nix
     ../../modules/nixos/profiles/nishir.nix
@@ -110,6 +110,7 @@
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
       wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;
       wifi-vintage-korean.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/hosts/minish/configuration.nix
+++ b/hosts/minish/configuration.nix
@@ -4,7 +4,7 @@
   imports = [
     ../../modules/nixos/profiles/ai.nix
     ../../modules/nixos/profiles/agent.nix
-    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/forgejo.nix
     ../../modules/nixos/profiles/distributed.nix
     ../../modules/nixos/profiles/nishir.nix
     ../../modules/nixos/profiles/server.nix

--- a/hosts/nalsha/configuration.nix
+++ b/hosts/nalsha/configuration.nix
@@ -1,7 +1,7 @@
 {
   imports = [
     ../../modules/nixos/profiles/ai.nix
-    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/forgejo.nix
     ../../modules/nixos/profiles/distributed.nix
     ../../modules/nixos/profiles/follower.nix
     ../../modules/nixos/profiles/nishir.nix

--- a/hosts/nemishi/configuration.nix
+++ b/hosts/nemishi/configuration.nix
@@ -4,7 +4,7 @@
   imports = [
     ../../modules/nixos/profiles/ai.nix
     ../../modules/nixos/profiles/agent.nix
-    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/forgejo.nix
     ../../modules/nixos/profiles/distributed.nix
     ../../modules/nixos/profiles/nishir.nix
     ../../modules/nixos/profiles/server.nix

--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -2,7 +2,7 @@
   imports = [
     ../../modules/nixos/profiles/ai.nix
     ../../modules/nixos/profiles/agent.nix
-    ../../modules/nixos/profiles/builder.nix
+    ../../modules/nixos/profiles/forgejo.nix
     ../../modules/nixos/profiles/distributed.nix
     ../../modules/nixos/profiles/nishir.nix
     ../../modules/nixos/profiles/server.nix

--- a/modules/nixos/profiles/distributed.nix
+++ b/modules/nixos/profiles/distributed.nix
@@ -64,7 +64,10 @@ in
 
     distributedBuilds = true;
 
-    settings.builders-use-substitutes = true;
+    settings = {
+      trusted-users = [ "builder" ];
+      builders-use-substitutes = true;
+    };
   };
 
   programs.ssh.knownHosts = mkSshKnownHosts [

--- a/modules/nixos/profiles/forgejo.nix
+++ b/modules/nixos/profiles/forgejo.nix
@@ -5,8 +5,6 @@
     ./machine.nix
   ];
 
-  nix.settings.trusted-users = [ "builder" ];
-
   services.gitea-actions-runner = {
     package = pkgs.forgejo-runner;
     instances = {


### PR DESCRIPTION
## What

Rename the `builder` profile to `forgejo` and relocate the Nix build trust
model:

- Rename `modules/nixos/profiles/builder.nix` to `forgejo.nix`. The profile
  configures Forgejo Actions runners, not Nix building.
- Move `nix.settings.trusted-users = [ "builder" ]` from the forgejo profile
  into `modules/nixos/profiles/distributed.nix`, where the distributed-build
  trust model lives.
- Update the forgejo import in all eight host configurations.

## Why

The `builder` profile name misdescribes its content: it sets up Forgejo Actions
runners and Docker, not Nix build machines. The `builder` trusted-user is a
distributed-build concern, so it belongs with the build-machine topology in
`distributed.nix`. This refactor sets up the next change (nixbot CI) cleanly
and removes a cross-cutting setting from an unrelated profile.

## References

Related: https://github.com/shikanime-labs/machines/issues/1225


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled the Forgejo service profile across additional hosts.
  - Added secure runner authentication support for one host.

- **Improvements**
  - Distributed builds now explicitly support trusted builders and binary substitutes.
  - Updated Forgejo access permissions while preserving existing runner and container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->