### PR TITLE
Add ROCm llama.cpp docker image

### DIFF
--- a/modules/flake/packages.nix
+++ b/modules/flake/packages.nix
@@ -1,8 +1,20 @@
 {
-  perSystem = { pkgs, ... }: {
-    packages = {
-      hermes-plugin-lcm = import ../../pkgs/hermes-plugin-lcm { inherit pkgs; };
-      hermes-plugin-rtk-rewrite = import ../../pkgs/hermes-plugin-rtk-rewrite { inherit pkgs; };
+  perSystem =
+    {
+      pkgs,
+      lib,
+      system,
+      ...
+    }:
+    {
+      packages = {
+        hermes-plugin-lcm = import ../../pkgs/hermes-plugin-lcm { inherit pkgs; };
+        hermes-plugin-rtk-rewrite = import ../../pkgs/hermes-plugin-rtk-rewrite { inherit pkgs; };
+      };
+    }
+    // lib.optionalAttrs (system == "x86_64-linux") {
+      # ROCm userland is x86_64-linux only; expose the image only there so
+      # `flake.packages.x86_64-linux.llama-cpp-oci` is the single entry point.
+      packages.llama-cpp-oci = import ../../pkgs/llama-cpp { inherit pkgs lib; };
     };
-  };
 }

--- a/pkgs/llama-cpp/default.nix
+++ b/pkgs/llama-cpp/default.nix
@@ -1,0 +1,46 @@
+# ROCm llama.cpp OCI image (gfx1151 Strix Halo) for the nix-containers
+# Skaffold builder. The host kernel provides the amdgpu driver and exposes
+# /dev/kfd + /dev/dri; the image carries only the ROCm userland.
+{
+  pkgs,
+  lib,
+}:
+let
+  llama-cpp = pkgs.llama-cpp.override {
+    rocmSupport = true;
+    rpcSupport = true;
+  };
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "llama-cpp-oci";
+  tag = "latest";
+
+  contents = [
+    pkgs.dockerTools.caCertificates
+    pkgs.dockerTools.usrBinEnv
+    llama-cpp
+  ];
+
+  config = {
+    Entrypoint = [
+      "${llama-cpp}/bin/llama-server"
+    ];
+    Cmd = [
+      "--host"
+      "0.0.0.0"
+      "--port"
+      "8080"
+    ];
+    ExposedPorts = {
+      "8080/tcp" = { };
+    };
+    Env = [ "HIP_VISIBLE_DEVICES=0" ];
+    User = "65532:65532";
+    WorkingDir = "/";
+  };
+
+  meta = with lib; {
+    description = "llama.cpp ROCm (gfx1151) inference server container";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -10,6 +10,12 @@ build:
           github:shikanime-studio/nix-containers/29ee036601b500007fb1c30f542a51876536676c
           -- skaffold build
       image: ghcr.io/shikanime-labs/machines/catbox
+    - custom:
+        buildCommand:
+          nix run
+          github:shikanime-studio/nix-containers/4ee46a03704810caf7763a1769f41b6a5d1fd27d
+          -- skaffold build
+      image: ghcr.io/shikanime-labs/machines/llama-cpp-oci
   tagPolicy:
     customTemplate:
       template: latest


### PR DESCRIPTION
## What

Adds a layered OCI image of llama.cpp with ROCm (gfx1151) + RPC support:

- pkgs/llama-cpp/default.nix — dockerTools.buildLayeredImage producing a plain docker-archive tarball (cross-platform, no stream wrapper)
- modules/flake/packages.nix — registers packages.x86_64-linux.llama-cpp (x86_64-linux only; ROCm userland does not exist elsewhere)
- skaffold.yaml — second artifact ghcr.io/shikanime-labs/machines/llama-cpp, pinned to nix-containers main (4ee46a0)

## Why

The nix-containers Skaffold builder publishes images straight from Nix; a standard layered tarball keeps the image cross-platform and independent of the streaming builder, matching the catbox flow.

## Verification

nix build of packages.x86_64-linux.llama-cpp on an x86_64-linux host: exit 0; archive inspected — valid docker-layout layers, manifest json reports architecture amd64 / os linux with the llama-server entrypoint config.

Related: https://github.com/shikanime-labs/machines/issues/1268