### PR TITLE
Build llama-cpp and catbox images with wharf --flake

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,14 +7,14 @@ build:
     - custom:
         buildCommand:
           nix run
-          github:shikanime-labs/wharf/86473d6e4aedb3a872a771c890dbaca06c0c74e0
-          -- skaffold build --flake .#catbox
+          github:shikanime-labs/wharf/d1faf2b6
+          -- skaffold build --flake .
       image: ghcr.io/shikanime-labs/machines/catbox
     - custom:
         buildCommand:
           nix run
-          github:shikanime-labs/wharf/86473d6e4aedb3a872a771c890dbaca06c0c74e0
-          -- skaffold build --flake .#llama-cpp
+          github:shikanime-labs/wharf/d1faf2b6
+          -- skaffold build --flake .
       image: ghcr.io/shikanime-labs/machines/llama-cpp
   tagPolicy:
     customTemplate:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -7,14 +7,14 @@ build:
     - custom:
         buildCommand:
           nix run
-          github:shikanime-studio/nix-containers/2775566e9b407443abb8446f519234a2ddc1927e
-          -- skaffold build
+          github:shikanime-labs/wharf/86473d6e4aedb3a872a771c890dbaca06c0c74e0
+          -- skaffold build --flake .#catbox
       image: ghcr.io/shikanime-labs/machines/catbox
     - custom:
         buildCommand:
           nix run
-          github:shikanime-studio/nix-containers/2775566e9b407443abb8446f519234a2ddc1927e
-          -- skaffold build
+          github:shikanime-labs/wharf/86473d6e4aedb3a872a771c890dbaca06c0c74e0
+          -- skaffold build --flake .#llama-cpp
       image: ghcr.io/shikanime-labs/machines/llama-cpp
   tagPolicy:
     customTemplate:


### PR DESCRIPTION
Add ROCm llama.cpp docker image

Switch the Skaffold builder to wharf (shikanime-labs/wharf, the renamed
nix-containers) using its new --flake flag: the llama-cpp artifact builds
from packages.x86_64-linux.llama-cpp while the registry name stays
ghcr.io/shikanime-labs/machines/llama-cpp; catbox moves to the same pin.

Related: https://github.com/shikanime-labs/machines/issues/1268


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the container build configuration to use the latest approved build source.
  - Made flake selection explicit to improve build consistency and reliability.
  - No end-user-facing functionality or interface changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->