### PR TITLE
Enable Hermes A2A server on darwin (telsha)

### DIFF
--- a/docs/a2a-mesh.md
+++ b/docs/a2a-mesh.md
@@ -1,0 +1,83 @@
+<!-- owner: shikanime | zone: internal | purpose: document the directional A2A agent mesh and its tailnet ACL backstop across the cluster↔workstation boundary -->
+
+# A2A Agent Mesh
+
+Directional mesh of Hermes agents across the Shikanime fleet, reachable over the
+Tailscale tailnet (`*.taila659a.ts.net`). Each host runs a Hermes agent that
+exposes an A2A server on `:9900` (and an api_server on `:8642`). Tailscale
+`serve --https` terminates TLS at the funnel and forwards to the local agent;
+peers dial `https://<host>.taila659a.ts.net:9900`.
+
+## Topology
+
+- **Peers** (`modules/nixos/profiles/ai.nix` `peers`, mirrored in the
+  darwin-gated A2A block of `modules/home/workstation.nix` for telsha): ashira,
+  fushi, manash, minish, nalsha, nemishi, nixtar, sashina, kushira, nishir,
+  telsha.
+- **Cluster peers** (NixOS): the ten `*.nixos`/k8s hosts.
+- **Workstation peers**: nixtar, telsha (macOS darwin). catbox holds an issued
+  a2a token (declared in `secrets/machine.enc.yaml`) but is not part of the
+  `peers` list, so it is not dialed or trusted by the mesh.
+
+## Directional rule (the boundary)
+
+The mesh is **unidirectional at the cluster↔workstation boundary** (PR #1241):
+
+- **Clusters** dial _and_ trust every other peer except self. They are the
+  trusted core: `trusted = all peers \ self`, `outbound = all peers \ self`.
+- **Workstations** (nixtar, telsha) dial _clusters plus other workstations_
+  (outbound = all peers \ self) but **trust only other workstations**. A
+  workstation never appears in a cluster's trusted set, and a cluster never
+  accepts inbound from a workstation.
+
+This keeps the control plane (clusters) authoritative while letting workstations
+cooperate with each other (e.g. telsha ↔ nixtar) without either being able to
+command a cluster.
+
+## How it is enforced (two layers)
+
+1. **App layer** — `modules/nixos/profiles/ai.nix` and the darwin-gated A2A
+   block in `modules/home/workstation.nix` compute `trusted`/`outbound` from the
+   peer lists via `mkSelfExcludedPeers` semantics. Auth uses per-peer bearer
+   tokens (`A2A_OWN_TOKEN` + `A2A_PEER_TOKENS`) rendered from sops secrets
+   (`hermes-agent-a2a-token-<peer>`).
+2. **Network layer (backstop)** — the tailnet ACL (`tailnet/policy.hujson`)
+   denies `tag:machine → tag:workstation :9900/:8642`. If a cluster were ever
+   misconfigured to dial a workstation, the packet is dropped at the network
+   layer. The ACL `tests[]` block asserts this so a future edit cannot widen
+   access without the test job failing before apply.
+
+Reachability therefore requires both layers to agree: workstation→cluster is
+permitted by the ACL grant (`tag:automata → tag:automata :9900/:8642`) and by
+the app-layer trusted/outbound sets.
+
+## darwin enablement (telsha)
+
+telsha runs Hermes via the Home Manager `services.hermes-agent` LaunchAgent
+(nix-darwin has no `services.tailscale`, and Tailscale is the GUI app). The
+darwin wiring lives in:
+
+- `modules/home/workstation.nix` — the A2A settings, sops token templates, and
+  peer-key env are folded into `services.hermes-agent` (and `sops.secrets`/
+  `sops.templates`) under a `pkgs.stdenv.isDarwin` gate, with `hostName` fixed
+  to `telsha` (the Home Manager config has no `networking.hostName`). This file
+  is shared with the NixOS hosts, so the gate keeps the A2A surface darwin-only.
+- `modules/darwin/profiles/workstation.nix` — the `launchd.daemons` oneshots
+  that `tailscale up --advertise-tags=tag:automata,tag:workstation` and
+  `tailscale serve --https=9900/8642` to localhost. No nix-darwin firewall
+  opening is needed (the agent listens on localhost; Tailscale forwards the
+  funnel).
+
+## Operation
+
+- **Add a peer**: append to `peers` in `modules/nixos/profiles/ai.nix` AND the
+  darwin-gated A2A `a2aPeers` block in `modules/home/workstation.nix`, then
+  issue the a2a-token + api-server secrets in every host's sops file
+  (`secrets/<host>.enc.yaml` for NixOS; `secrets/shikanime.enc.yaml` for the
+  darwin user). The fleet learns the new token automatically via
+  `mkA2aPeerTokens`.
+- **Tag a host**: a workstation must carry `tag:automata` (and
+  `tag:workstation`) for the ACL grants/denies to cover it. Tags are set
+  out-of-band in the Tailscale control plane, not in nix.
+- **Verify reachability**: from a workstation,
+  `curl -H "Authorization: Bearer $A2A_OWN_TOKEN" https://<cluster>.taila659a.ts.net:9900/.well-known/agent.json`.

--- a/modules/darwin/profiles/workstation.nix
+++ b/modules/darwin/profiles/workstation.nix
@@ -71,4 +71,42 @@
       StandardErrorPath = "/var/log/tailscale-serve-lmstudio.log";
     };
   };
+
+  # A2A agent mesh (telsha). The Hermes agent serves plain HTTP on :9900 and
+  # the api_server on :8642; Tailscale serve terminates TLS and forwards to
+  # localhost, so peers reach https://telsha.taila659a.ts.net:9900. Advertise
+  # the automata + workstation tags so the tailnet ACL grants/deny backstop
+  # cover this host. Idempotent; re-applied at boot.
+  launchd.daemons.tailscale-up-a2a = {
+    command = "/Applications/Tailscale.app/Contents/MacOS/Tailscale up --advertise-tags=tag:automata,tag:workstation";
+    serviceConfig = {
+      Label = "org.nixos.tailscale-up-a2a";
+      RunAtLoad = true;
+      KeepAlive = false;
+      StandardOutPath = "/var/log/tailscale-up-a2a.log";
+      StandardErrorPath = "/var/log/tailscale-up-a2a.log";
+    };
+  };
+
+  launchd.daemons.tailscale-serve-a2a = {
+    command = "/Applications/Tailscale.app/Contents/MacOS/Tailscale serve --yes --bg --https=9900 http://127.0.0.1:9900";
+    serviceConfig = {
+      Label = "org.nixos.tailscale-serve-a2a";
+      RunAtLoad = true;
+      KeepAlive = false;
+      StandardOutPath = "/var/log/tailscale-serve-a2a.log";
+      StandardErrorPath = "/var/log/tailscale-serve-a2a.log";
+    };
+  };
+
+  launchd.daemons.tailscale-serve-api = {
+    command = "/Applications/Tailscale.app/Contents/MacOS/Tailscale serve --yes --bg --https=8642 http://127.0.0.1:8642";
+    serviceConfig = {
+      Label = "org.nixos.tailscale-serve-api";
+      RunAtLoad = true;
+      KeepAlive = false;
+      StandardOutPath = "/var/log/tailscale-serve-api.log";
+      StandardErrorPath = "/var/log/tailscale-serve-api.log";
+    };
+  };
 }

--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -21,6 +21,157 @@ let
 
   hermesLcmPlugin = import ../../pkgs/hermes-plugin-lcm { inherit pkgs; };
   rtkRewritePlugin = import ../../pkgs/hermes-plugin-rtk-rewrite { inherit pkgs; };
+
+  # A2A peer mesh (darwin-only, telsha). Mirrors modules/nixos/profiles/ai.nix
+  # `peers`; the Home Manager config has no networking.hostName, so the host
+  # name is fixed here. Shared symmetric tokens live in secrets/shikanime.enc.yaml
+  # (copied from secrets/machine.enc.yaml), so values must match the fleet.
+  a2aHostName = "telsha";
+  a2aPeers = [
+    {
+      name = "ashira";
+      capabilities = [
+        "build"
+        "build-x86"
+        "k8s-follower"
+      ];
+    }
+    {
+      name = "fushi";
+      capabilities = [
+        "build"
+        "build-arm"
+        "k8s-node"
+      ];
+    }
+    {
+      name = "manash";
+      capabilities = [
+        "build"
+        "build-x86"
+        "k8s-leader"
+      ];
+    }
+    {
+      name = "minish";
+      capabilities = [
+        "build"
+        "build-arm"
+        "k8s-node"
+      ];
+    }
+    {
+      name = "nalsha";
+      capabilities = [
+        "build"
+        "build-x86"
+        "k8s-follower"
+      ];
+    }
+    {
+      name = "nemishi";
+      capabilities = [
+        "build"
+        "build-arm"
+        "k8s-node"
+      ];
+    }
+    {
+      name = "nixtar";
+      capabilities = [
+        "graphical"
+        "media"
+        "nvidia"
+        "k8s-leader"
+      ];
+    }
+    {
+      name = "sashina";
+      capabilities = [
+        "build-x86"
+        "k8s-node"
+      ];
+    }
+    {
+      name = "kushira";
+      capabilities = [
+        "build-x86"
+        "k8s-node"
+      ];
+    }
+    {
+      name = "nishir";
+      capabilities = [
+        "build-x86"
+        "k8s-leader"
+      ];
+    }
+    {
+      name = "telsha";
+      capabilities = [
+        "command"
+        "workstation"
+        "darwin"
+      ];
+    }
+  ];
+
+  a2aOtherPeers = builtins.filter (p: p.name != a2aHostName) a2aPeers;
+
+  mkA2aTrustedPeers = peers': lib.concatStringsSep "," (map (p: p.name) peers');
+
+  mkA2aAgent =
+    { name, capabilities }:
+    {
+      inherit capabilities;
+      url = "https://${name}.taila659a.ts.net:9900";
+      auth = {
+        type = "bearer";
+        token = "\\${"env:A2A_OWN_TOKEN"}";
+      };
+    };
+
+  mkA2aAgents =
+    peers': builtins.listToAttrs (map (peer: lib.nameValuePair peer.name (mkA2aAgent peer)) peers');
+
+  mkA2aPeerToken =
+    peer: "${peer.name}:${config.sops.placeholder."hermes-agent-a2a-token-${peer.name}"}";
+
+  mkA2aPeerTokens = peers': lib.concatStringsSep "," (map mkA2aPeerToken peers');
+
+  mkA2aTokenSecretName = peer: "hermes-agent-a2a-token-${peer}";
+
+  mkPeerApiServerKeyName = peer: "hermes-agent-api-server-key-${peer}";
+
+  mkBotPeers =
+    peers':
+    builtins.listToAttrs (
+      map (
+        peer:
+        lib.nameValuePair peer.name {
+          url = "https://${peer.name}.taila659a.ts.net:8642";
+        }
+      ) peers'
+    );
+
+  mkPeerKeyEnvs =
+    peers':
+    lib.concatStringsSep "\n" (
+      map (
+        peer:
+        let
+          secretName = mkPeerApiServerKeyName peer.name;
+        in
+        "HERMES_PEER_${lib.toUpper peer.name}_KEY=${config.sops.placeholder.${secretName}}"
+      ) peers'
+    );
+
+  a2aBasePlugins = [
+    "disk-cleanup"
+    "hermes-lcm"
+    "rtk-rewrite"
+    "security-guidance"
+  ];
 in
 {
   catppuccin = {
@@ -108,191 +259,239 @@ in
   };
 
   # Hermes Agent — declarative config ported from modules/nixos/profiles/ai.nix,
-  # minus the fleet/gateway/automation surface (matrix, a2a, bot_peers,
-  # platforms, platform_toolsets, honcho memory, sops environmentFiles).
-  # backend.mode defaults to "none" and gateway.enable defaults to false, so
-  # enabling the service writes config.yaml without launching any daemon.
-  services.hermes-agent = {
-    enable = true;
+  # minus the fleet/gateway/automation surface (matrix, bot_peers, platforms,
+  # platform_toolsets, honcho memory, sops environmentFiles) on non-darwin
+  # hosts. The A2A surface (server + peer mesh) is added only on darwin via
+  # recursiveUpdate so the base config is unchanged elsewhere.
+  services.hermes-agent =
+    let
+      basePlugins = a2aBasePlugins;
+    in
+    lib.recursiveUpdate
+      {
+        enable = true;
 
-    extraPlugins = [
-      hermesLcmPlugin
-      rtkRewritePlugin
-    ];
+        extraPlugins = [
+          hermesLcmPlugin
+          rtkRewritePlugin
+        ];
 
-    extraPackages = with pkgs; [
-      agent-browser
-      curl
-      gh
-      git
-      nodejs
-      rtk
-      yarn
-    ];
+        extraPackages = with pkgs; [
+          agent-browser
+          curl
+          gh
+          git
+          nodejs
+          rtk
+          yarn
+        ];
 
-    extraDependencyGroups = [
-      "anthropic"
-      "computer-use"
-    ];
+        extraDependencyGroups = [
+          "anthropic"
+          "computer-use"
+        ];
 
-    settings = {
-      context.engine = "lcm";
+        settings = {
+          context.engine = "lcm";
 
-      custom_providers = [
-        {
-          name = "aperture-anthropic";
-          base_url = "https://ai.taila659a.ts.net/v1";
-          api_mode = "anthropic_messages";
-          model = "glm-4.7";
-          models = [
-            "glm-4.7"
-            "glm-5.2"
+          custom_providers = [
+            {
+              name = "aperture-anthropic";
+              base_url = "https://ai.taila659a.ts.net/v1";
+              api_mode = "anthropic_messages";
+              model = "glm-4.7";
+              models = [
+                "glm-4.7"
+                "glm-5.2"
+              ];
+            }
+            {
+              name = "aperture-openai";
+              base_url = "https://ai.taila659a.ts.net/v1";
+              api_mode = "chat_completions";
+              model = "tencent/hy3:free";
+              models = [
+                "deepseek/deepseek-v4-flash"
+                "gemini-2.5-flash"
+                "gemini-2.5-flash-lite"
+                "gemini-2.5-pro"
+                "gemini-3-flash-preview"
+                "google/gemma-4-e2b"
+                "inclusionai/ling-3.0-flash:free"
+                "labs-leanstral-1-5"
+                "nvidia/nemotron-3-ultra-550b-a55b:free"
+                "openrouter/openrouter/free"
+                "poolside/laguna-xs-2.1:free"
+                "qwen/qwen3-8b"
+                "stepfun/step-3.7-flash:free"
+                "tencent/hy3:free"
+              ];
+            }
           ];
-        }
-        {
-          name = "aperture-openai";
-          base_url = "https://ai.taila659a.ts.net/v1";
-          api_mode = "chat_completions";
-          model = "tencent/hy3:free";
-          models = [
-            "deepseek/deepseek-v4-flash"
-            "gemini-2.5-flash"
-            "gemini-2.5-flash-lite"
-            "gemini-2.5-pro"
-            "gemini-3-flash-preview"
-            "google/gemma-4-e2b"
-            "inclusionai/ling-3.0-flash:free"
-            "labs-leanstral-1-5"
-            "nvidia/nemotron-3-ultra-550b-a55b:free"
-            "openrouter/openrouter/free"
-            "poolside/laguna-xs-2.1:free"
-            "qwen/qwen3-8b"
-            "stepfun/step-3.7-flash:free"
-            "tencent/hy3:free"
+
+          fallback_providers = [
+            {
+              api_mode = "chat_completions";
+              model = "inclusionai/ling-3.0-flash:free";
+              provider = "custom:aperture-openai";
+            }
+            {
+              api_mode = "chat_completions";
+              model = "poolside/laguna-s-2.1:free";
+              provider = "custom:aperture-openai";
+            }
+            {
+              api_mode = "chat_completions";
+              model = "labs-leanstral-1-5";
+              provider = "custom:aperture-openai";
+            }
+            {
+              api_mode = "chat_completions";
+              model = "stepfun/step-3.7-flash:free";
+              provider = "custom:aperture-openai";
+            }
+            {
+              api_mode = "chat_completions";
+              model = "tencent/hy3:free";
+              provider = "custom:aperture-openai";
+            }
           ];
-        }
-      ];
 
-      fallback_providers = [
-        {
-          api_mode = "chat_completions";
-          model = "inclusionai/ling-3.0-flash:free";
-          provider = "custom:aperture-openai";
-        }
-        {
-          api_mode = "chat_completions";
-          model = "poolside/laguna-s-2.1:free";
-          provider = "custom:aperture-openai";
-        }
-        {
-          api_mode = "chat_completions";
-          model = "labs-leanstral-1-5";
-          provider = "custom:aperture-openai";
-        }
-        {
-          api_mode = "chat_completions";
-          model = "stepfun/step-3.7-flash:free";
-          provider = "custom:aperture-openai";
-        }
-        {
-          api_mode = "chat_completions";
-          model = "tencent/hy3:free";
-          provider = "custom:aperture-openai";
-        }
-      ];
+          model = {
+            default = "tencent/hy3:free";
+            provider = "custom:aperture-openai";
+            base_url = "https://ai.taila659a.ts.net/v1";
+          };
 
-      model = {
-        default = "tencent/hy3:free";
-        provider = "custom:aperture-openai";
-        base_url = "https://ai.taila659a.ts.net/v1";
-      };
+          auxiliary = {
+            vision = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            web_extract = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            compression = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            skills_hub = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            approval = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            mcp = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            title_generation = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            memory_query_rewrite = {
+              provider = "custom:aperture-anthropic:openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            tts_audio_tags = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            triage_specifier = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            kanban_decomposer = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            profile_describer = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+            curator = {
+              provider = "custom:aperture-openai";
+              model = "tencent/hy3:free";
+              base_url = "https://ai.taila659a.ts.net/v1";
+            };
+          };
 
-      auxiliary = {
-        vision = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        web_extract = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        compression = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        skills_hub = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        approval = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        mcp = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        title_generation = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        memory_query_rewrite = {
-          provider = "custom:aperture-anthropic:openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        tts_audio_tags = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        triage_specifier = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        kanban_decomposer = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        profile_describer = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        curator = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-      };
+          mcp_servers.aperture = {
+            url = "https://ai.taila659a.ts.net/v1/mcp";
+            enabled = true;
+          };
 
-      mcp_servers.aperture = {
-        url = "https://ai.taila659a.ts.net/v1/mcp";
-        enabled = true;
-      };
+          display = {
+            interface = "tui";
+            streaming = true;
+          };
 
-      display = {
-        interface = "tui";
-        streaming = true;
-      };
+          plugins.enabled = basePlugins;
+        };
+      }
+      (
+        lib.optionalAttrs pkgs.stdenv.isDarwin {
+          environmentFiles = [
+            config.sops.templates.hermes-agent-a2a-env.path
+            config.sops.templates.hermes-agent-peer-keys-env.path
+          ];
 
-      plugins.enabled = [
-        "disk-cleanup"
-        "hermes-lcm"
-        "rtk-rewrite"
-        "security-guidance"
-      ];
-    };
-  };
+          settings = {
+            platforms.a2a.enabled = true;
+            a2a_agents = mkA2aAgents a2aOtherPeers;
+            bot_peers = mkBotPeers a2aOtherPeers;
+            platform_toolsets = {
+              cli = [
+                "hermes-cli"
+                "a2a"
+              ];
+              api_server = [
+                "hermes-api-server"
+                "a2a"
+              ];
+            };
+            plugins.enabled = basePlugins ++ [ "platforms/a2a-platform" ];
+          };
+        }
+      );
 
   xdg.enable = true;
+  sops = lib.mkIf pkgs.stdenv.isDarwin {
+    secrets = builtins.listToAttrs (
+      (map (p: lib.nameValuePair (mkA2aTokenSecretName p.name) { }) a2aPeers)
+      ++ (map (p: lib.nameValuePair (mkPeerApiServerKeyName p.name) { }) a2aPeers)
+    );
+
+    templates = {
+      hermes-agent-a2a-env = {
+        content = ''
+          A2A_HOST=0.0.0.0
+          A2A_PORT=9900
+          A2A_AGENT_NAME=${a2aHostName}
+          A2A_PUBLIC_URL=https://${a2aHostName}.taila659a.ts.net:9900
+          A2A_OWN_TOKEN=${config.sops.placeholder."${mkA2aTokenSecretName a2aHostName}"}
+          A2A_PEER_TOKENS=${mkA2aPeerTokens a2aOtherPeers}
+          A2A_TRUSTED_PEERS=${mkA2aTrustedPeers a2aOtherPeers}
+        '';
+      };
+      hermes-agent-peer-keys-env = {
+        content = toString (mkPeerKeyEnvs a2aOtherPeers);
+      };
+    };
+  };
 }

--- a/secrets/shikanime.enc.yaml
+++ b/secrets/shikanime.enc.yaml
@@ -1,9 +1,31 @@
 cachix-token: ENC[AES256_GCM,data:dwXGa5vw/rMwCj2hXQOGR+qxrc29gMKpqATFm4gmIBKJ5A36Hav2Sib8SNU6NwhvHXi79scQLE/wt8Qyn9M1JH+IgoI44Qbde5sWCBtoYHNJFC3Ai1uhYKqWgv4AUAkBndi2PtSguZe1a+sM69QgXnlY8AAkHM/y7CXShBLQ97kGo8ma/+7u+mzHTablMz23Hw==,iv:4wqET0AwsNOSKSZENOwrMnDtL98JXqhSrSDG8DOJoqU=,tag:VI6pUkNx/1Wm0+yEGix6Zg==,type:str]
 github-token: ENC[AES256_GCM,data:Go4qeh7pk3aLDuGStx5P7FCZ79zqjUCk4loGYw4Nev2jdunWb6wWKA==,iv:Bli3zECdAmBPP7oD95YssvCaaw7kYNA+p3/qjDjchSw=,tag:piXnXxaQFYvbNNmke758hA==,type:str]
+hermes-agent-a2a-token-ashira: ENC[AES256_GCM,data:571Vg2RNtYmgYlI8OpwfNUDaTkZ+XSWWwkCdJMnEsM741bgVSU0B8NCpdPLCL8SyLqwQO/KETJc8kOpg0SVSfg==,iv:aRfRfe7n+sPmvj5Blk6cGOIVozwWda9O344Glz8mFBo=,tag:2Km0x4pndNJDIrstiPCgSQ==,type:str]
+hermes-agent-a2a-token-fushi: ENC[AES256_GCM,data:n+qUloMpPd0/gssEts7rpSS8r1tYvSIbpkHqb1BpSOl92aKRXB3KKWYYk6+5OtQnUv4pMCgIncqvGOtyVLjIUw==,iv:V6xWnOdQC9Xyn5f/MPU13WiYU2Pi892DuMJEgNiNRtQ=,tag:yzUqIW+suBOrZ5/PsKfVrA==,type:str]
+hermes-agent-a2a-token-kushira: ENC[AES256_GCM,data:dzZG0FJVsOjpUCzo9b+1USPptixCmE7v1x25GjXOHtz+o9YzbcpxklWmQ5YS/eeSboYqp+NpPt48GCveF3LWJA==,iv:X7jPZZnF+Y2GsMflgPHjwiUFFTuYE46Y/SvKYHprjyw=,tag:kznw1XaBvXAldslWrA4+BA==,type:str]
+hermes-agent-a2a-token-manash: ENC[AES256_GCM,data:lURv/G4o1tQiuT+ivlbra59AA/2NZpG7ddyHKg7WnuKY270W79C6QPUDtgMWnm55jUY31xOXMz4znZqv9mDEEQ==,iv:o1NDek2J/GUPW6z45ahBiT5eV3BaZXUZlj4ICrOZQqE=,tag:MJ9yLRZE/yfh1MZHUBsHHg==,type:str]
+hermes-agent-a2a-token-minish: ENC[AES256_GCM,data:CwNv2ahk+q0N03Ttxq4MRf4iXgLgVfJgYY4A2drjbH1gFNKlfWMEx5B9LHHJdecwVuPV6C6OdHdfuTYN77BcdQ==,iv:XRYcHHzAos3GApW04aYe50+7yPYWGEN666jrYBgRbg0=,tag:NFl2mERVEFTK/HkgxQ5wmw==,type:str]
+hermes-agent-a2a-token-nalsha: ENC[AES256_GCM,data:o90Ao0o0oSZQmuhVn72ENKA13h289FJKhHfsIbLTPHt6CubdGN4tsrMAq548YgXoRwilgIdsmc3UD212bPKwyw==,iv:awJX1JgVGf7WRIr0mVKlvrArE8FPbJzvzrIcVIYd19g=,tag:/0pgOeX3bTZMM8sbjAscog==,type:str]
+hermes-agent-a2a-token-nemishi: ENC[AES256_GCM,data:fzMHsxqpE4XadvAe8UKf5cHvZYzg4is8IayCp9+ByMCn81dRdBWIoOH3fA1RvPh+WP87oyaoyynHyOz02yz+Mw==,iv:+RSCCk5wDClbbsjgsCWzve/bMyoXapXFzHCHS/nFHbc=,tag:rYgz0fYM4TRk+3LRFkYpGA==,type:str]
+hermes-agent-a2a-token-nishir: ENC[AES256_GCM,data:uFH2wKKcpDTmLAzOHVQdnvkLvLFApXPiO8Sdbvkq/hpL8n+JUqwXXhteynfI6O4MluCkedzyIhTkc3y9RLKCHw==,iv:LNc/ZY3+SsVBc7Th5Ay2A1x7ljCtZwpZu7yOo3+3SQ0=,tag:I1GG1k/xNMhJgQ0ggvhwXw==,type:str]
+hermes-agent-a2a-token-nixtar: ENC[AES256_GCM,data:Na8op7AFov4UuEU4PzAdWp4/rRzEttSe7Cj1Cpj4neZnp9In3aV9CFuCzO+JyO7MUdLDgpJ4WS598aFEd59mnA==,iv:PIr6iTX6Cpvdn8Wfz375GzpEVNSBJWV8CdCLCwjvmkE=,tag:oH9/rqhCx1q7WNbda36YYQ==,type:str]
+hermes-agent-a2a-token-sashina: ENC[AES256_GCM,data:hb18nJYFdFKNAiiZkx1cUst5oWO0UGt+cfEN8isKrUC9FRTSNKHcCV+JxLBx2DGKdLZEoXi3sqw4mpyy96j8lw==,iv:NNgo2XZvwadpI08hK/fpmaM4Q+Icjaf3+8al+E7yegc=,tag:kiC+k8FESQJNUvziNfyY3A==,type:str]
+hermes-agent-a2a-token-telsha: ENC[AES256_GCM,data:eKKr24whaDFtoXVKkf9u0RT/9vjUCWo0aUSq2/bPOKQaLkszXLGxiQOytnd3N0PQd8ZsOszPaWPYO8IGE3YhcA==,iv:h7XOy1Otz0AfotILUS9dJw0tjEKpl19+NzN0gPZdxRE=,tag:qQi6/H3DAF5Zs2kiqjgxAw==,type:str]
+hermes-agent-api-server-key-ashira: ENC[AES256_GCM,data:qw2VlNluzKyF1n0CRhozbr20366JC1+bH5xoDA7G1AOIUB4uCfHzD0QeDfVQ7tbf,iv:92AcBC+Vyu1F5UplGtrBYoooJg1c/v/222SApXw3omY=,tag:MkZRLaS2+oQLMzgH64LM3A==,type:str]
+hermes-agent-api-server-key-fushi: ENC[AES256_GCM,data:JuRDTGxGqTdHCTxGwNqE4IRc3z59BwC5TDL2ll0DSYD3bq24r4GDQt0FEraYm94=,iv:U1UgLbm0TFcr/75/Y6azP1BGmhx9Z26TSdjxtue/4Ok=,tag:r+xhoCDYh82wkIvBrVEXtA==,type:str]
+hermes-agent-api-server-key-kushira: ENC[AES256_GCM,data:E5H4vFw0rZ1SP4WH9LHpIxRvqwDg7g==,iv:K0v68GK+y0JJL/In5L+zaluW3rudZSVeFuv/OK4e+2w=,tag:ouiHTsZ0EN+g2io0X4HSAw==,type:str]
+hermes-agent-api-server-key-manash: ENC[AES256_GCM,data:R2f+6dWi5RXBPjOZD7bP+ckuUW71RG/LqDZHvO5kFhTyVkvYBHJs9csvMfpicg==,iv:2QW0hhz36V2ERp0cDJOV3SG83E/E71gehh/E2W7bTRc=,tag:bLpv7b/oOQXsXX4plvYVww==,type:str]
+hermes-agent-api-server-key-minish: ENC[AES256_GCM,data:qHyxV6KtqNsO922cy8YhgcOLM1BWSkHcra3YpCykeDerZyaorOkwdAVrlsjLUA==,iv:qT9L2gJtCfiQdED20P9DRv4daY+gfkPp0nV1nk8u14A=,tag:dqzmZo1c8+HLOFa7RPof/g==,type:str]
+hermes-agent-api-server-key-nalsha: ENC[AES256_GCM,data:8Ea1MY66MxySnBDCgJlE6c2LLLztdgoe10Sqe4unsGiWKJryxiIR4IhXyChn2eI=,iv:xdCjhcd5PaqgmM8S7CitZIszaf/tKHSSobm2JAXseCs=,tag:5qd8BhDJ989yblsflcRYGQ==,type:str]
+hermes-agent-api-server-key-nemishi: ENC[AES256_GCM,data:KsMzLLo/jwj6YHxFLkM/3+2477Fbb7j06+YMlOHgGGOl0YeFOoyuGeYfDlksQQ==,iv:uH1Ta9gKsw0v4z0kTvWuPyj3sX6zFlGiKRuNlEzkufY=,tag:3GSRK2hxagJhU50Mq9DJ2Q==,type:str]
+hermes-agent-api-server-key-nishir: ENC[AES256_GCM,data:0yddwUuZHvRjE1/rO1pkgSsKATKVKECZkdpxLVeUbsedrWXmN2KI1j2RCEwrsnldwGX+T8cHCwLiBbVWufeSmA==,iv:kEnytJcUbWbGz/sVI5VZw75N76umDJ1rK8zD9v2Urs0=,tag:BB2dw+qW/v2BgJpK+fY7SQ==,type:str]
+hermes-agent-api-server-key-nixtar: ENC[AES256_GCM,data:aAOiXR/PDVfyPyrjEfw4G1Qy78q2R5POFfx0ILBAAZRMg+Qiz91XD3oOMMpT,iv:NgMtBP7CowanGE6m9UTFW0jCs4edIDbkwOBc90JUbRA=,tag:2yX1zTPd73nPnvW5IxyCVQ==,type:str]
+hermes-agent-api-server-key-sashina: ENC[AES256_GCM,data:k9VvAAE0m37UK7Qwvkiw3sf10eQ76Q==,iv:8DgCQcJJtDGG8QNG6WSUG2xWajkmGg8q6WbyG5AH2mk=,tag:pJSYVCgtIt3VD+OGK/9jNA==,type:str]
+hermes-agent-api-server-key-telsha: ENC[AES256_GCM,data:oozu95arI7xb3FodaSOJySukOTZ3+fxT4klwMHBrLytmMfwcZ5bYysmCt4DM/Tv7DwZpLmyNrRGeweMLvScKSA==,iv:Sg/jyiOV9zKaZovCxs580l85LwkCqYh/398YMhEHuR4=,tag:oJV9Zrj0dT/UZUndsyEEwA==,type:str]
 sops:
   version: 3.13.3
-  lastmodified: "2026-08-07T11:20:56Z"
-  mac: ENC[AES256_GCM,data:8OIanVJyek9qvLqSNZ4CQ6g8cyrsP4nHb+ixh4BR4GRO+9P3FEBnXliHqQ+rL8lju4aKF8qeGjpkN7Qv1HeP868AluC6jfbeikLJG42s5H6dSDWu7RWP9z2gk44Xsnqkyxvbd0IITaHWhMRNl3CAPEFQvOxa23zth0X00DJzqko=,iv:MgZ/yAblP+ZZIH6TZ1gUMvMttiIOrKrosfqgcX9kzFw=,tag:DQvYzjFrOR52rGd8vbuL0Q==,type:str]
+  lastmodified: "2026-08-29T15:27:12Z"
+  mac: ENC[AES256_GCM,data:uInjM9rfLxMksc865pumool+JJP6eSEx6cwF55tEpROEl0RIaHT1cTbuH2iczyPbRJjENSRFaM21XQGyuxf8dhQ1khfKh+fVcFFhoBhBIqoe9f2t4Zlg0fo0xYorrx9Mzt4ykob11akuoGkk9lvtGm+x5skccaHoK6iwByIZvac=,iv:OwKBLzfFfFPfj6D6jhzDKG3jXRKKNjg9A721NLESLHg=,tag:a3GFeRrsNJRzRaVto4O81Q==,type:str]
   unencrypted_suffix: _unencrypted
   age:
     - enc: |


### PR DESCRIPTION
## Summary

Enable the Hermes A2A agent server on the darwin workstation **telsha**, folding
the A2A configuration into the shared `workstation.nix` modules rather than new
standalone modules. The A2A surface is **darwin-gated** so NixOS hosts that
import `home/workstation.nix` (via `automata.nix` / `shika.nix` / `meika.nix`)
are unaffected.

This closes the darwin half of the directional A2A mesh from #1241 (cluster↔
workstation boundary). telsha serves its Agent Card + JSON-RPC on `:9900` and
its api_server on `:8642`, with Tailscale `serve` terminating TLS and
forwarding to localhost; peers reach `https://telsha.taila659a.ts.net:9900`.

## Changes

- `modules/home/workstation.nix` — A2A block (peer list, `mkA2aAgents` /
  `mkBotPeers` / `mkA2aPeerTokens`, `services.hermes-agent` settings with
  `platforms.a2a.enabled`, `a2a_agents`, `bot_peers`, `platform_toolsets`,
  `plugins`, sops `hermes-agent-a2a-env` + `hermes-agent-peer-keys-env`
  templates) folded in under a `pkgs.stdenv.isDarwin` gate. `hostName` is
  hardcoded to `telsha` (Home Manager has no `networking.hostName`).
- `modules/darwin/profiles/workstation.nix` — three launchd daemons:
  `tailscale-up-a2a` (advertise `tag:automata,tag:workstation`),
  `tailscale-serve-a2a` (`:9900`), `tailscale-serve-api` (`:8642`).
- `secrets/shikanime.enc.yaml` — 22 A2A entries (11
  `hermes-agent-a2a-token-*` + 11 `hermes-agent-api-server-key-*`) copied from
  `secrets/machine.enc.yaml` with **canonical values** (no new tokens minted,
  so mutual auth against the cluster mesh stays valid).
- `docs/a2a-mesh.md` — topology + enforcement notes; darwin enablement and the
  add-a-peer procedure reference the `workstation.nix` files.

## Verification

- `nix eval` of `darwinConfigurations.telsha`: `platforms.a2a.enabled = true`,
  10 `a2a_agents` (self excluded), `plugins.enabled` includes
  `platforms/a2a-platform`, both sops templates present, 22 A2A secrets,
  `environmentFiles` resolves to the rendered template paths, and the 3 A2A
  launchd daemons are present.
- `nix eval` of `nixosConfigurations.nixtar` (imports `home/workstation.nix`
  via `meika.nix`/`shika.nix`): `a2a_agents` absent, no A2A sops templates —
  the darwin gate holds.

## Out-of-band follow-ups (not in this PR)

- Tag `nixtar` + `telsha` `tag:automata` (and `tag:workstation`) in the
  Tailscale console so the ACL grant/deny backstop covers them.
- Tailnet ACL PR: deny `tag:machine → tag:workstation :9900/:8642` as a
  backstop (WIP in the `tailnet` repo).

Related: #1242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure agent-to-agent connectivity for macOS workstations, enabling communication between configured Hermes agents and services.
  - Added automatic workstation startup configuration for secure A2A and API access.
  - Added trusted peer communication with authenticated access and encrypted credentials.

- **Documentation**
  - Added operational guidance for configuring the mesh, adding peers, applying access controls, and verifying connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->