### PR TITLE
Add host log shipper to victorialogs (vlagent)

### DIFF
--- a/modules/darwin/profiles/base.nix
+++ b/modules/darwin/profiles/base.nix
@@ -70,5 +70,15 @@ in
         StandardErrorPath = "/var/log/vmagent.log";
       };
     };
+    vlagent = {
+      command = "${pkgs.vlagent}/bin/vlagent -fileCollector.glob=/var/log/**/*.log -remoteWrite.url=https://logs.taila659a.ts.net/insert/0/logs";
+      serviceConfig = {
+        Label = "org.nixos.vlagent";
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/var/log/vlagent.log";
+        StandardErrorPath = "/var/log/vlagent.log";
+      };
+    };
   };
 }

--- a/modules/nixos/profiles/base.nix
+++ b/modules/nixos/profiles/base.nix
@@ -1,6 +1,7 @@
 {
   config,
   lib,
+  pkgs,
   ...
 }:
 
@@ -135,10 +136,28 @@
     };
   };
 
-  # Required for node-exporter textfile collector.
-  systemd.tmpfiles.rules = [
-    "d /var/lib/node_exporter/textfile_collector 0755 root root -"
-  ];
+  systemd = {
+    # Host log pipeline: journald -> vlagent -> vlinsert.
+    services.vlagent = {
+      description = "VictoriaLogs agent (host journal -> victorialogs)";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      serviceConfig = {
+        ExecStart = "${pkgs.vlagent}/bin/vlagent -remoteWrite.url=https://logs.taila659a.ts.net/insert/0/logs";
+        User = "vlagent";
+        SupplementaryGroups = [ "systemd-journal" ];
+        Restart = "always";
+        RestartSec = "5s";
+        DynamicUser = true;
+      };
+    };
+
+    # Required for node-exporter textfile collector.
+    tmpfiles.rules = [
+      "d /var/lib/node_exporter/textfile_collector 0755 root root -"
+    ];
+  };
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions


### PR DESCRIPTION
## Summary
- Ship host logs to the new VictoriaLogs `vlinsert` endpoint (`logs.taila659a.ts.net/insert/0/logs`) via `vlagent`, mirroring the existing `vmagent` metrics pipeline.
- NixOS base: `vlagent` reads the systemd journal (`systemd-journal` group, `DynamicUser`) and remote-writes to the ingest URL.
- darwin base: `vlagent` uses `-fileCollector.glob=/var/log/**/*.log` (no journald on macOS) to the same endpoint.

## Test plan
- [x] `nix eval` of `nixosConfigurations.ashira.config.systemd.services.vlagent.serviceConfig.ExecStart` resolves `vlagent` (VictoriaLogs 1.52.0) with the correct journald→vlinsert command.
- [x] `nix eval` of `darwinConfigurations.telsha.config.launchd.daemons.vlagent.command` resolves the fileCollector→vlinsert command.
- [ ] End-to-end ingest after DNS for `logs.taila659a.ts.net` resolves (dependent on shikanime-labs/manifests#1922 landing).

## Related
Closes shikanime-labs/manifests#1920 (host log shipping unit)

🤖 Generated with [Hermes Agent](https://hermes-agent.nousresearch.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic log collection on macOS, forwarding system log files to the configured remote logging service.
  * Added automatic log forwarding on Linux, sending host journal logs to VictoriaLogs.
  * Services start automatically, remain available, and recover if interrupted.
  * macOS service output and errors are recorded locally for easier troubleshooting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->