### PR TITLE
Remove orphaned NFS recovery link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,6 @@ Plugins (e.g. `noctalia/translator`, the launcher `/tr` provider) are enabled
 under the same `programs.noctalia.settings.plugins.enabled` attrset — see
 [docs/noctalia-plugins.md](docs/noctalia-plugins.md).
 
-### NFS share-manager recovery
-
-When a Longhorn volume served over NFS (share-manager export) leaves pods stuck
-in `ContainerCreating` — stale ClusterIP mounts, or a wedged kubelet operation
-queue — the fix is in
-[docs/nishir-nfs-recovery.md](docs/nishir-nfs-recovery.md).
-
 ### Bitwarden biometric unlock
 
 Graphical NixOS hosts wire Bitwarden's fingerprint/PAM unlock and relocate its


### PR DESCRIPTION
## What
Remove the orphaned "NFS share-manager recovery" subsection and its relative
link to `docs/nishir-nfs-recovery.md` from `README.md`. This is a one-file change
(7 deletions, 0 insertions versus `main`).

## Why
PR #1237 (Fix rumdl-check line-length in nishir NFS recovery doc) deleted
`docs/nishir-nfs-recovery.md` but left its relative link at `README.md:101`. That
broken link fails `rumdl-check` with `MD057` and breaks the Release and
Integration CI jobs on `main` (trunk red).

The doc was intentionally removed, so the correct fix is to drop the dangling
reference rather than restore the file. Verified green via the authoritative CI
path (`nix develop ... -c 'nix fmt'` → treefmt/rumdl-check) and
`nix run nixpkgs#rumdl -- check README.md` → `Success: No issues found in 1 file`.

## References
Related: https://github.com/shikanime-labs/machines/pull/1237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the section covering recovery procedures for Longhorn NFS share-manager failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->