### PR TITLE
Add rbw Bitwarden CLI support with pinentry and SSH agent

### DIFF
--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -35,6 +35,7 @@ in
       docker-credential-helpers
       pass
       qpdf
+      rbw
       rclone
       wget
       zip


### PR DESCRIPTION
Add rbw (Bitwarden CLI) as the pinentry package for GnuPG agent and add it to home packages on the workstation.

- modules/nixos/profiles/workstation.nix: change pinentryPackage from pkgs.pinentry-all to pkgs.rbw, add enableSSHSupport = true
- modules/home/workstation.nix: add rbw to home.packages

Flake check passes for all systems (aarch64-darwin, darwin, nixos).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password manager support to workstation environments.
  * Enabled SSH authentication through the GnuPG agent.
  * Configured a dedicated graphical PIN entry interface for secure authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->