### PR TITLE
Restructure llama-cpp packages into server and OCI image

### DIFF
--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -21,7 +21,7 @@
   # points at this host on the service port.
   services.llama-cpp = {
     enable = true;
-    package = pkgs.callPackage ../../pkgs/llama-cpp/default.nix {
+    package = pkgs.callPackage ../../pkgs/llama-cpp/package.nix {
       inherit (pkgs) system;
     };
     openFirewall = true;

--- a/pkgs/llama-cpp/default.nix
+++ b/pkgs/llama-cpp/default.nix
@@ -7,22 +7,7 @@
 
 let
   rocmSupport = system == "x86_64-linux";
-  vulkanSupport = system == "aarch64-linux";
-  glm5nextSrc = pkgs.fetchFromGitHub {
-    owner = "unslothai";
-    repo = "llama.cpp";
-    rev = "b9b8207fcfc2962093b9466df7af4ff29c2a81ef";
-    hash = "sha256-V8a8OzIKeFBBJGAIiyIuRdT215mLTmGBLHWzfU8If4o=";
-  };
-  llama-cpp =
-    (pkgs.llama-cpp.override {
-      inherit rocmSupport vulkanSupport;
-      rpcSupport = true;
-    }).overrideAttrs
-      (_old: {
-        version = "0.4.0-glm5next";
-        src = glm5nextSrc;
-      });
+  llama-cpp = pkgs.callPackage ./package.nix { inherit system; };
 in
 pkgs.dockerTools.buildLayeredImage {
   name = "llama-cpp";

--- a/pkgs/llama-cpp/package.nix
+++ b/pkgs/llama-cpp/package.nix
@@ -1,0 +1,26 @@
+{
+  pkgs,
+  system,
+  ...
+}:
+
+let
+  rocmSupport = system == "x86_64-linux";
+  vulkanSupport = system == "aarch64-linux";
+  glm5nextSrc = pkgs.fetchFromGitHub {
+    owner = "unslothai";
+    repo = "llama.cpp";
+    rev = "b9b8207fcfc2962093b9466df7af4ff29c2a81ef";
+    hash = "sha256-V8a8OzIKeFBBJGAIiyIuRdT215mLTmGBLHWzfU8If4o=";
+  };
+  llama-cpp =
+    (pkgs.llama-cpp.override {
+      inherit rocmSupport vulkanSupport;
+      rpcSupport = true;
+    }).overrideAttrs
+      (_old: {
+        version = "0.4.0-glm5next";
+        src = glm5nextSrc;
+      });
+in
+llama-cpp


### PR DESCRIPTION
## What

Split the llama-cpp package: pkgs/llama-cpp now holds the glm5next llama.cpp server derivation (what the NixOS module needs), and pkgs/llama-cpp-oci-image holds the container image. The flake llama-cpp attribute keeps resolving to the published image, so the skaffold artifacts and ghcr.io registry names stay unchanged; sashina's host service consumes the server derivation by path.

## Why

services.llama-cpp on sashina consumed the dockerTools image package, so systemd tried to exec from the tarball store path and the unit failed with status 203/EXEC (Not a directory), leaving the host-floor router down. The module contract is a derivation with a bin/llama-server, not a container tarball.

## References

Related: https://github.com/shikanime-labs/machines/issues/1280

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>

Co-authored-by: Automata <automata@shikanime.studio>