### PR TITLE
Fix vlagent crash loop on read-only working directory

### DIFF
--- a/modules/darwin/profiles/base.nix
+++ b/modules/darwin/profiles/base.nix
@@ -71,7 +71,12 @@ in
       };
     };
     vlagent = {
-      command = "${pkgs.vlagent}/bin/vlagent -fileCollector.glob=/var/log/**/*.log -remoteWrite.url=https://logs.i.shikanime.studio/insert/0/logs";
+      command = ''
+        ${pkgs.bash}/bin/bash -c 'mkdir -p /var/lib/vlagent && exec ${pkgs.vlagent}/bin/vlagent \
+          -fileCollector.glob=/var/log/**/*.log \
+          -remoteWrite.tmpDataPath=/var/lib/vlagent \
+          -remoteWrite.url=https://logs.i.shikanime.studio/insert/0/logs'
+      '';
       serviceConfig = {
         Label = "org.nixos.vlagent";
         RunAtLoad = true;

--- a/modules/nixos/profiles/base.nix
+++ b/modules/nixos/profiles/base.nix
@@ -144,7 +144,8 @@
       after = [ "network-online.target" ];
       wants = [ "network-online.target" ];
       serviceConfig = {
-        ExecStart = "${pkgs.vlagent}/bin/vlagent -remoteWrite.url=https://logs.i.shikanime.studio/insert/0/logs";
+        ExecStart = "${pkgs.vlagent}/bin/vlagent -remoteWrite.tmpDataPath=/var/lib/vlagent -remoteWrite.url=https://logs.i.shikanime.studio/insert/0/logs";
+        StateDirectory = "vlagent";
         User = "vlagent";
         SupplementaryGroups = [ "systemd-journal" ];
         Restart = "always";

--- a/modules/nixos/profiles/base.nix
+++ b/modules/nixos/profiles/base.nix
@@ -1,7 +1,6 @@
 {
   config,
   lib,
-  pkgs,
   ...
 }:
 
@@ -136,23 +135,12 @@
     };
   };
 
+  services.vlagent = {
+    enable = true;
+    remoteWrite.url = "https://logs.i.shikanime.studio/insert/0/logs";
+  };
+
   systemd = {
-    # Host log pipeline: journald -> vlagent -> vlinsert.
-    services.vlagent = {
-      description = "VictoriaLogs agent (host journal -> victorialogs)";
-      wantedBy = [ "multi-user.target" ];
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
-      serviceConfig = {
-        ExecStart = "${pkgs.vlagent}/bin/vlagent -remoteWrite.tmpDataPath=/var/lib/vlagent -remoteWrite.url=https://logs.i.shikanime.studio/insert/0/logs";
-        StateDirectory = "vlagent";
-        User = "vlagent";
-        SupplementaryGroups = [ "systemd-journal" ];
-        Restart = "always";
-        RestartSec = "5s";
-        DynamicUser = true;
-      };
-    };
 
     # Required for node-exporter textfile collector.
     tmpfiles.rules = [

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/ijzycc96fyzqbsay31j2xcgvz2q0pxqs-darwin-system-26.11.15abb8c

--- a/result
+++ b/result
@@ -1,1 +1,1 @@
-/nix/store/j9m41a5i6y3pb8395fp5z62yijv7az81-darwin-system-26.11.15abb8c
+/nix/store/ijzycc96fyzqbsay31j2xcgvz2q0pxqs-darwin-system-26.11.15abb8c


### PR DESCRIPTION
## What

Stop the vlagent crash loop on every fleet host:

- darwin (`modules/darwin/profiles/base.nix`): launchd daemon command wrapped with `bash -c 'mkdir -p /var/lib/vlagent && exec vlagent …'` (daemon runs as root) plus `-remoteWrite.tmpDataPath=/var/lib/vlagent`.
- NixOS (`modules/nixos/profiles/base.nix`): hand-rolled systemd unit replaced by the upstream `services.vlagent` module (`enable` + `remoteWrite.url`) — the module already pins `-remoteWrite.tmpDataPath` under the unit's `CacheDirectory`.
- Remove the tracked `result` build-output symlink at the repo root.

## Why

vlagent creates its remote-write persistent queue at the relative path `vlagent-remotewrite-data` (the process working directory). LaunchDaemons start in `/` and the previous NixOS DynamicUser unit had no writable state directory, so vlagent panicked at startup on every host and respawned forever:

- telsha (darwin): `panic: FATAL: cannot create directory: mkdir vlagent-remotewrite-data: read-only file system`, launchd `last exit code = 2`
- sashina (NixOS): identical panic, systemd restart counter at 1230

With the path pinned, a live run of the same binary starts cleanly: `opened fast queue … persistence is enabled`, no panic. On NixOS the supported `services.vlagent` module now owns the unit and the writable-state handling.

## Note

NixOS hosts currently ingest nothing even with the agent running — no collector input is configured (no journald flag). Left as a follow-up to keep this PR single-purpose.

## References

Related: https://github.com/shikanime-labs/machines
