### PR TITLE
Fix A2A 502s: drop A2A_HOST so the platform uses its loopback default

### DIFF
--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -562,7 +562,6 @@ in
       };
       hermes-agent-a2a-env = {
         content = ''
-          A2A_HOST=0.0.0.0
           A2A_PORT=9900
           A2A_AGENT_NAME=${config.networking.hostName}
           A2A_PUBLIC_URL=https://${config.networking.hostName}.taila659a.ts.net:9900


### PR DESCRIPTION
## What

- Remove `A2A_HOST=0.0.0.0` from the `hermes-agent-a2a-env` sops template. The platform plugin already defaults to a `127.0.0.1` bind when `A2A_HOST` is unset.

## Why

Fleet-wide A2A probes returned 502 on `https://<host>.taila659a.ts.net:9900`. Agent logs on `minish` show the cause, repeating every 5 minutes:

```
ERROR hermes_plugins.a2a_platform.adapter: A2A: could not bind 0.0.0.0:9900 — [Errno 98] Address already in use
```

`tailscale serve --https=9900` terminates TLS on the tailnet IP and proxies to the local agent, but tailscaled itself holds `<ts-ip>:9900` — so a `0.0.0.0` bind collides with it and the A2A socket never comes up. With `A2A_HOST` unset the plugin binds loopback: the same shape as the api_server on `:8642`, which already works. Inbound auth (`A2A_PEER_TOKENS` + `A2A_TRUSTED_PEERS`) is unchanged and still gates the public URL.

Verified: `nix eval` of the rendered `hermes-agent-a2a-env` template on `fushi` no longer contains `A2A_HOST`.

## References

Related: https://github.com/shikanime-labs/machines/issues/1281
