### PR TITLE
Fix RPi4 48-bit VA via buildLinux overlay

### DIFF
--- a/modules/nixos/hardware/rpi4.nix
+++ b/modules/nixos/hardware/rpi4.nix
@@ -7,22 +7,39 @@
 
   hardware.raspberry-pi."4".fkms-3d.enable = true;
 
+  nixpkgs.overlays = [
+    # Envoy's tcmalloc assumes 48-bit VA and aborts at startup on RPi4 nodes
+    # (manifests PR #2015, follow-up to #1951): the RPi vendor kernel is built
+    # from bcm2711_defconfig, which selects CONFIG_ARM64_VA_BITS_39. Switch the
+    # Kconfig choice to 48-bit VA.
+    #
+    # boot.kernelPatches cannot do this: nixos-hardware wraps the kernel in
+    # `.overrideAttrs`, which detaches the `.override` hook the NixOS kernel
+    # module uses to apply patch entries — they are silently dropped. The
+    # kernel itself is built by `buildLinux`, so guard on the RPi defconfig and
+    # merge the two keys into its structuredExtraConfig. VA_BITS is a Kconfig
+    # choice: 39 must be disabled for 48 to hold.
+    (_final: prev: {
+      buildLinux =
+        args:
+        prev.buildLinux (
+          if (args.defconfig or "") == "bcm2711_defconfig" then
+            args
+            // {
+              structuredExtraConfig = (args.structuredExtraConfig or { }) // {
+                ARM64_VA_BITS_39 = lib.kernel.no;
+                ARM64_VA_BITS_48 = lib.kernel.yes;
+              };
+            }
+          else
+            args
+        );
+    })
+  ];
+
   boot = {
     # Disable UAS for external USB drives - use more stable usb-storage
     # Blacklist UAS kernel module to prevent crashes on VL805
     blacklistedKernelModules = [ "uas" ];
-
-    # fushi/minish ran the RPi4 kernel with CONFIG_ARM64_VA_BITS=39 (512GB VA).
-    # Envoy's tcmalloc assumes 48-bit VA and aborts at startup on those nodes,
-    # forcing every dataplane into CrashLoopBackOff (manifests PR #2015, follow-up
-    # to #1951). Layer 48-bit VA onto whatever kernel nixos-hardware selects so
-    # this stays correct if the kernel source changes; lets the EnvoyProxy
-    # nodeAffinity workaround be reverted once the rebuilt image is rolled out.
-    kernelPatches = [
-      {
-        name = "arm64-va-bits-48";
-        config.ARM64_VA_BITS_48 = lib.kernel.yes;
-      }
-    ];
   };
 }


### PR DESCRIPTION
## What

Replaces the `boot.kernelPatches` entry in `modules/nixos/hardware/rpi4.nix` with a `nixpkgs.overlays` entry on `buildLinux` that merges `ARM64_VA_BITS_39 = no` + `ARM64_VA_BITS_48 = yes` into `structuredExtraConfig`.

## Why

`boot.kernelPatches` never reaches the RPi kernel build: nixos-hardware wraps the kernel in `.overrideAttrs`, which detaches the `.override` hook the NixOS kernel module uses to apply patch entries — they are silently dropped. Evidence (all verified live):

- `config.boot.kernelPackages.kernel.patches` holds only the 3 stock nixpkgs patches; `arm64-va-bits-48` absent.
- Built kernel configfile: `CONFIG_ARM64_VA_BITS_39=y`.
- Eval'd kernel drv byte-identical to the kernel running on fushi.

`buildLinux` is the call that actually receives the kernel args. VA_BITS is a Kconfig choice, so 39 must be disabled for 48 to hold.

Post-fix build of the kernel configfile yields `CONFIG_ARM64_VA_BITS_48=y` / `CONFIG_ARM64_VA_BITS=48`.

## References

- Closes https://github.com/shikanime-labs/machines/issues/1247 (code-fix acceptance re-gated on this PR)
- Correction comment: https://github.com/shikanime-labs/machines/issues/1247#issuecomment-5515909531
- Supersedes the kernelPatches approach of https://github.com/shikanime-labs/machines/pull/1248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Raspberry Pi 4 kernel configuration to use 48-bit virtual addressing.
  * Disabled 39-bit virtual addressing for Raspberry Pi 4 kernels, improving compatibility with supported hardware and software.
  * Other Raspberry Pi 4 boot settings, including the USB Attached SCSI (`uas`) device handling, remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->