### PR TITLE
Add nixbot CI on the fleet leader

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -552,6 +552,27 @@
         "type": "github"
       }
     },
+    "nixbot": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_3"
+      },
+      "locked": {
+        "lastModified": 1787797215,
+        "narHash": "sha256-XKC7Iw09l4QFNhg7yKy6rVhaS/X8v/txPVOMP40Rpic=",
+        "owner": "Mic92",
+        "repo": "nixbot",
+        "rev": "dfc08bf8c37820c5a56cb2e50adba14c6f3b4fa4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nixbot",
+        "type": "github"
+      }
+    },
     "nixd": {
       "inputs": {
         "flake-parts": [
@@ -773,12 +794,13 @@
         "identities": "identities",
         "knix": "knix",
         "nix-darwin": "nix-darwin",
+        "nixbot": "nixbot",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_3",
         "noctalia": "noctalia",
         "noctalia-greeter": "noctalia-greeter",
         "sops-nix": "sops-nix",
-        "treefmt-nix": "treefmt-nix_3"
+        "treefmt-nix": "treefmt-nix_4"
       }
     },
     "rust-overlay": {
@@ -878,6 +900,27 @@
       }
     },
     "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "nixbot",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_4": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"

--- a/flake.nix
+++ b/flake.nix
@@ -113,6 +113,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    nixbot = {
+      url = "github:Mic92/nixbot";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     noctalia = {
       url = "github:noctalia-dev/noctalia";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/hosts/manash/configuration.nix
+++ b/hosts/manash/configuration.nix
@@ -5,6 +5,7 @@
     ../../modules/nixos/profiles/distributed.nix
     ../../modules/nixos/profiles/leader.nix
     ../../modules/nixos/profiles/nishir.nix
+    ../../modules/nixos/profiles/nixbot.nix
     ../../modules/nixos/profiles/server.nix
     ../../modules/nixos/hardware/beelink-eq.nix
     ../../modules/nixos/users/builder.nix
@@ -110,6 +111,9 @@
       codeberg-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       forgejo-runner-token.sopsFile = ../../secrets/builder.enc.yaml;
       nix-access-token.sopsFile = ../../secrets/machine.enc.yaml;
+      nixbot-app-secret.sopsFile = ../../secrets/manash.enc.yaml;
+      nixbot-oauth-secret.sopsFile = ../../secrets/manash.enc.yaml;
+      nixbot-webhook-secret.sopsFile = ../../secrets/manash.enc.yaml;
       rke2-token.sopsFile = ../../secrets/nishir.enc.yaml;
       wifi-sfr-e368.sopsFile = ../../secrets/wifi.enc.yaml;
       wifi-sfr-e368-5ghz.sopsFile = ../../secrets/wifi.enc.yaml;

--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -155,6 +155,7 @@ let
       };
       modules = [
         ../../hosts/manash/configuration.nix
+        inputs.nixbot.nixosModules.nixbot
       ]
       ++ (mkBeelinkClusterModules system);
     };

--- a/modules/nixos/profiles/nixbot.nix
+++ b/modules/nixos/profiles/nixbot.nix
@@ -1,0 +1,61 @@
+{ config, lib, ... }:
+
+# Nixbot control node: a zero-config, pull-based, self-hosted Nix CI that
+# builds `.#checks` on PR open and default-branch push. Runs on ONE control
+# host; builds offload to the existing nix remote builders declared by
+# `distributed.nix`. Requires the `nixbot` flake input
+# (github:Mic92/nixbot) wired into the host's module list.
+{
+  imports = [
+    ./machine.nix
+    ./distributed.nix
+  ];
+
+  services.nixbot = {
+    enable = true;
+
+    # Web frontend + GitHub App webhook endpoint.
+    domain = "nixbot.taila659a.ts.net";
+
+    # Control-plane user; the CI owner. Provider-qualified "github:<login>".
+    admins = [ "github:shikanimedeva" ];
+
+    # GitHub App auth (see docs/GITHUB.md): automatic webhook setup + check-run
+    # reporting with a working Re-run button. Files land via sops.
+    github = {
+      enable = true;
+      appId = 0; # FIXME: GitHub App ID
+      appSecretKeyFile = config.sops.secrets.nixbot-app-secret.path;
+      webhookSecretFile = config.sops.secrets.nixbot-webhook-secret.path;
+      oauthId = "aaaaaaaaaaaaaaaaaaaa"; # FIXME: OAuth client id
+      oauthSecretFile = config.sops.secrets.nixbot-oauth-secret.path;
+      # One-shot import on first boot: repositories with this topic are enabled.
+      topic = "build-with-buildbot";
+      # Only the org we actually build.
+      userAllowlist = [ "shikanime-labs" ];
+    };
+
+    # Systems built locally; everything else arrives via nix remote builders
+    # from `distributed.nix`.
+    buildSystems = [ "x86_64-linux" ];
+
+    # Bound eval so a busy org cannot starve the control node.
+    evalWorkerCount = 2;
+    evalMaxMemorySize = 4096;
+
+    nginx.enableACME = true;
+  };
+
+  sops.secrets = {
+    nixbot-app-secret.restartUnits = [ "nixbot.service" ];
+    nixbot-webhook-secret.restartUnits = [ "nixbot.service" ];
+    nixbot-oauth-secret.restartUnits = [ "nixbot.service" ];
+  };
+
+  # Nixbot drives the local nix daemon; the remote-build trust model lives in
+  # `distributed.nix` (imported above), which trusts the `builder` user.
+  nix.settings.max-jobs = lib.mkDefault 2;
+
+  # Let's Encrypt terms; nixbot provisions a cert for `domain`.
+  security.acme.acceptTerms = true;
+}


### PR DESCRIPTION
## What

Wire nixbot (github.com/Mic92/nixbot) onto the fleet leader (manash) for a
pull-based, zero-config Nix CI:

- Add the `nixbot` flake input (nixpkgs follows) and import its module on the
  leader only.
- Add a `services.nixbot` control-node profile: GitHub App auth, the
  `shikanime-labs` allowlist, ACME, and bounded eval.
- Offload builds to the existing distributed build machines (ashira, manash,
  nalsha; fushi, minish, nemishi).

## Why

The fleet builds Nix outputs through GitHub Actions composite logic and Forgejo
Actions runners; there is no pull-based, self-hosted Nix CI that builds every
flake `checks` with zero per-job pipeline configuration. Issue #270 in the
actions repo evaluates pull-based GitOps-style CI candidates and recommends
nixbot. This PR implements that recommendation on the fleet.

Stacks on https://github.com/shikanime-labs/machines/pull/1227 (the forgejo
profile rename).

## References

Related: https://github.com/shikanime-labs/actions/issues/270
Related: https://github.com/shikanime-labs/machines/issues/1225


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Nixbot control node for managing distributed Nix builds.
  * Enabled GitHub App authentication with administrator and repository access controls.
  * Added support for x86_64 build machines and bounded evaluation resources.
  * Added secure web access through an ACME-provisioned HTTPS endpoint.
* **Security**
  * Integrated encrypted secret management for application, OAuth, and webhook credentials.
  * Configured automatic service restarts when managed secrets are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->