### PR TITLE
Expose full 128 GiB GTT ceiling to the ms s1 iGPU

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -34,8 +34,8 @@ GPU/ROCm acceleration lives entirely in
   microcode so the compute stack reaches `/dev/dri/renderD128`.
 - `hardware.graphics.enable = true` + `enable32Bit` (inherited from
   nixos-hardware `common-gpu-amd`) — Mesa/ROCm userspace.
-- `boot.kernelParams = [ "amdgpu.gttsize=98304" "ttm.pages_limit=25165824" ]` —
-  96 GiB GTT carve-out for the unified-memory iGPU.
+- `boot.kernelParams = [ "amdgpu.gttsize=131072" "ttm.pages_limit=33554432" ]` —
+  full 128 GiB GTT ceiling for the unified-memory iGPU.
 
 The llama.cpp inference _service_ (server/rpc roles, `:8080`/`:50052`) is not
 yet wired as a module — the nodes are provisioned with acceleration enabled and
@@ -51,6 +51,6 @@ online. When added back, the ROCm package is
   RPC-bound, move to a USB4 ring first (community measured ~8 µs vs ~65 µs)
   before any other tuning.
 - `ctx-size` is intentionally conservative at 128k; raise toward 1M only with
-  measured VRAM/KV headroom — the 96 GiB GTT cap on Strix Halo bounds it.
+  measured VRAM/KV headroom — the 128 GiB GTT cap on Strix Halo bounds it.
 - The model file is not fetched by the module — stage it manually (e.g. via
   `hf download unsloth/DeepSeek-V4-Flash-0731-GGUF --include "*UD-IQ4_XS*"`).

--- a/modules/nixos/hardware/minisforum-ms-s1.nix
+++ b/modules/nixos/hardware/minisforum-ms-s1.nix
@@ -6,11 +6,13 @@
 
     # Strix Halo has no dedicated VRAM: the iGPU carves its working set out of
     # the 128GB unified LPDDR5X via GTT. The defaults cap GTT at roughly half
-    # of RAM, which is not enough to keep a large model resident. 96GiB GTT
-    # (gttsize is MiB) with a matching TTM page limit (96GiB / 4KiB pages).
+    # of RAM, which is not enough to keep a large model resident. Give the
+    # iGPU the full 128GiB ceiling (gttsize is MiB) with a matching TTM page
+    # limit (128GiB / 4KiB pages) — GTT is demand-paged, so this is an upper
+    # bound, not a reservation; pages commit only when the GPU touches them.
     kernelParams = [
-      "amdgpu.gttsize=98304"
-      "ttm.pages_limit=25165824"
+      "amdgpu.gttsize=131072"
+      "ttm.pages_limit=33554432"
     ];
 
     loader = {


### PR DESCRIPTION
## What
Raises the Strix Halo shared hardware module (imported by both `kushira` and `sashina`) from a 96 GiB GTT carve-out to the full 128 GiB unified-memory ceiling.

Changes `boot.kernelParams` in `modules/nixos/hardware/minisforum-ms-s1.nix` from `amdgpu.gttsize=98304 ttm.pages_limit=25165824` to `amdgpu.gttsize=131072 ttm.pages_limit=33554432`, and syncs `docs/inference.md`.

## Why
The user requested maximum RAM-to-VRAM allocation on the 128 GB Strix Halo nodes. GTT is demand-paged, so this is an upper bound rather than a reservation: pages commit only as the GPU touches them, leaving the OS its full working-set headroom. `gttsize=131072` + `pages_limit=33554432` is the community-validated full-128 GiB ceiling for the AI Max+ 395 (Radeon 8060S). Both nodes stay symmetric per the two-Halo cluster discipline.

## References
Configuration mirrors the canonical Strix Halo max-VRAM kernel set (amdgpu.gttsize=131072 / ttm.pages_limit=33554432). Effective on both hosts after the next rebuild plus a reboot, since kernel params require it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Strix Halo inference guidance to support a 128 GiB GTT configuration and corresponding context-window limit.

* **Configuration**
  * Increased the Minisforum MS-S1 AMD GPU GTT limit to 128 GiB.
  * Updated the matching memory page limit and clarified that the allocation is demand-paged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->