### PR TITLE
Move telemetry, honcho, forgejo endpoints to i.shikanime.studio

### DIFF
--- a/modules/darwin/profiles/base.nix
+++ b/modules/darwin/profiles/base.nix
@@ -40,7 +40,7 @@ in
     remotes = [
       {
         name = "forgejo";
-        url = "https://forgejo.taila659a.ts.net/shikanime-labs/machines.git";
+        url = "https://forgejo.i.shikanime.studio/shikanime-labs/machines.git";
       }
     ];
   };
@@ -60,7 +60,7 @@ in
       command = ''
         ${pkgs.victoriametrics}/bin/vmagent \
           -promscrape.config=${vmagentConfig} \
-          -remoteWrite.url=https://telemetry.taila659a.ts.net/insert/0/prometheus
+          -remoteWrite.url=https://telemetry.i.shikanime.studio/insert/0/prometheus
       '';
       serviceConfig = {
         Label = "org.nixos.vmagent";

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -282,7 +282,7 @@ in
           }
         ];
         documents."honcho.json" = builtins.toJSON {
-          baseUrl = "https://honcho.taila659a.ts.net";
+          baseUrl = "https://honcho.i.shikanime.studio";
           hosts.hermes = {
             peerName = config.networking.hostName;
             aiPeer = "hermes";

--- a/modules/nixos/profiles/base.nix
+++ b/modules/nixos/profiles/base.nix
@@ -46,7 +46,7 @@
       remotes = [
         {
           name = "forgejo";
-          url = "https://forgejo.taila659a.ts.net/shikanime-labs/machines.git";
+          url = "https://forgejo.i.shikanime.studio/shikanime-labs/machines.git";
         }
       ];
     };
@@ -132,7 +132,7 @@
           ];
         }
       ];
-      remoteWrite.url = "https://telemetry.taila659a.ts.net/insert/0/prometheus";
+      remoteWrite.url = "https://telemetry.i.shikanime.studio/insert/0/prometheus";
     };
   };
 

--- a/modules/nixos/profiles/forgejo.nix
+++ b/modules/nixos/profiles/forgejo.nix
@@ -12,7 +12,7 @@
         enable = true;
         name = config.networking.hostName;
         tokenFile = config.sops.templates.forgejo-runner-token.path;
-        url = "https://forgejo.taila659a.ts.net";
+        url = "https://forgejo.i.shikanime.studio";
         labels = [
           "docker:docker://node:22-bookworm"
           "nixos-latest:docker://nixos/nix"


### PR DESCRIPTION
## Summary
Point shared service endpoints at `i.shikanime.studio` instead of Tailscale MagicDNS names:

- `telemetry.taila659a.ts.net` → `telemetry.i.shikanime.studio` (Prometheus remote-write, NixOS + darwin base)
- `logs.taila659a.ts.net` untouched (not in scope)
- `honcho.taila659a.ts.net` → `honcho.i.shikanime.studio` (ai profile baseUrl)
- `forgejo.taila659a.ts.net` → `forgejo.i.shikanime.studio` (git remotes in NixOS + darwin base, forgejo profile)

6 URLs across 4 files. Host-plane names (SSH, builders, A2A peers) stay on MagicDNS.

## Test plan
- [x] `nix eval` clean: `nixosConfigurations.nixtar`, `darwinConfigurations.telsha`
- [x] `nix fmt` on touched files: 0 changed

DNS/TLS for `\*.i.shikanime.studio` must serve these three names before any host rebuilds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated service connections to use the new `shikanime.studio` addresses.
  * Source control, telemetry, AI orchestration, and automation runner services now connect through their updated endpoints.
  * Existing functionality remains unchanged while services transition away from the previous internal hostnames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->