### PR TITLE
Pin llama-cpp image build to linux/amd64 only

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -8,13 +8,13 @@ build:
         buildCommand:
           nix run
           github:shikanime-labs/wharf/d1faf2b6
-          -- skaffold build --flake .
+          -- skaffold build --flake . --platforms linux/amd64,linux/arm64
       image: ghcr.io/shikanime-labs/machines/catbox
     - custom:
         buildCommand:
           nix run
           github:shikanime-labs/wharf/d1faf2b6
-          -- skaffold build --flake .
+          -- skaffold build --flake . --platforms linux/amd64
       image: ghcr.io/shikanime-labs/machines/llama-cpp
   tagPolicy:
     customTemplate:


### PR DESCRIPTION
## What

Fixes the llama-cpp artifact's wharf invocation: `--platforms` is a flag of the root `build` command, not `skaffold build`. The artifact now calls:

```
nix run github:shikanime-labs/wharf/d1faf2b6 -- build --flake . --accept-flake-config --platforms linux/amd64
```

catbox keeps `skaffold build` (both platforms, Skaffold-driven).

## Why

The llama-cpp image is ROCm-only (x86_64-linux userland); the wharf aarch64 platform arm could never resolve a package and failed the whole Release run. The first pin attempt passed `--platforms` to `skaffold build`, which wharf rejected with `unknown flag: --platforms` (Release run 34253725584).

## Verification

- `nix run github:shikanime-labs/wharf/d1faf2b6 -- build --help` shows `--platforms` on the root `build` command only.
- `packages.x86_64-linux.llama-cpp` builds green on x86_64-linux.

Related: https://github.com/shikanime-labs/machines/pull/1276
