### PR TITLE
Fix SOPS_AGE_KEY escape in devenv

### DIFF
--- a/modules/flake/devenv.nix
+++ b/modules/flake/devenv.nix
@@ -21,7 +21,7 @@
           inputs.devlib.devenvModules.shikanime
           inputs.identities.devenvModules.default
         ];
-        env.SOPS_AGE_KEY = "\\${{ secrets.CATBOX_SOPS_KEY }}";
+        env.SOPS_AGE_KEY = "\${{ secrets.CATBOX_SOPS_KEY }}";
 
         identities = {
           enable = true;


### PR DESCRIPTION
## What

Fix the SOPS_AGE_KEY devenv template so the flake evaluates again.

## Why

PR #1230 shipped `env.SOPS_AGE_KEY = "\\${{ secrets.CATBOX_SOPS_KEY }}"` with two backslashes, which is a Nix syntax error (`unexpected '}'`). It breaks every flake evaluation and blocks the catbox containerdisk build that #1230 was supposed to enable. One backslash matches the `CACHIX_AUTH_TOKEN` pattern used on the same file.

## References

Related: https://github.com/shikanime-labs/machines/pull/1230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub Actions secret interpolation for the SOPS age key environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->