### PR TITLE
Exclude tag revisions from jj restack alias

### DIFF
--- a/modules/home/vcs.nix
+++ b/modules/home/vcs.nix
@@ -39,7 +39,7 @@
             "--onto"
             "trunk()"
             "--source"
-            "roots(trunk()..) & mutable()"
+            "branch_heads()"
             "--simplify-parents"
           ];
           stack = [
@@ -77,10 +77,8 @@
         revset-aliases = {
           "closest_merge(to)" = "heads(::to & merges())";
           "nulls()" = "empty() & mutable()";
-        };
-        ui = {
-          default-command = "log";
-          movement.edit = true;
+          "stacked()" = "ancestors(reachable(trunk(), mutable()), 2) & mutable()";
+          "branch_heads()" = "roots(trunk()..) & mutable() & ~tags()";
         };
       };
     };

--- a/modules/home/vcs.nix
+++ b/modules/home/vcs.nix
@@ -31,7 +31,7 @@
         aliases = {
           prune = [
             "abandon"
-            "nulls()"
+            "empty() & mutable()"
             "conflicts()"
           ];
           restack = [
@@ -75,10 +75,16 @@
         '';
         remotes.upstream.auto-track-bookmarks = "main";
         revset-aliases = {
+          # Merge commits closest to `to` that are ancestors of @.
           "closest_merge(to)" = "heads(::to & merges())";
-          "nulls()" = "empty() & mutable()";
+          # Mutable commits stacked within 2 hops of the mutable trunk frontier.
           "stacked()" = "ancestors(reachable(trunk(), mutable()), 2) & mutable()";
+          # Mutable branch heads off trunk, excluding tagged releases.
           "branch_heads()" = "roots(trunk()..) & mutable() & ~tags()";
+        };
+        ui = {
+          default-command = "log";
+          movement.edit = true;
         };
       };
     };


### PR DESCRIPTION
Refactor `restack` to exclude tag revisions from the rebase source set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Jujutsu restacking behavior by targeting branch heads more reliably.
  * Excluded tagged commits from branch-head selection to prevent unintended restacking.
  * More accurately identifies mutable, non-empty changes during repository maintenance.
* **Improvements**
  * Added clearer revision selection for stacked and branch-head workflows.
  * Documented revision-selection rules for easier configuration understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->