### PR TITLE
Build llama-cpp and catbox images with wharf --flake (rebased)

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,14 +7,14 @@ build:
     - custom:
         buildCommand:
           nix run
-          github:shikanime-studio/nix-containers/2775566e9b407443abb8446f519234a2ddc1927e
-          -- skaffold build
+          github:shikanime-labs/wharf/86473d6e4aedb3a872a771c890dbaca06c0c74e0
+          -- skaffold build --flake .#catbox
       image: ghcr.io/shikanime-labs/machines/catbox
     - custom:
         buildCommand:
           nix run
-          github:shikanime-studio/nix-containers/2775566e9b407443abb8446f519234a2ddc1927e
-          -- skaffold build
+          github:shikanime-labs/wharf/86473d6e4aedb3a872a771c890dbaca06c0c74e0
+          -- skaffold build --flake .#llama-cpp
       image: ghcr.io/shikanime-labs/machines/llama-cpp
   tagPolicy:
     customTemplate:


### PR DESCRIPTION
Add ROCm llama.cpp docker image

Switch the Skaffold builder to wharf (shikanime-labs/wharf, the renamed
nix-containers) using its new --flake flag: the llama-cpp artifact builds
from packages.x86_64-linux.llama-cpp while the registry name stays
ghcr.io/shikanime-labs/machines/llama-cpp; catbox moves to the same pin.

Related: https://github.com/shikanime-labs/machines/issues/1268
