### PR TITLE
Remove syncthing tailscale-serve service

### DIFF
--- a/modules/nixos/profiles/leader.nix
+++ b/modules/nixos/profiles/leader.nix
@@ -52,21 +52,6 @@
           ];
         in
         ashira ++ manash ++ nalsha ++ nishir;
-
-      traefik.extraConfig.ports = {
-        syncthing = {
-          port = 22000;
-          expose.default = true;
-          exposedPort = 22000;
-          protocol = "TCP";
-        };
-        syncthing-udp = {
-          port = 22000;
-          expose.default = true;
-          exposedPort = 22000;
-          protocol = "UDP";
-        };
-      };
     };
 
     # Expose RKE2 API (9345) and Kubernetes API (6443) as a single Tailscale Service.

--- a/modules/nixos/profiles/nishir.nix
+++ b/modules/nixos/profiles/nishir.nix
@@ -66,29 +66,6 @@ with lib;
       canal.backend = "host-gw";
     };
 
-    tailscale.serve.services.syncthing = {
-      endpoints."tcp:22000" = "tcp://127.0.0.1:22000";
-      advertised = true;
-    };
-  };
-
-  systemd.services.tailscale-serve-syncthing = {
-    description = "Expose RKE2 and Kubernetes APIs via Tailscale serve";
-    after = [
-      "tailscaled.service"
-      "tailscale-serve.service"
-    ];
-    wants = [ "tailscaled.service" ];
-    wantedBy = [ "multi-user.target" ];
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = true;
-      Restart = "on-failure";
-      RestartSec = "5s";
-    };
-    script = ''
-      ${getExe pkgs.tailscale} serve --yes --bg --service=svc:syncthing --https=443 https+insecure://127.0.0.1:443
-    '';
   };
 
   systemd.services.cluster-policy-route = {


### PR DESCRIPTION
## What
Drop the `syncthing` Tailscale *serve* service and its `tailscale-serve-syncthing` systemd unit (nishir), plus the orphaned Traefik `syncthing`/`syncthing-udp` port entries (leader).

## Why
syncthing now terminates directly on the tailnet via its own Tailscale BYOD Envoy Gateway (manifests PR #1844), which claims the canonical `syncthing` tailnet device name. The `tailscale.serve` syncthing service held that name and forced the Envoy data plane to collide-suffix; removing it frees `syncthing.taila659a.ts.net` for the gateway. The Traefik syncthing ports are dead once ingress moved off Traefik.

## Note
Merge in tandem with manifests #1844. Until then, the `syncthing` tailnet name is still served here and the gateway must not rename yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Removed external Syncthing access through Traefik and Tailscale.
  * RKE2 and Kubernetes API access through Tailscale remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->