### PR TITLE
Add in-repo docs for the Machines project

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,37 @@
+<!-- owner: shikanime | zone: internal | purpose: machine config architecture -->
+
+# Architecture
+
+`machines` is the Nix flake source of truth for every host Shikanime manages —
+NixOS, nix-darwin, and shared Home Manager modules. The working copy is the
+system; `comin` declaratively deploys it to hosts.
+
+## Layers
+
+- `flake.nix` — entry point; imports module sets and exposes host configs and
+  build outputs (flake-parts + devlib).
+- `hosts/` — per-machine entry points:
+  - `hosts/<name>/configuration.nix` — NixOS host
+  - `hosts/telsha/darwin-configuration.nix` — nix-darwin host
+  - `hosts/<name>/users/<user>/home-configuration.nix` — Home Manager
+  - `hosts/<name>/facter.json` — hardware facts for `nixos-facter` hosts
+- `modules/` — shared profiles:
+  - `modules/nixos/` — `base`, `minimal`, `workstation`, `follower`,
+    `distributed`, `nishir`/`talashi` cluster profiles, `ai` (hermes-agent +
+    computer-use `cua-driver`)
+  - `modules/darwin/` — macOS host profiles
+  - `modules/home/` — shared Home Manager modules
+  - `modules/flake/` — flake-parts glue
+- `secrets/` — `sops-nix` encrypted `*.enc.yaml`; decrypted at eval/activation.
+- `infra/`, `pkgs/`, `skaffold.yaml` — cluster glue, local packages, automation.
+
+## Hosts
+
+`ashira`, `manash`, `nalsha` (x86_64 servers), `fushi`, `minish`, `nemishi`
+(ARM), `kushira`/`sashina` (Strix Halo inference), `nixtar` (GUI workstation),
+`catbox` (KubeVirt containerdisk), `telsha` (nix-darwin).
+
+## Deployment
+
+`comin` pulls the flake and switches each host; ARM and x86_64 share profiles
+but differ in the flake `systems` list.

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -1,0 +1,34 @@
+<!-- owner: shikanime | zone: internal | purpose: local setup and build/switch loop -->
+
+# Development
+
+## Prerequisites
+
+- Nix with flakes enabled, `direnv`, and the repo's SOPS age key to read
+  `secrets/`.
+
+## Local loop
+
+1. `direnv allow` (or `nix develop`) to enter the dev shell.
+2. Edit host/module Nix; keep one logical change per commit.
+3. `nix fmt` to format.
+4. `nix flake check --accept-flake-config --no-pure-eval` — the flags are
+   required (pure eval fails on comin / Nix access-token wiring).
+
+## Build and switch
+
+```sh
+# build a host's toplevel
+nix build .#nixosConfigurations.manash.config.system.build.toplevel
+# switch a NixOS host
+sudo nixos-rebuild switch --flake .#manash
+# switch the darwin host
+darwin-rebuild switch --flake .#telsha
+```
+
+## VCS
+
+Primary VCS is Jujutsu (`.jj`): `jj describe -m "<msg>"` stamps the working
+copy, `jj diff --git` reviews. Commits are DCO- and GPG-signed; add a
+`Reviewed-by:` trailer when pushing via git. Large work splits into a `gh stack`
+of PRs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,26 @@
+<!-- owner: shikanime | zone: internal | purpose: index of the internal-ops docs zone -->
+
+# Machines — Internal Docs
+
+## Internal ops
+
+- [Architecture](./Architecture.md) — flake, hosts, modules, secrets, deploy
+- [Development](./Development.md) — local setup and build/switch loop
+- [Runbook](./Runbook.md) — deploy hosts and manage secrets
+- [Troubleshooting](./Troubleshooting.md) — known failure modes
+- [Reference](./Reference.md) — flake outputs and command surface
+
+## Operational notes (pre-existing)
+
+- [bitwarden-biometric.md](./bitwarden-biometric.md)
+- [inference.md](./inference.md)
+- [nemishi-firmware-spam.md](./nemishi-firmware-spam.md)
+- [nemishi-nvme-probe.md](./nemishi-nvme-probe.md)
+- [network-interfaces.md](./network-interfaces.md)
+- [network-performance-remediation.md](./network-performance-remediation.md)
+- [noctalia-plugins.md](./noctalia-plugins.md)
+- [rpi5-nixos.md](./rpi5-nixos.md)
+
+## User-facing docs
+
+- [README.md](../README.md) — full directory layout and usage

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -1,0 +1,30 @@
+<!-- owner: shikanime | zone: internal | purpose: flake outputs and command surface -->
+
+# Reference
+
+## Flake outputs
+
+- `nixosConfigurations.<host>` for `ashira`, `manash`, `nalsha`, `fushi`,
+  `minish`, `nemishi`, `kushira`, `sashina`, `nixtar`
+- `darwinConfigurations.telsha`
+- `packages.<system>.*` — including `catbox` (KubeVirt containerdisk)
+
+## Key commands
+
+| Command                                                               | Purpose               |
+| --------------------------------------------------------------------- | --------------------- |
+| `nix develop`                                                         | enter dev shell       |
+| `nix fmt`                                                             | format the repo       |
+| `nix flake check --accept-flake-config --no-pure-eval`                | validate flake        |
+| `nix build .#nixosConfigurations.<host>.config.system.build.toplevel` | build host            |
+| `sudo nixos-rebuild switch --flake .#<host>`                          | switch NixOS host     |
+| `darwin-rebuild switch --flake .#telsha`                              | switch darwin host    |
+| `sops secrets/<host>.enc.yaml`                                        | edit encrypted secret |
+
+## Module map
+
+- `modules/nixos/` — `base`, `minimal`, `workstation`, `follower`,
+  `distributed`, `nishir`, `talashi`, `ai`
+- `modules/darwin/` — `base`, `minimal`, `workstation`, `distributed`
+- `modules/home/` — shell, editor, font, VCS, workstation settings
+- `modules/flake/` — flake-parts glue

--- a/docs/Runbook.md
+++ b/docs/Runbook.md
@@ -1,0 +1,34 @@
+<!-- owner: shikanime | zone: internal | purpose: deploy hosts and manage secrets -->
+
+# Runbook
+
+## Deploy a host
+
+`comin` reconciles hosts from the flake on its poll interval. To force a switch
+now, run on the target:
+
+```sh
+sudo nixos-rebuild switch --flake .#<host>
+# or for darwin
+darwin-rebuild switch --flake .#telsha
+```
+
+CI builds `packages.<system>.*` (incl. `catbox`) for verification; the published
+package outputs are convenience artifacts.
+
+## Edit a secret
+
+Never commit plaintext. Edit the encrypted source and let SOPS re-key:
+
+```sh
+sops secrets/<host>.enc.yaml
+```
+
+Each host points `sops.defaultSopsFile` at its own secret file. Some hosts use
+`sops.templates.*` to materialize config fragments at activation.
+
+## Branch protection
+
+- 1 approving review, linear history, signed commits, squash+rebase only.
+- Keep one logical change per PR; land stacked work with `gh stack merge`, never
+  `gh pr merge` on a stacked PR.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -1,0 +1,26 @@
+<!-- owner: shikanime | zone: internal | purpose: known failure modes and fixes -->
+
+# Troubleshooting
+
+## `nix flake check` fails on eval
+
+Pure eval breaks on the comin / Nix access-token wiring. Use
+`nix flake check --accept-flake-config --no-pure-eval` (matches CI).
+
+## ARM host build differs from x86_64
+
+`fushi`/`minish`/`nemishi` (aarch64-linux) and the x86_64 nodes share profiles
+but differ in the flake `systems` list. When touching
+`modules/nixos/profiles/distributed.nix`, keep both architectures in mind.
+
+## Secret does not decrypt
+
+Confirm you hold the SOPS age key for the repo and that `sops.defaultSopsFile`
+points at the right `secrets/<host>.enc.yaml`. Plaintext never lands in git —
+change the encrypted source, not a generated fragment.
+
+## `comin` does not pick up a change
+
+Verify the host polls the expected flake ref and that the commit is on the
+branch `comin` tracks. A local `nixos-rebuild switch` confirms the config
+independent of `comin`.


### PR DESCRIPTION
## What
Seed the internal-ops docs/ zone (Architecture, Development, Runbook, Troubleshooting, Reference) plus index, per the shikanime docs doctrine.

## Why
The sks-doc sweep generates a consistent in-repo docs/ set across every shikanime-labs / shikanime-studio repo.

## References
https://github.com/shikanime-labs/machines