### PR TITLE
Grant hermes read-only journal access for node health checks

### DIFF
--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -210,6 +210,13 @@ in
     rtk
   ];
 
+  # Fleet agents self-check node health (journalctl -u, dmesg). Read-only
+  # journal access only — deliberately NOT wheel (no sudo for agents).
+  users.users.hermes.extraGroups = [
+    "adm"
+    "systemd-journal"
+  ];
+
   networking.firewall.allowedTCPPorts = [
     9900
     8642


### PR DESCRIPTION
## What

- `users.users.hermes.extraGroups = [ "adm" "systemd-journal" ];` in the shared fleet `ai.nix` profile.

## Why

Fleet agents self-check node health but cannot read the journal: the `hermes` system user has only its own group (`id hermes` on `minish` → `uid=992 groups=990(hermes)`), so `journalctl -u`, `dmesg`, and OOM/kill investigations come back permission-denied, and agent self-checks report UNKNOWN instead of real state.

- `adm` + `systemd-journal` = read-only journal access. Deliberately **not** `wheel` — agents must not hold sudo.
- No `docker` group: RKE2 nodes run containerd, there is no docker daemon, and `docker ps` cannot work there. Container state is visible through the Kubernetes plane instead.
- No `systemd-journal-remote`: that is a log **receiver**, not a reader.
- Kubernetes-level metrics already flow via the node_exporter → vmagent pipeline in `base.nix`; this only fixes the agent's *local* diagnostic reach.

Verified: `nix eval .#nixosConfigurations.fushi.config.users.users.hermes.extraGroups` → `["adm","systemd-journal"]`.

## References

Related: https://github.com/shikanime-labs/machines/issues/1281
