### PR TITLE
Switch llama.cpp package to the glm5next-capable unslothai fork

### DIFF
--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -21,9 +21,8 @@
   # points at this host on the service port.
   services.llama-cpp = {
     enable = true;
-    package = pkgs.llama-cpp.override {
-      rocmSupport = true;
-      rpcSupport = true;
+    package = pkgs.callPackage ../../pkgs/llama-cpp/default.nix {
+      inherit (pkgs) system;
     };
     openFirewall = true;
     settings = {

--- a/pkgs/llama-cpp/default.nix
+++ b/pkgs/llama-cpp/default.nix
@@ -8,10 +8,21 @@
 let
   rocmSupport = system == "x86_64-linux";
   vulkanSupport = system == "aarch64-linux";
-  llama-cpp = pkgs.llama-cpp.override {
-    inherit rocmSupport vulkanSupport;
-    rpcSupport = true;
+  glm5nextSrc = pkgs.fetchFromGitHub {
+    owner = "unslothai";
+    repo = "llama.cpp";
+    rev = "b9b8207fcfc2962093b9466df7af4ff29c2a81ef";
+    hash = "sha256-V8a8OzIKeFBBJGAIiyIuRdT215mLTmGBLHWzfU8If4o=";
   };
+  llama-cpp =
+    (pkgs.llama-cpp.override {
+      inherit rocmSupport vulkanSupport;
+      rpcSupport = true;
+    }).overrideAttrs
+      (_old: {
+        version = "0.4.0-glm5next";
+        src = glm5nextSrc;
+      });
 in
 pkgs.dockerTools.buildLayeredImage {
   name = "llama-cpp";


### PR DESCRIPTION
## What

Point the machines llama.cpp package at the unsouthai fork branch
`glm5next/upstream` (rev b9b8207fcfc2962093b9466df7af4ff29c2a81ef) via
`overrideAttrs` on the existing nixpkgs expression, keeping the ROCm /
Vulkan / RPC support switching intact. sashina's `services.llama-cpp`
package now uses this package instead of a raw `pkgs.llama-cpp.override`,
so the host-floor router and the OCI image share one glm5next-capable
build.

- `pkgs/llama-cpp/default.nix` — fork src + version `0.4.0-glm5next`
- `hosts/sashina/configuration.nix` — package via `callPackage` of the
  repo package

## Why

nixpkgs llama-cpp rejects the GLM-5.3-Flash GGUF with
`unknown model architecture: 'glm5next'`, so the model cannot load on
sashina even though the ~120 GB GGUF is fully cached. The `glm5next`
architecture is only carried by the unslothai fork. Building both the
host service and the image from the same forked package also puts both
on the fork's newer ggml RPC protocol, which should be re-tested against
the llama.cpp 0.2.0 RPC segfault seen during the two-node GPU tests.

## References

Related: https://github.com/shikanime-labs/machines/issues/1280

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Co-authored-by: Automata <automata@shikanime.studio>
