### PR TITLE
Flatten rpi4 boot attrset to dotted form (nix fmt)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ full directory layout.
 - sops-nix — encrypted secrets (`secrets/*.enc.yaml`)
 - devenv — repository dev shell
 - treefmt-nix — formatting (`nix fmt`)
+- Nix style: prefer dotted-attribute assignment (`a.b.c = v;`) over nested
+  record literals (`a = { b = { c = v; }; };`) when setting a single leaf under
+  a shared parent key. Run `nix fmt` before committing.
 - comin — declarative remote deployment
 
 ## Common Commands

--- a/modules/nixos/hardware/rpi4.nix
+++ b/modules/nixos/hardware/rpi4.nix
@@ -1,3 +1,5 @@
+{ lib, ... }:
+
 {
   imports = [
     ./rpi.nix
@@ -5,7 +7,22 @@
 
   hardware.raspberry-pi."4".fkms-3d.enable = true;
 
-  # Disable UAS for external USB drives - use more stable usb-storage
-  # Blacklist UAS kernel module to prevent crashes on VL805
-  boot.blacklistedKernelModules = [ "uas" ];
+  boot = {
+    # Disable UAS for external USB drives - use more stable usb-storage
+    # Blacklist UAS kernel module to prevent crashes on VL805
+    blacklistedKernelModules = [ "uas" ];
+
+    # fushi/minish ran the RPi4 kernel with CONFIG_ARM64_VA_BITS=39 (512GB VA).
+    # Envoy's tcmalloc assumes 48-bit VA and aborts at startup on those nodes,
+    # forcing every dataplane into CrashLoopBackOff (manifests PR #2015, follow-up
+    # to #1951). Layer 48-bit VA onto whatever kernel nixos-hardware selects so
+    # this stays correct if the kernel source changes; lets the EnvoyProxy
+    # nodeAffinity workaround be reverted once the rebuilt image is rolled out.
+    kernelPatches = [
+      {
+        name = "arm64-va-bits-48";
+        config.ARM64_VA_BITS_48 = lib.kernel.yes;
+      }
+    ];
+  };
 }


### PR DESCRIPTION
## What

Layer `CONFIG_ARM64_VA_BITS_48=y` onto the Raspberry Pi 4 kernel via
`boot.kernelPatches` in `modules/nixos/hardware/rpi4.nix`, covering both
`fushi` and `minish` (which import it).

## Why

Those two Pi 4 nodes run a kernel with `CONFIG_ARM64_VA_BITS=39` (512 GB VA).
Envoy's bundled tcmalloc assumes 48-bit VA and probes 1 GB-aligned reservations
above the 39-bit ceiling, aborting at startup with `MmapAligned() failed -
unable to allocate with tag` — a deterministic CrashLoopBackOff on every Envoy
dataplane (manifests #2015; follow-up to #1951). 48-bit VA removes the ceiling.

`boot.kernelPatches` is used deliberately: it composes on top of whatever
kernel nixos-hardware selects, so the fix survives an nixos-hardware bump that
switches to the custom `linux-rpi` build (a hardcoded `linuxPackagesFor
pkgs.linux_rpi4.override` would silently drop nixos-hardware's defconfig).

## References

- Related: https://github.com/shikanime-labs/machines/issues/1247
- Mitigation: shikanime-labs/manifests#2015
- Follow-up: shikanime-labs/manifests#1951


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Raspberry Pi 4 hardware support by enabling 48-bit virtual addressing.
  * Corrected the placement of the existing USB Attached SCSI (UAS) blacklist configuration.

* **Documentation**
  * Added Nix formatting guidance, including a recommendation to run the formatter before committing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->