### PR TITLE
Remove chart-managed ingress from flux operator web

### DIFF
--- a/modules/nixos/profiles/leader.nix
+++ b/modules/nixos/profiles/leader.nix
@@ -6,25 +6,6 @@
   services = {
     knix = {
       enable = true;
-      addons.flux.operator.extraConfig.web.ingress = {
-        enabled = true;
-        annotations."tailscale.com/tags" = "tag:web";
-        className = "tailscale";
-        hosts = [
-          {
-            host = "nishir-flux";
-            paths = [
-              {
-                path = "/";
-                pathType = "ImplementationSpecific";
-              }
-            ];
-          }
-        ];
-        tls = [
-          { hosts = [ "nishir-flux" ]; }
-        ];
-      };
       # Tailscale IP SANs — required because agents resolve hostnames to IPv6
       # first; without these the load balancer's TLS handshake to the supervisor
       # port (9345) fails with "tls: internal error".


### PR DESCRIPTION
The flux-operator UI is now exposed through the Envoy Gateway plane
in manifests (HTTPRoute on the flux BYOD gateway at
flux.i.shikanime.studio), so the tailscale Ingress rendered from
web.ingress chart values is dead configuration.

Deployed state: manifests#2051 is live on nishir with the UI
serving 200 over the new route; the old nishir-flux MagicDNS
ingress remains in place until this PR deploys and drops it.

Related: https://github.com/shikanime-labs/manifests/pull/2051

Co-authored-by: Automata <automata@shikanime.studio>