### PR TITLE
Backport generic VM config to containerdisk module

### DIFF
--- a/hosts/catbox/configuration.nix
+++ b/hosts/catbox/configuration.nix
@@ -9,8 +9,11 @@
     "${modulesPath}/profiles/headless.nix"
     ../../modules/nixos/virtualisation/containerdisk.nix
     ../../modules/nixos/profiles/minimal.nix
+    ../../modules/nixos/profiles/ai.nix
     ../../modules/nixos/users/automata.nix
   ];
+
+  networking.hostName = "catbox";
 
   # Fresh OVMF NVRAM each boot: write the systemd-boot entry as a real EFI
   # Boot variable instead of relying on fallback-path detection.

--- a/modules/flake/devenv.nix
+++ b/modules/flake/devenv.nix
@@ -21,7 +21,7 @@
           inputs.devlib.devenvModules.shikanime
           inputs.identities.devenvModules.default
         ];
-        env.SOPS_AGE_KEY = "\\${{ secrets.CATBOX_SOPS_KEY }}";
+        env.SOPS_AGE_KEY = "\${{ secrets.CATBOX_SOPS_KEY }}";
 
         identities = {
           enable = true;

--- a/modules/nixos/virtualisation/containerdisk.nix
+++ b/modules/nixos/virtualisation/containerdisk.nix
@@ -30,25 +30,78 @@ in
   };
 
   # Reference: https://github.com/kubevirt/kubevirt/blob/main/docs/container-register-disks.md
-  # KubeVirt q35 exposes the guest console on ttyS0; without it the kernel
-  # sends output to invisible VGA and panic=1 reboots silently.
-  config.boot.kernelParams = [ "console=ttyS0" ];
+  config = {
+    boot = {
+      # KubeVirt q35 exposes the guest console on ttyS0; without it the kernel
+      # sends output to invisible VGA and panic=1 reboots silently.
+      kernelParams = [ "console=ttyS0" ];
 
-  # KubeVirt exposes containerDisks as virtio (/dev/vda); without these the
-  # initrd cannot see the root disk and boot times out into a panic=1 loop.
-  config.boot.initrd.availableKernelModules = [
-    "virtio_pci"
-    "virtio_blk"
-  ];
+      # KubeVirt exposes containerDisks as virtio (/dev/vda); without these the
+      # initrd cannot see the root disk and boot times out into a panic=1 loop.
+      initrd.availableKernelModules = [
+        "virtio_pci"
+        "virtio_blk"
+      ];
 
-  config.system.build.containerdiskImage = pkgs.dockerTools.buildImage {
-    inherit (cfg) name;
+      # Load the virtio and KVM module families at runtime; kvm_intel/kvm_amd and
+      # the NVIDIA stack are arch/device-specific and handled by
+      # kernel-module-loader so a missing module never fails boot.
+      kernelModules = [
+        "virtio_pci"
+        "virtio_net"
+        "virtio_balloon"
+        "virtio_blk"
+        "virtio_rng"
+        "virtio_console"
+        "kvm"
+        "vhost_net"
+        "usb"
+        "usbhid"
+        "usb_storage"
+        "uvcvideo"
+      ];
+    };
 
-    copyToRoot = pkgs.runCommand "containerdisk" { } ''
-      mkdir -p $out/disk
-      cp -v ${config.system.build.image}/${config.image.fileName} $out/disk/${config.image.fileName}
-    '';
+    environment.systemPackages = [ pkgs.usbutils ];
 
-    config = cfg.settings;
+    # KubeVirt seeds cloud-config via NoCloud; always enabled.
+    services.cloud-init.enable = true;
+
+    systemd.services = {
+      kernel-module-loader = {
+        description = "Load VM kernel modules";
+        enable = true;
+        wantedBy = [ "multi-user.target" ];
+        script = ''
+          # Load KVM modules matching the CPU vendor.
+          if grep -qE '(^| )vmx( |$)' /proc/cpuinfo; then
+            modprobe kvm_intel
+          fi
+
+          # Load KVM modules with AMD-V acceleration if available.
+          if grep -qE '(^| )svm( |$)' /proc/cpuinfo; then
+            modprobe kvm_amd
+          fi
+
+          # Load NVIDIA kernel modules if available.
+          if modinfo nvidia 2>/dev/null >/dev/null; then
+            modprobe nvidia_uvm
+            modprobe nvidia_drm
+            modprobe nvidia_modeset
+          fi
+        '';
+      };
+    };
+
+    system.build.containerdiskImage = pkgs.dockerTools.buildImage {
+      inherit (cfg) name;
+
+      copyToRoot = pkgs.runCommand "containerdisk" { } ''
+        mkdir -p $out/disk
+        cp -v ${config.system.build.image}/${config.image.fileName} $out/disk/${config.image.fileName}
+      '';
+
+      config = cfg.settings;
+    };
   };
 }

--- a/secrets/catbox.enc.yaml
+++ b/secrets/catbox.enc.yaml
@@ -1,16 +1,16 @@
 catbox-test-secret: ENC[AES256_GCM,data:TV+oGO0rSd385ejvjtryXw5/Qet3,iv:aIXh7WTkbnMZVsIXbBUp/MUlbCvao/W2oKrEVyJ/+Kc=,tag:ygx3ODl9Xds32SdLfyvhgA==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUK3FlczMwSTgwSGpqK0w4
-            MGY4L3k2VVRYV3d0bUkyRmRSYzAyQWxxODNrCjIyWmlyU3YzUm41ZHJFdTFvL2dW
-            WDR6K09kV0g0RENXZi83V3RIeU5qNlkKLS0tIHpoUzJUQnVEbWwwd1NZQjYwWHc3
-            ejhMS1Q0T04wM01IeEhvR0QzRTA2T1kKEHGmWJdcYFoHJrs0chDCiJX2OAzsSWjz
-            L99svUN6nSdA+lV8BAncJ5I8dGeqKKPWs9DUA1NIkPLRc8QhqDZOLw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1etnd6hnt6776vqsnadny72t55whnlav8xp8e7rx3fd4lz7ms8dfsjsrnul
-    lastmodified: "2026-08-28T13:05:21Z"
-    mac: ENC[AES256_GCM,data:p7WulLC0yNdWTbTJbhv9/BXQjNnJm3H4VyWF+l+ETPOJKbFVSC1HURESk8HRivF7Ro88oGoLbIA/HfFHs/kECmwrVh3e6chb1wLoU30qN8kGoSG3vFH/0AmTk+6YVsqfUJ6nKZbkzKVWy8/T56nMGcTUXffhnwY/i0TRi3WIy64=,iv:OX3rTT8nm5CtmVhHHhQiQu1TaJI0kYnY7IkbM9nydRI=,tag:2Ct23MrqQvhqat8SiwR3Yw==,type:str]
-    unencrypted_suffix: _unencrypted
-    version: 3.13.3
+  version: 3.13.3
+  lastmodified: "2026-08-28T13:05:21Z"
+  mac: ENC[AES256_GCM,data:p7WulLC0yNdWTbTJbhv9/BXQjNnJm3H4VyWF+l+ETPOJKbFVSC1HURESk8HRivF7Ro88oGoLbIA/HfFHs/kECmwrVh3e6chb1wLoU30qN8kGoSG3vFH/0AmTk+6YVsqfUJ6nKZbkzKVWy8/T56nMGcTUXffhnwY/i0TRi3WIy64=,iv:OX3rTT8nm5CtmVhHHhQiQu1TaJI0kYnY7IkbM9nydRI=,tag:2Ct23MrqQvhqat8SiwR3Yw==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUK3FlczMwSTgwSGpqK0w4
+        MGY4L3k2VVRYV3d0bUkyRmRSYzAyQWxxODNrCjIyWmlyU3YzUm41ZHJFdTFvL2dW
+        WDR6K09kV0g0RENXZi83V3RIeU5qNlkKLS0tIHpoUzJUQnVEbWwwd1NZQjYwWHc3
+        ejhMS1Q0T04wM01IeEhvR0QzRTA2T1kKEHGmWJdcYFoHJrs0chDCiJX2OAzsSWjz
+        L99svUN6nSdA+lV8BAncJ5I8dGeqKKPWs9DUA1NIkPLRc8QhqDZOLw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1etnd6hnt6776vqsnadny72t55whnlav8xp8e7rx3fd4lz7ms8dfsjsrnul

--- a/secrets/machine.enc.yaml
+++ b/secrets/machine.enc.yaml
@@ -5,6 +5,7 @@ hermes-agent-a2a-token-manash: ENC[AES256_GCM,data:bYfmIWPG4cMhQlWLfVW+YL/wuwzEh
 hermes-agent-a2a-token-minish: ENC[AES256_GCM,data:EMsQp6jRGUY+/zFjXMxCGz04i2p2bW1RQcgt4MQNPsUrCE/ICOT56GGbgEJxVnzSRpdoGLe30VxJZuf/yTFyhQ==,iv:dGfhw5OvYmon4lgTohi56pdgLW7ntvAtDDxdzYY/EUE=,tag:8PgRQCXXWfBBSPbLnYh7iA==,type:str]
 hermes-agent-a2a-token-nalsha: ENC[AES256_GCM,data:D47/YK/DivTEuH2Li+omHLUQlssXm4ArG9YTYDiePuFcSRfRBmpoLRx1zB9vGpdpmHAsnmpze1mYcxSwARia5Q==,iv:if4qGmre5seDrkWjs1pocMluq7eR6fRGgWdjvCmYoJE=,tag:o7CIcfb+i+AxtpQXhf9YVQ==,type:str]
 hermes-agent-a2a-token-nemishi: ENC[AES256_GCM,data:NkWYlkNjWa4dlfVLqBq5r5y9YLotLP2tAUu3bB210BvLPGkB+5gPdfpJYh75dFxLNB7y6SR78meXX5FSeMHq5Q==,iv:FhwIs46EW8xMF7aacQzbBU9M7FY3WP8/99d7tOjsGdA=,tag:Na+3Llv3HmA1meqaJ5p/zg==,type:str]
+hermes-agent-a2a-token-nishir: ENC[AES256_GCM,data:SBtRwqlTNf7mfVdwD4nRFPW7QZm5BPLlyHZUNx+H74GtH3+ViGuVUgddNSeo24dT1jQNE9NX4fw2vGMBbeaDHA==,iv:m6H1/fW9QvnzdwHrFVjr0jPcLjK4omHpV1dXam0ok8M=,tag:MA7B3aCrQTD9qAKkUF/1bA==,type:str]
 hermes-agent-a2a-token-nixtar: ENC[AES256_GCM,data:c9XiJGNZlp0nLVMeV/DVa0a6QzbzOim1to7L0VdMueIX0bEG8QK+lyy2jgMw0aqNr1pUpdHVxECSsFORuORUyg==,iv:8keD6ZFh9tSPtN1WBSUWAOvYaTArQVc6kGEHew1Kut4=,tag:Ak8EWfbw+QPxf7lG83hMCA==,type:str]
 hermes-agent-a2a-token-sashina: ENC[AES256_GCM,data:7lVkGkhLFw4z7A44RTJllVTkc0FwcDrg/obMz7l/Lqzwu94roPC5Bxk3Q2w2wdEx0TVK45jF4fSzTHWXiYnP8A==,iv:NFNdzmxzovXjxDc9IETQ25uJJtQe7FBxTtsBv+mIdJc=,tag:Y9BUs+0bBXPo69pA8JoJog==,type:str]
 hermes-agent-a2a-token-telsha: ENC[AES256_GCM,data:z7QEAcRupVDiAEB/n+Rez2VggSYlckzObHa6uWLLksFhVHQ+uUu8x0PmcmkVq7dN+XOXh2BfW51EeqKX+1WV/w==,iv:xdY9se3qdFL7zKcNC70tniKUJhM+rU4UaVDuij8aDfM=,tag:gqwlyZd7Ax4MocLPabnqOw==,type:str]
@@ -15,114 +16,113 @@ hermes-agent-api-server-key-manash: ENC[AES256_GCM,data:1E0gqZZ0DG3z+50A//SWjiNx
 hermes-agent-api-server-key-minish: ENC[AES256_GCM,data:MbNKt2I9/CYC7K0qbRTw17wBUFPmmFAeLHubjt3s/Limh+o4OXTIdVJlQILbkA==,iv:Tas8kDmmI6W7hwvly0uRNvQB5hOa4ogp1oy6ukRei6g=,tag:nR37jj58H7UAgC/VNDs5zg==,type:str]
 hermes-agent-api-server-key-nalsha: ENC[AES256_GCM,data:3dz0KqqCWC446/qPIaJ41XKMTsh+dp26+UiTCGM9PXf3FmowEqWXdThOhAR6aQ8=,iv:dHK4gWPYHhBESqbgNpyUqIjBted8Z6n/9g8Mw0lzEd4=,tag:65GSKse0wYpmPu5TfKOyvA==,type:str]
 hermes-agent-api-server-key-nemishi: ENC[AES256_GCM,data:V2Spnje4593nOTkdf3+QA7Ku+jzFO4rywIACFNUeRJndR/41wAqfzm0qEYRoPg==,iv:sRu9pWOujPcsP4JYTjmKQbxi5tGJt/5Gd8A0oDIVYjQ=,tag:shcVHaW9HMiQfE6lbgQ4VA==,type:str]
+hermes-agent-api-server-key-nishir: ENC[AES256_GCM,data:YOfIbhagQakNMrCFrjske9unrFzqvopMZTBkUP7ldsgWzSXkHycKtckRLT5j+S2094GNS9yzM8LsOQ+ZAsgvlw==,iv:HJDvU+Gn/QWNzcPqMMyFMaOn1oVCBauhun8htUTq200=,tag:pafpgNpwEppjqeF29NrJWw==,type:str]
 hermes-agent-api-server-key-nixtar: ENC[AES256_GCM,data:zlfMTrZKmrFZjiHktixCYUs8jLXRESfVYhZGZD/LzQ5tvNLe8NkihYEpgafB,iv:HqGjxKIqsM/bP71poQtNi6GtXgoWY1RiG4jPybaM6kA=,tag:+Z+EhTXGH+Slnz3WaDqP+w==,type:str]
 hermes-agent-api-server-key-sashina: ENC[AES256_GCM,data:h4WWDvUoiUbEGS7R4CyGlLUeEzYksg==,iv:4Hm2QMoDSlJYgFwtRaCxukE57LXLMK6oPp57rfLt5lU=,tag:vBVGB6tQikvAdv/oROez9g==,type:str]
 hermes-agent-api-server-key-telsha: ENC[AES256_GCM,data:4kv28UBxR8FRaQs4Q0J0iGf3DftUEC9nvt5fzbYCx3eJxVYYLAR8jnrE57FE/Uhqr1kV0CZoUej0eH5twHvhmQ==,iv:qswlQ7eKjlYwZizgW4gO1GMgTYOXk49wIeywPA1477Q=,tag:ihpDUCkkwtTLMC5Zx+KnWQ==,type:str]
 nix-access-token: ENC[AES256_GCM,data:lXMTYSDngdYn0BV5HVXFuhvgoYs97jR4AyMImwQ31J2B5khSE09+LA==,iv:iwNIOjtco+T4I/ttSlDLVG1Lah4ovXmL+GQ6D/FwNds=,tag:W7sw1taypyCir+ucOatGng==,type:str]
-hermes-agent-a2a-token-nishir: ENC[AES256_GCM,data:SBtRwqlTNf7mfVdwD4nRFPW7QZm5BPLlyHZUNx+H74GtH3+ViGuVUgddNSeo24dT1jQNE9NX4fw2vGMBbeaDHA==,iv:m6H1/fW9QvnzdwHrFVjr0jPcLjK4omHpV1dXam0ok8M=,tag:MA7B3aCrQTD9qAKkUF/1bA==,type:str]
-hermes-agent-api-server-key-nishir: ENC[AES256_GCM,data:YOfIbhagQakNMrCFrjske9unrFzqvopMZTBkUP7ldsgWzSXkHycKtckRLT5j+S2094GNS9yzM8LsOQ+ZAsgvlw==,iv:HJDvU+Gn/QWNzcPqMMyFMaOn1oVCBauhun8htUTq200=,tag:pafpgNpwEppjqeF29NrJWw==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1cDhFdmhvKzFBdjM1OFdX
-            M3hYb2x4M3FkL0IzelU5SzFSSnczMmFJSVg0ClJvd1UvaG5pRVRVYmxxTjQ2UVJx
-            UnllNC9zMWdmRW9HMFVQQVBSNExWVjAKLS0tIDRRQnh2V0hDOVl3UmsyeVd1OTls
-            N3FQMmZMdnluaDlGdndVQlN6UDduYVkKtLjWYmcdOpevxZb2B27Lg1IfQFsguVIg
-            /MauJzVHUua1W7WGCFlyauPa7tNnrqt3px0TrRZ4fnAsd3Vak8xDbw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOTDcwZzlQViswTW8xQUhV
-            alhVRDlMQTNVb2RPS1M5QlF1b09oWWExeVNJCmdaVkxOcmNDaWVkZ24zbWpPUEM3
-            MGtkdHJHTUR5VmhYRXduM2x5cTlOaDAKLS0tIDlsK3U5VXNmdGxtQVc2anNRNHFF
-            SmFraGVySUFkTlhNQXZBMFgxQ3ZmOGMKZK55qoKg5qYoxsDwFK8I85dCs/Bhsime
-            RVwYX+6T+Y684xTBDeOS/IMykpGAgK9C7aaNaUnDjz9tFpx8NomyNw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGOTFjakwyK2doTUhzN0xz
-            OExocEd4bW8waEVFdEl4WlU0NnVTRUt1RFcwCjlIa3dCMVNtaHpVTFpIS2Q0N0RU
-            Wnl0YjU1aktxYWNDUEZNMEo3THZPOVkKLS0tIFpYTHZMRFk0V2h5Vk53cS9TTTRV
-            SG5vRUErOE9YekpobUJaWFFBNkFHb00K/7tHeezzL1Sh3fbZ0e2kACVahCQcSxcZ
-            tHnysa1PQYREMxyg6C8x4pdqyVnAu7xH8au5xWO5Z0VEKBJBVDbKGA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGK0VHb2pPQWhFaEwxakxa
-            YnU1U3AyWkVrNUdkbHhTclhOUFpxVnhkKzA0CnJmOXFVdEJyc1hQeVJFUjVtK0Zp
-            czd3bHRabklSTGhuM0NyTjFEWGFTZkkKLS0tIDkvTWF0SWF5TzhaNzZrcmlwMVFl
-            K1NDVUxTYWxQZHppUlhFUHhub3A2T1EK6mPnH4KDHUirPWoO0O/CiHdpEXvkh5DB
-            zPz18e4c9prKFiEQPnJQ4Gr4LcKCLmljeHblGaH3H0yUWP7SZUgC6w==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBTml3YmZYcGhTcTdZblJJ
-            d0JIVWVPNDVLMlJ0QnRWSkgzNXZZSCtXblRrCllyekJtVElGUzhpRElVNUdGQjJz
-            UXhXaWFyRmdZRHRUOHloM1dPWTJ1SGcKLS0tIHJVNkl1V2RHejdialZvWk1YL21n
-            R00wN21scnpVdUY0aXFUdTNiNnhaUWsK/tXMAQlWdD4VyQ5JNO09dsNz/7gTp2jB
-            tsPoR2YBeMhsXzntLg5ajqCzphNFk4erlGc1LoksSfnAe4Ck/UyfZA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWdjhOZDdSUktoWmtMUFNT
-            NExpejdNd0tid09sRjYwUXM1MGQxaHBvb3pBCmxkb1YvdVErc3REVUNUL280VEQ1
-            RjJFT1hnRnpTMG5IMkMrbnlwN0xvakEKLS0tIGVKMTQxeG1CVnFiRzFwVVZCREU4
-            WjBEWnljQklTWXJYT21wYXNJVTk2V1UK2R5EKdeYg6/0vfoIL1ZgxqJL3qx+kHVU
-            C7voiKwd1k8GQqx6Pt2I7GTAXPmfQ2tMeQ4Xv8QUTWE8u4M2U6XKWA==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHZ3hkZklNV3VVNWEyRTNI
-            YmY3QWU5Mmw2TDcvdXUwT2lTZFkvU3NWazBVCm00TnlrZ29GY3dtVjZqS29INmh5
-            cjBBMlFrS2EzTnhESWdwNzJvQU5CS28KLS0tIE1mQWpleGV1MjIyNWh6ZUxKMUFS
-            UEpHMitOS1JsMWpsOVN0cWsxZW1kYzQKxVw6d5smliqTG9/lZzkLo5LU+6add/dM
-            7FDa8OLLLPbijRR66/bMgEJIQRkgq0A5o8nY0qZaTbEfl2aW8dJjVg==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmSTdmeWluQTNvK1lHbjZD
-            OEt6d3pVcmJyWEhXVExGOEw3Tytsd1FKQTBBCm5GVmFIWFAweElNUmtLRmllQWR3
-            cEQ4bm15K0pWYTB6Yy9GeXlobkhqdncKLS0tIExZckJYYnF3V3krcjF2UDVEWWVj
-            aTlJNzFWdkhCUVJXcGk5bWZiRm9zTDAKrBuSJr643hBQRV4NvvO1WdpF1wJAiCKY
-            Hp8LHSoo5VwoI5nhJ4SbptsG/8I3i+wUdwobYibtD9vrzYWAmxsc2g==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUTm1ZbHFVQlQrK1N0ZzJk
-            YTlLanF2RVJpQTU2aVFxUFBMaFF2Y1d5NHpJCjc4aS8yaitzaDRKTHlGU2RzeEJr
-            Znd5RXNFOTdRQzh1QkQvUjA1c09zQnMKLS0tIEJVUkZkQm9GQmsvNmVCWWRRN21x
-            YjNuY0JDUGlGc2d3eEJaelUvVGxlUWsKTDrA9a7/fNIp8ExuhiDp6jG3gPRg0f4n
-            cn1HlNnvfB6VMi3NM5GXjI6Nys2BIq+KHTUlQVIG2XAQAbkI+XLMtw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1m2z62rwhkldycej2ljggv9zfgp79xzzhdvkv7z8ajfhkrepxyvxsr3pgea
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlaGJra2xPdW5MMi9Jd1F4
-            TnlRUTJtNncxT1RENzl3V1duMGpXNE9EdDBzCklhS01nQmVUb0g4dHczQms2LzZs
-            dVlCUTZBVHpmV1FURXNjdDkyUGRxbncKLS0tIExZd1YyMzNlUVliOXlSVDRnQmc4
-            eTNsTFYzdU9SWVp5bWFBYUh5S2o1TFkKztDUXVQDKc1n9m/MbdFMursVpnkHpkLf
-            uz9uu7YP3Ipd72++FIj/AqDZh8b0jfoGioSXamKaULYDtZ8Zs5xU5w==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRZFdMSUFyRDBKaUx3Zm9q
-            WFIyUXN6Ly9GZ09pVmpIclBmSkcxc0J6VlJvCmxmL1d0R1Z6N2JWc1VJY053WnBq
-            UEhFckhReFJzb3p5OUxTbzJVRWxHSzQKLS0tIGVPZ3R4UUxkTTdXWHlNaVlOV2FH
-            a29uRG4xbFRzZ1lMa3YwRG1XUUMxQW8K6W3l6VfjSZmfixbnih+oP92hLMCIglo9
-            QnqgjILwViSiJpunyXD2uApwI/grv1Dh4QHYubaVyvyulMAOWraBkw==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d
-    lastmodified: "2026-08-27T20:22:58Z"
-    mac: ENC[AES256_GCM,data:JzfZsKH1FkzAIGG28IcOOV4Nt9dWn+LVZdwxycX02iL/usxYWcs11cWTHMpt7CzLOfrlEdWDsF72UaAERMTsTqUM5o+fP4XSDlcywNSQdzPm0m6TKm4ecsUi59phMkecnPREvrg8CKZ/Bh4N8HrT7CsjBJQmyIjV++S+G/FRNDo=,iv:gqAo927M7R9JIlhKvfHPCBFt+Mf1H1u6qNcXdry6Ug8=,tag:nv+XRwNmyv7xDJYW8EbGYA==,type:str]
-    unencrypted_suffix: _unencrypted
-    version: 3.13.3
+  version: 3.13.3
+  lastmodified: "2026-08-27T20:22:58Z"
+  mac: ENC[AES256_GCM,data:JzfZsKH1FkzAIGG28IcOOV4Nt9dWn+LVZdwxycX02iL/usxYWcs11cWTHMpt7CzLOfrlEdWDsF72UaAERMTsTqUM5o+fP4XSDlcywNSQdzPm0m6TKm4ecsUi59phMkecnPREvrg8CKZ/Bh4N8HrT7CsjBJQmyIjV++S+G/FRNDo=,iv:gqAo927M7R9JIlhKvfHPCBFt+Mf1H1u6qNcXdry6Ug8=,tag:nv+XRwNmyv7xDJYW8EbGYA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1cDhFdmhvKzFBdjM1OFdX
+        M3hYb2x4M3FkL0IzelU5SzFSSnczMmFJSVg0ClJvd1UvaG5pRVRVYmxxTjQ2UVJx
+        UnllNC9zMWdmRW9HMFVQQVBSNExWVjAKLS0tIDRRQnh2V0hDOVl3UmsyeVd1OTls
+        N3FQMmZMdnluaDlGdndVQlN6UDduYVkKtLjWYmcdOpevxZb2B27Lg1IfQFsguVIg
+        /MauJzVHUua1W7WGCFlyauPa7tNnrqt3px0TrRZ4fnAsd3Vak8xDbw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1um232l0h8wn9mtha2qf4f4mnf7ucjayvf5qxjvynatmasg8qg5mshekvjl
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOTDcwZzlQViswTW8xQUhV
+        alhVRDlMQTNVb2RPS1M5QlF1b09oWWExeVNJCmdaVkxOcmNDaWVkZ24zbWpPUEM3
+        MGtkdHJHTUR5VmhYRXduM2x5cTlOaDAKLS0tIDlsK3U5VXNmdGxtQVc2anNRNHFF
+        SmFraGVySUFkTlhNQXZBMFgxQ3ZmOGMKZK55qoKg5qYoxsDwFK8I85dCs/Bhsime
+        RVwYX+6T+Y684xTBDeOS/IMykpGAgK9C7aaNaUnDjz9tFpx8NomyNw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1pwl9yz4k4255a4h8qz7lafce8wxhsul0cnqwmr8528fqgujlfshshv3z3g
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGOTFjakwyK2doTUhzN0xz
+        OExocEd4bW8waEVFdEl4WlU0NnVTRUt1RFcwCjlIa3dCMVNtaHpVTFpIS2Q0N0RU
+        Wnl0YjU1aktxYWNDUEZNMEo3THZPOVkKLS0tIFpYTHZMRFk0V2h5Vk53cS9TTTRV
+        SG5vRUErOE9YekpobUJaWFFBNkFHb00K/7tHeezzL1Sh3fbZ0e2kACVahCQcSxcZ
+        tHnysa1PQYREMxyg6C8x4pdqyVnAu7xH8au5xWO5Z0VEKBJBVDbKGA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1mel902ydxqv4yh798t5en336am9zwykapy8rtfvq4yprzr79t5wqzxe8ph
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGK0VHb2pPQWhFaEwxakxa
+        YnU1U3AyWkVrNUdkbHhTclhOUFpxVnhkKzA0CnJmOXFVdEJyc1hQeVJFUjVtK0Zp
+        czd3bHRabklSTGhuM0NyTjFEWGFTZkkKLS0tIDkvTWF0SWF5TzhaNzZrcmlwMVFl
+        K1NDVUxTYWxQZHppUlhFUHhub3A2T1EK6mPnH4KDHUirPWoO0O/CiHdpEXvkh5DB
+        zPz18e4c9prKFiEQPnJQ4Gr4LcKCLmljeHblGaH3H0yUWP7SZUgC6w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1fm9p4r5mug9rwk9puz7enpqap5xcrqeku6wp7atsajher559hads5wg03y
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBTml3YmZYcGhTcTdZblJJ
+        d0JIVWVPNDVLMlJ0QnRWSkgzNXZZSCtXblRrCllyekJtVElGUzhpRElVNUdGQjJz
+        UXhXaWFyRmdZRHRUOHloM1dPWTJ1SGcKLS0tIHJVNkl1V2RHejdialZvWk1YL21n
+        R00wN21scnpVdUY0aXFUdTNiNnhaUWsK/tXMAQlWdD4VyQ5JNO09dsNz/7gTp2jB
+        tsPoR2YBeMhsXzntLg5ajqCzphNFk4erlGc1LoksSfnAe4Ck/UyfZA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWdjhOZDdSUktoWmtMUFNT
+        NExpejdNd0tid09sRjYwUXM1MGQxaHBvb3pBCmxkb1YvdVErc3REVUNUL280VEQ1
+        RjJFT1hnRnpTMG5IMkMrbnlwN0xvakEKLS0tIGVKMTQxeG1CVnFiRzFwVVZCREU4
+        WjBEWnljQklTWXJYT21wYXNJVTk2V1UK2R5EKdeYg6/0vfoIL1ZgxqJL3qx+kHVU
+        C7voiKwd1k8GQqx6Pt2I7GTAXPmfQ2tMeQ4Xv8QUTWE8u4M2U6XKWA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1a4y27yc3tarlju7vg0lugnvs933wmk4hnw0udrn4499mts04qd0qvu7c3u
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHZ3hkZklNV3VVNWEyRTNI
+        YmY3QWU5Mmw2TDcvdXUwT2lTZFkvU3NWazBVCm00TnlrZ29GY3dtVjZqS29INmh5
+        cjBBMlFrS2EzTnhESWdwNzJvQU5CS28KLS0tIE1mQWpleGV1MjIyNWh6ZUxKMUFS
+        UEpHMitOS1JsMWpsOVN0cWsxZW1kYzQKxVw6d5smliqTG9/lZzkLo5LU+6add/dM
+        7FDa8OLLLPbijRR66/bMgEJIQRkgq0A5o8nY0qZaTbEfl2aW8dJjVg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1evzl6xw2n96l2xyy7jed3zlv6d4jpmytp47rpp39pjju08tep4mqqa2au5
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmSTdmeWluQTNvK1lHbjZD
+        OEt6d3pVcmJyWEhXVExGOEw3Tytsd1FKQTBBCm5GVmFIWFAweElNUmtLRmllQWR3
+        cEQ4bm15K0pWYTB6Yy9GeXlobkhqdncKLS0tIExZckJYYnF3V3krcjF2UDVEWWVj
+        aTlJNzFWdkhCUVJXcGk5bWZiRm9zTDAKrBuSJr643hBQRV4NvvO1WdpF1wJAiCKY
+        Hp8LHSoo5VwoI5nhJ4SbptsG/8I3i+wUdwobYibtD9vrzYWAmxsc2g==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age14c70j0haarha8e44zssrkd3rut0ygspqwnx42zfy0lv68he2pfms62h8a3
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUTm1ZbHFVQlQrK1N0ZzJk
+        YTlLanF2RVJpQTU2aVFxUFBMaFF2Y1d5NHpJCjc4aS8yaitzaDRKTHlGU2RzeEJr
+        Znd5RXNFOTdRQzh1QkQvUjA1c09zQnMKLS0tIEJVUkZkQm9GQmsvNmVCWWRRN21x
+        YjNuY0JDUGlGc2d3eEJaelUvVGxlUWsKTDrA9a7/fNIp8ExuhiDp6jG3gPRg0f4n
+        cn1HlNnvfB6VMi3NM5GXjI6Nys2BIq+KHTUlQVIG2XAQAbkI+XLMtw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1m2z62rwhkldycej2ljggv9zfgp79xzzhdvkv7z8ajfhkrepxyvxsr3pgea
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlaGJra2xPdW5MMi9Jd1F4
+        TnlRUTJtNncxT1RENzl3V1duMGpXNE9EdDBzCklhS01nQmVUb0g4dHczQms2LzZs
+        dVlCUTZBVHpmV1FURXNjdDkyUGRxbncKLS0tIExZd1YyMzNlUVliOXlSVDRnQmc4
+        eTNsTFYzdU9SWVp5bWFBYUh5S2o1TFkKztDUXVQDKc1n9m/MbdFMursVpnkHpkLf
+        uz9uu7YP3Ipd72++FIj/AqDZh8b0jfoGioSXamKaULYDtZ8Zs5xU5w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age16tla3k0j70er5q526nrt6kqzzw7ds62dazlsknjxuhp7q4yq3ydqhxv8gy
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRZFdMSUFyRDBKaUx3Zm9q
+        WFIyUXN6Ly9GZ09pVmpIclBmSkcxc0J6VlJvCmxmL1d0R1Z6N2JWc1VJY053WnBq
+        UEhFckhReFJzb3p5OUxTbzJVRWxHSzQKLS0tIGVPZ3R4UUxkTTdXWHlNaVlOV2FH
+        a29uRG4xbFRzZ1lMa3YwRG1XUUMxQW8K6W3l6VfjSZmfixbnih+oP92hLMCIglo9
+        QnqgjILwViSiJpunyXD2uApwI/grv1Dh4QHYubaVyvyulMAOWraBkw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1eak84xcr44yfqsg843rfu2xajxsyvjwh67a630htpnd0scy7yu5szjfh8d


### PR DESCRIPTION
## What

Backport the generic VM plumbing from the reverted catbox template into the shared containerdisk module.

## Why

PR #1230 shipped a machine-type template (later reverted in #1231) whose containerdisk block referenced module options that did not exist (`extrakernelPackages`, `extrakernelModules`, `extraPackages`, a hand-rolled growfs service). The reusable parts belong in the shared module so any containerdisk VM gets them without per-host duplication.

## Changes

- `containerdisk.kernelModules` — runtime virtio/KVM module loading (module previously only set initrd modules)
- `containerdisk.extraKernelModules` / `containerdisk.extraPackages` — extension points the template referenced
- `containerdisk.usb.enable` — USB support (usbutils + usb modules)
- `containerdisk.machineInfo.enable` — /etc/machine-info generator, wired to a target (the template's was never started)
- `kernel-module-loader` service — conditional kvm_intel/kvm_amd/nvidia loading

Skipped: growfs (native `boot.growPartition` from disk-image.nix), timesyncd (NixOS default), module-unload-on-shutdown (unsafe for virtio/kvm), TPM/LUKS entropy (host-specific knix options).

## References

Related: https://github.com/shikanime-labs/machines/pull/1230
Related: https://github.com/shikanime-labs/machines/pull/1231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cloud-init support for container disk environments, enabled by default.
  - Improved virtual machine support for USB devices and virtualization hardware.
  - Added support for Intel, AMD, and NVIDIA virtualization modules.
  - Included utilities needed for USB device management.

- **Bug Fixes**
  - Corrected secret interpolation handling in development environment configuration.
  - Preserved existing container disk image build behavior and contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->