### PR TITLE
Move llama-cpp service off port 8080

### DIFF
--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -28,7 +28,9 @@
     openFirewall = true;
     settings = {
       host = "0.0.0.0";
-      port = 8080;
+      # 8080 is taken by k3s node-local-dns (node-cache on 169.254.20.10)
+      # on every cluster node; use 18080 for the host-level service.
+      port = 18080;
       # Router preset: section names MUST equal the gateway's
       # modelNameOverride route keys.
       models-preset = "/etc/llama-cpp/models-preset.ini";


### PR DESCRIPTION
## What

Moves the sashina llama-cpp service from port 8080 to 18080.

## Why

k3s node-local-dns (`node-cache`) binds `169.254.20.10:8080` on every cluster node, and llama-server cannot bind `0.0.0.0:8080` alongside it — the service entered a bind-failure restart loop on first deploy. 18080 is free; the gateway's Backend endpoint updates in manifests in a companion change.

## Verification

`nix eval` of the sashina config resolves `services.llama-cpp.settings.port` to 18080.

## References

Related: https://github.com/shikanime-labs/machines/pull/1265
