### PR TITLE
Run llama.cpp inference directly on sashina

### DIFF
--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -1,4 +1,9 @@
 {
+  pkgs,
+  ...
+}:
+
+{
   imports = [
     ../../modules/nixos/profiles/ai.nix
     ../../modules/nixos/profiles/agent.nix
@@ -10,6 +15,52 @@
     ../../modules/nixos/users/builder.nix
     ../../modules/nixos/users/nishir.nix
   ];
+
+  # llama.cpp router — ROCm (gfx1151) + RPC backend, mirroring the runtime
+  # flags the in-cluster LWS used. The Envoy AI Gateway's local-floor Backend
+  # points at this host on the service port.
+  services.llama-cpp = {
+    enable = true;
+    package = pkgs.llama-cpp.override {
+      rocmSupport = true;
+      rpcSupport = true;
+    };
+    openFirewall = true;
+    settings = {
+      host = "0.0.0.0";
+      port = 8080;
+      # Router preset: section names MUST equal the gateway's
+      # modelNameOverride route keys.
+      models-preset = "/etc/llama-cpp/models-preset.ini";
+      models-dir = "/var/lib/llama-cpp/models";
+      models-max = 5;
+      models-autoload = true;
+      embeddings = true;
+      ctx-size = 32768;
+      flash-attn = "on";
+      cache-type-k = "q8_0";
+      cache-type-v = "q8_0";
+      n-gpu-layers = 999;
+      mmap = false;
+    };
+  };
+
+  environment.etc."llama-cpp/models-preset.ini".text = ''
+    [deepseek/deepseek-v4-flash-0731]
+    hf = unsloth/DeepSeek-V4-Flash-0731-GGUF:UD-Q3_K_M
+
+    [z-ai/glm-5.3-flash]
+    hf = unsloth/GLM-5.3-Flash-GGUF:UD-IQ3_XXS
+
+    [qwen/qwen3.8-27b]
+    hf = unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_XL
+
+    [qwen/qwen3.8-flash]
+    hf = unsloth/Qwen3.8-Flash-Next-GGUF:UD-Q4_K_XL
+
+    [qwen/qwen3-embedding-8b]
+    hf = Qwen/Qwen3-Embedding-8B-GGUF:Q6_K
+  '';
 
   networking = {
     hostName = "sashina";

--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -140,6 +140,33 @@ in
 
       custom_providers = [
         {
+          name = "shikanime-anthropic";
+          base_url = "https://inference.i.shikanime.studio/anthropic";
+          api_mode = "anthropic_messages";
+          key_env = "SKS_API_KEY";
+          model = "z-ai/glm-5.3-flash";
+          models = [
+            "z-ai/glm-5.3-flash"
+            "z-ai/glm-5.3"
+            "qwen/qwen3.8-27b"
+            "qwen/qwen3.8-flash"
+            "deepseek/deepseek-v4-flash"
+          ];
+        }
+        {
+          name = "shikanime-openai";
+          base_url = "https://inference.i.shikanime.studio/v1";
+          api_mode = "chat_completions";
+          key_env = "SKS_API_KEY";
+          model = "poolside/laguna-s-2.1:free";
+          models = [
+            "poolside/laguna-s-2.1:free"
+            "qwen/qwen3.8-flash"
+            "qwen/qwen3.8-27b"
+            "deepseek/deepseek-v4-flash"
+          ];
+        }
+        {
           name = "aperture-anthropic";
           base_url = "https://ai.taila659a.ts.net/v1";
           api_mode = "anthropic_messages";
@@ -175,18 +202,13 @@ in
 
       fallback_providers = [
         {
-          api_mode = "chat_completions";
-          model = "inclusionai/ling-3.0-flash:free";
-          provider = "custom:aperture-openai";
+          api_mode = "anthropic_messages";
+          model = "z-ai/glm-5.3";
+          provider = "custom:shikanime-anthropic";
         }
         {
           api_mode = "chat_completions";
-          model = "poolside/laguna-s-2.1:free";
-          provider = "custom:aperture-openai";
-        }
-        {
-          api_mode = "chat_completions";
-          model = "labs-leanstral-1-5";
+          model = "deepseek/deepseek-v4-flash";
           provider = "custom:aperture-openai";
         }
         {
@@ -195,84 +217,16 @@ in
           provider = "custom:aperture-openai";
         }
         {
-          api_mode = "chat_completions";
-          model = "tencent/hy3:free";
-          provider = "custom:aperture-openai";
+          api_mode = "anthropic_messages";
+          model = "deepseek/deepseek-v4-flash";
+          provider = "custom:shikanime-anthropic";
         }
       ];
 
       model = {
-        default = "tencent/hy3:free";
-        provider = "custom:aperture-openai";
-        base_url = "https://ai.taila659a.ts.net/v1";
-      };
-
-      auxiliary = {
-        vision = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        web_extract = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        compression = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        skills_hub = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        approval = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        mcp = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        title_generation = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        memory_query_rewrite = {
-          provider = "custom:aperture-anthropic:openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        tts_audio_tags = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        triage_specifier = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        kanban_decomposer = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        profile_describer = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        curator = {
-          provider = "custom:aperture-openai";
-          model = "tencent/hy3:free";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
+        default = "qwen/qwen3.8-27b";
+        provider = "custom:shikanime-anthropic";
+        base_url = "https://inference.i.shikanime.studio/anthropic";
       };
 
       mcp_servers.aperture = {

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/j9m41a5i6y3pb8395fp5z62yijv7az81-darwin-system-26.11.15abb8c


### PR DESCRIPTION
## What

Enables the nixpkgs `services.llama-cpp` NixOS module on sashina with:

- A `llama-cpp` package override built with `rocmSupport` (gfx1151 iGPU) and `rpcSupport` (RPC backend for future cross-node layer offload).
- Router mode driven by `/etc/llama-cpp/models-preset.ini`, with section names matching the Envoy AI Gateway route keys (`z-ai/glm-5.3-flash`, `deepseek/deepseek-v4-flash-0731`, `qwen/qwen3.8-27b`, `qwen/qwen3.8-flash`, `qwen/qwen3-embedding-8b`).
- The same runtime flags the in-cluster LWS used (`models-max 5`, autoload, embeddings, ctx 32768, flash-attn, q8_0 KV cache, `n-gpu-layers 999`, mmap off).
- Models cached under `/var/lib/llama-cpp/models` (persistent, no re-download on restart).
- Firewall opened on the service port so the gateway's local-floor Backend can target the host.

## Why

The in-cluster llama.cpp router (LWS pods) is being retired in favor of running llama.cpp directly on the NixOS host: no container image with GGML_RPC exists upstream, the k8s pod path added moving parts (Ray flags, preset configmaps, controller panics) without benefit, and the host already has the GTT ceiling and ROCm firmware configured.

## Verification

- `nix eval` of the sashina config resolves `services.llama-cpp.package` to `llama-cpp-0.2.0` with both support flags.
- kushira and other hosts eval unaffected.

## References

Related: https://github.com/ggml-org/llama.cpp/blob/master/tools/rpc/README.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a local AI model router with GPU acceleration, remote procedure support, automatic model loading, embeddings, and response caching.
  - Added access to five DeepSeek, GLM, and Qwen models through the router.
  - Added Shikanime Anthropic and OpenAI-compatible providers to Hermes Agent.

- **Updates**
  - Changed the default Hermes Agent model to Shikanime’s Qwen model.
  - Updated fallback behavior to prioritize Shikanime Anthropic models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->