### PR TITLE
Wire USB4 IPv4LL peer link for MS-S1 hosts

### DIFF
--- a/modules/nixos/hardware/minisforum-ms-s1.nix
+++ b/modules/nixos/hardware/minisforum-ms-s1.nix
@@ -15,6 +15,13 @@
       "ttm.pages_limit=33554432"
     ];
 
+    kernel.sysctl = {
+      "net.core.busy_poll" = 50;
+      "net.core.busy_read" = 50;
+    };
+
+    kernelModules = [ "thunderbolt-net" ];
+
     loader = {
       efi.canTouchEfiVariables = true;
       systemd-boot.enable = true;
@@ -49,20 +56,9 @@
     };
   };
 
-  # Radeon 8060S (gfx1151) needs firmware so ROCm compute and VAAPI reach
-  # /dev/dri/renderD128. Userspace graphics libs + amdgpu initrd come from
-  # nixos-hardware's common-gpu-amd.
   hardware.enableRedistributableFirmware = true;
 
-  services.fstrim.enable = true;
-
   networking = {
-    useNetworkd = true;
-
-    # balance-alb (mode 6): aggregates both 10G NICs without switch-side LACP,
-    # same reason as the Beelinks — the NETGEAR MS308 is unmanaged.
-    # ponytail: mode 6 is unverified at 10G; drop bond0 and bridge enp1s0
-    # directly if per-flow throughput regresses.
     bonds.bond0 = {
       # Realtek RTL8127. Names assumed to match the Beelink enumeration —
       # confirm with `ip -br link` on first boot before install.
@@ -77,29 +73,51 @@
     };
 
     bridges.br0.interfaces = [ "bond0" ];
+
+    # balance-alb (mode 6): aggregates both 10G NICs without switch-side LACP,
+    # same reason as the Beelinks — the NETGEAR MS308 is unmanaged.
+    # ponytail: mode 6 is unverified at 10G; drop bond0 and bridge enp1s0
+    # directly if per-flow throughput regresses.
+    useNetworkd = true;
   };
 
-  # NIC performance tuning: hardware offloads + RPS for both RTL8127 ports.
-  systemd.services.network-nic-performance = {
-    after = [ "network-online.target" ];
-    description = "Enable NIC hardware offloads and RPS";
-    script = ''
-      for iface in enp1s0 enp2s0; do
-        ip link show "$iface" >/dev/null 2>&1 || continue
-        ${pkgs.ethtool}/bin/ethtool -K "$iface" rx-udp-gro-forwarding on rx-gro-list off
-        ${pkgs.ethtool}/bin/ethtool -K "$iface" tso on gso on sg on tx on rx on 2>/dev/null || true
-        for rxq in /sys/class/net/"$iface"/queues/rx-*; do
-          echo ffff > "$rxq"/rps_cpus 2>/dev/null || true
-        done
-      done
-    '';
-    serviceConfig = {
-      Type = "oneshot";
-      RemainAfterExit = true;
-      Restart = "on-failure";
-      RestartSec = "5s";
+  services.fstrim.enable = true;
+
+  systemd = {
+    # Direct USB4 peer link (kushira <-> sashina). IPv4LL keeps it
+    # config-free; no DHCP server exists on a bare cable. MTU 65522 is
+    # the thunderbolt-net driver max (TBNET_MAX_MTU - ETH_HLEN).
+    network.networks."40-thunderbolt" = {
+      matchConfig.Driver = "thunderbolt-net";
+      linkConfig = {
+        MTUBytes = 65522;
+        RequiredForOnline = "no";
+      };
+      networkConfig.LinkLocalAddressing = "ipv4";
     };
-    wantedBy = [ "multi-user.target" ];
-    wants = [ "network-online.target" ];
+
+    # NIC performance tuning: hardware offloads + RPS for both RTL8127 ports.
+    services.network-nic-performance = {
+      after = [ "network-online.target" ];
+      description = "Enable NIC hardware offloads and RPS";
+      script = ''
+        for iface in enp1s0 enp2s0; do
+          ip link show "$iface" >/dev/null 2>&1 || continue
+          ${pkgs.ethtool}/bin/ethtool -K "$iface" rx-udp-gro-forwarding on rx-gro-list off
+          ${pkgs.ethtool}/bin/ethtool -K "$iface" tso on gso on sg on tx on rx on 2>/dev/null || true
+          for rxq in /sys/class/net/"$iface"/queues/rx-*; do
+            echo ffff > "$rxq"/rps_cpus 2>/dev/null || true
+          done
+        done
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+    };
   };
 }


### PR DESCRIPTION
## What

Adds USB4 IPv4LL peer networking to the Minisforum MS-S1 hardware module, so the two MS-S1 hosts (kushira <-> sashina) get a direct point-to-point link over a USB4 cable:

- `boot.kernelModules = [ "thunderbolt-net" ]` — load the USB4 NIC driver at boot.
- `systemd.network.networks."40-thunderbolt"` — driver-matched networkd network with IPv4LL addressing (no DHCP server exists on a bare cable), MTU 65522 (thunderbolt-net driver max, `TBNET_MAX_MTU - ETH_HLEN`), `RequiredForOnline = "no"` so the peer link never blocks `network-online.target`.
- `net.core.busy_read` / `net.core.busy_poll` = 50 — busy-poll sysctls for the high-MTU link.

No per-host `configuration.nix` changes: the module is shared by both `hosts/kushira` and `hosts/sashina`.

## Why

The two MS-S1 nodes sit on the same desk; a direct USB4 link gives east-west traffic between them a path that does not traverse the 10G bond/bridge. IPv4LL keeps it config-free.

## Validation

- `nix eval` of `nixosConfigurations.{kushira,sashina}.config.system.build.toplevel` evaluates the full graph cleanly on both hosts.
- The generated `40-thunderbolt.network` unit text matches the intended config:
  `[Match] Driver=thunderbolt-net` / `[Link] MTUBytes=65522, RequiredForOnline=no` / `[Network] LinkLocalAddressing=ipv4`.
- `boot.kernelModules` includes `thunderbolt-net`; `net.core.busy_read` resolves to 50.

Post-boot expectation (manual step, not CI-verifiable): `ip -br addr show thunderbolt0` shows a 169.254.x.x/16 on both sides and sub-millisecond ping between them.

## References

Related: https://github.com/shikanime-labs/machines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Thunderbolt networking support with IPv4 link-local addressing.
  * Configured a larger MTU for Thunderbolt network connections.

* **Performance**
  * Increased kernel network busy-poll and read settings to improve responsiveness.
  * Preserved existing network interface performance tuning while reorganizing its configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->