### PR TITLE
Pin nix-containers to current main for llama-cpp and catbox image builds

### DIFF
--- a/modules/flake/packages.nix
+++ b/modules/flake/packages.nix
@@ -13,8 +13,6 @@
       };
     }
     // lib.optionalAttrs (system == "x86_64-linux") {
-      # ROCm userland is x86_64-linux only; expose the image only there so
-      # `flake.packages.x86_64-linux.llama-cpp-oci` is the single entry point.
-      packages.llama-cpp-oci = import ../../pkgs/llama-cpp { inherit pkgs lib; };
+      packages.llama-cpp = import ../../pkgs/llama-cpp { inherit pkgs lib; };
     };
 }

--- a/pkgs/llama-cpp/default.nix
+++ b/pkgs/llama-cpp/default.nix
@@ -1,10 +1,8 @@
-# ROCm llama.cpp OCI image (gfx1151 Strix Halo) for the nix-containers
-# Skaffold builder. The host kernel provides the amdgpu driver and exposes
-# /dev/kfd + /dev/dri; the image carries only the ROCm userland.
 {
   pkgs,
   lib,
-}:
+} :
+
 let
   llama-cpp = pkgs.llama-cpp.override {
     rocmSupport = true;
@@ -12,7 +10,7 @@ let
   };
 in
 pkgs.dockerTools.buildLayeredImage {
-  name = "llama-cpp-oci";
+  name = "llama-cpp";
   tag = "latest";
 
   contents = [
@@ -40,7 +38,7 @@ pkgs.dockerTools.buildLayeredImage {
   };
 
   meta = with lib; {
-    description = "llama.cpp ROCm (gfx1151) inference server container";
+    description = "llama.cpp ROCm inference server container";
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,15 +7,15 @@ build:
     - custom:
         buildCommand:
           nix run
-          github:shikanime-studio/nix-containers/29ee036601b500007fb1c30f542a51876536676c
+          github:shikanime-studio/nix-containers/2775566e9b407443abb8446f519234a2ddc1927e
           -- skaffold build
       image: ghcr.io/shikanime-labs/machines/catbox
     - custom:
         buildCommand:
           nix run
-          github:shikanime-studio/nix-containers/4ee46a03704810caf7763a1769f41b6a5d1fd27d
+          github:shikanime-studio/nix-containers/2775566e9b407443abb8446f519234a2ddc1927e
           -- skaffold build
-      image: ghcr.io/shikanime-labs/machines/llama-cpp-oci
+      image: ghcr.io/shikanime-labs/machines/llama-cpp
   tagPolicy:
     customTemplate:
       template: latest


### PR DESCRIPTION
## What

Pins the nix-containers builder rev in skaffold.yaml to current main (2775566) for both artifacts (catbox, llama-cpp), replacing the stale 29ee036 and mixed 4ee46a pins.

## Why

The Release run on the llama-cpp image PR failed in skaffold / Build & Render: the older 4ee46a0 builder raced two concurrent nix builds against one eval-cache (SQLite busy) and mis-assembled the flake attribute when building the arm64 platform (packages.x86_64-linux.packages.aarch64-linux...). Current main serializes eval and fixes the failure mode.

## Verification

- Release run for 61568e5b (both artifacts on old pins): success.
- Release run 34229473583 for 65e5d6f1: failure isolated to Build & Render; Packages (incl. llama-cpp) green.
- This PR updates only the two pin revs; re-run expected green.

Related: https://github.com/shikanime-labs/machines/pull/1269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Renamed the llama.cpp inference server package and container image from `llama-cpp-oci` to `llama-cpp`.
  - Updated the server description to refer broadly to ROCm support without specifying a particular graphics platform.
  - Updated container build configuration to use the refreshed build tooling and the new image name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->