### PR TITLE
Bump nixpkgs to clear flake-checker 30-day gate

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -632,11 +632,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1785454630,
-        "narHash": "sha256-LQy14TZp77TwbQf40gg1V3jo8FwJG0jGDkAH+zRHqg8=",
+        "lastModified": 1788039129,
+        "narHash": "sha256-pa4Q0qErvCvzCaaUph7Sm37RhR4xvPrYI8Lgz6k85+A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1559d3daa3ecc813a650b79375ea61b6741b8746",
+        "rev": "d2f67949798825fe853f7c5d0492b8bf016d3f88",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Bump the single root `nixpkgs` input (`github:nixos/nixpkgs/nixos-unstable`)
from `1559d3da` (2026-07-30, 31 days old) to `d2f6794` (2026-08-29, 2 days
old). Only `flake.lock` changes.

## Why

The `flake-checker` pre-commit hook rejects any lock whose nixpkgs is >30 days
old. At 31 days it was failing `checks.*.pre-commit`, which wedged the entire
`nix / Checks` suite — for *every* PR, including the unrelated RPi4 VA_BITS fix
(#1248). This unblocks CI without touching any code.

## Scope

- One input bumped; all other nixpkgs inputs are `follows = "nixpkgs"`.
- No flake.nix / module changes. No evaluation output shift expected beyond the
  nixpkgs bump.

## Note

Intentionally isolated from #1248 to keep that PR a single logical change.
After this lands, #1248 should be rebased onto the new `main` to inherit the
fresh lock.