### PR TITLE
feat/home: SSH_ASKPASS via rbw

### DIFF
--- a/modules/home/ssh-askpass
+++ b/modules/home/ssh-askpass
@@ -1,0 +1,20 @@
+#!/bin/sh
+# SSH_ASKPASS protocol: stdin = prompt text, stdout = passphrase
+prompt="$(cat)"
+key="$(echo "$prompt" | sed -n 's/.*for \(.*\)/\1/p')"
+
+if [ -z "$key" ]; then
+  echo "Usage: ssh-askpass <prompt>" >&2
+  exit 1
+fi
+
+# Sanitize key for Bitwarden search (replace / with _)
+key_safe="$(printf "%s" "$key" | tr '/' '_')"
+
+# Try matching by key first, then fallback to ssh- prefix
+match="$(rbw list --ignorecase --field name "$key_safe" 2>/dev/null | head -1)"
+if [ -n "$match" ]; then
+  rbw get "$match"
+else
+  rbw get "ssh-${key_safe}"
+fi

--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -35,11 +35,20 @@ in
       docker-credential-helpers
       pass
       qpdf
+      rbw
       rclone
       wget
       zip
     ];
     sessionPath = [ "${config.home.homeDirectory}/.local/bin" ];
+    sessionVariables."SSH_ASKPASS" = "${config.home.homeDirectory}/.local/bin/ssh-askpass";
+
+    file.".local/bin/ssh-askpass" = {
+      enable = true;
+      source = pkgs.writeScriptBin "ssh-askpass" (
+        pkgs.writeScript "ssh-askpass" (builtins.readFile ./ssh-askpass)
+      );
+    };
   };
 
   programs = {
@@ -70,7 +79,7 @@ in
       enable = true;
       settings = {
         base_url = "https://vaultwarden.i.shikanime.studio/";
-        pinentry = pkgs.pinentry-all;
+        email = "william.phetsinorath@shikanime.studio";
       };
     };
 

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/fszgxzqfh2x325z3ncm74jfinlg4mi8p-darwin-system-26.11.15abb8c


### PR DESCRIPTION
## What

- Add `rbw` to home packages
- Add `SSH_ASKPASS` session variable pointing to `~/.local/bin/ssh-askpass`
- Add `~/.local/bin/ssh-askpass` script that reads from Bitwarden via `rbw`
  - Extracts key from SSH_ASKPASS prompt (e.g., "Enter passphrase for /path/to/key" → "path/to/key")
  - Sanitizes key for Bitwarden search (replaces `/` with `_`)
  - Searches for exact match in Bitwarden, falls back to `ssh-` prefix

## Why

Enables Bitwarden-backed SSH key passphrase retrieval without interactive pinentry.

## References

- `modules/home/ssh-askpass` — the ssh-askpass script
- `modules/home/workstation.nix` — home config changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic SSH credential retrieval through Bitwarden.
  * Configured workstation environments to use the new SSH authentication helper.
  * Added `rbw` configuration for secure credential access.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->