### PR TITLE
Restructure llama-cpp packages into server and OCI image

### DIFF
--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -21,7 +21,7 @@
   # points at this host on the service port.
   services.llama-cpp = {
     enable = true;
-    package = pkgs.callPackage ../../pkgs/llama-cpp/package.nix {
+    package = pkgs.callPackage ../../pkgs/llama-cpp/default.nix {
       inherit (pkgs) system;
     };
     openFirewall = true;

--- a/modules/flake/packages.nix
+++ b/modules/flake/packages.nix
@@ -13,6 +13,8 @@
       };
     }
     // lib.optionalAttrs (system == "x86_64-linux" || system == "aarch64-linux") {
-      packages.llama-cpp = pkgs.callPackage ../../pkgs/llama-cpp/default.nix { inherit system; };
+      packages.llama-cpp = pkgs.callPackage ../../pkgs/llama-cpp-oci-image/default.nix {
+        inherit system;
+      };
     };
 }

--- a/pkgs/llama-cpp-oci-image/default.nix
+++ b/pkgs/llama-cpp-oci-image/default.nix
@@ -1,0 +1,49 @@
+{
+  pkgs,
+  lib,
+  system,
+  ...
+}:
+
+let
+  rocmSupport = system == "x86_64-linux";
+  llama-cpp = pkgs.callPackage ../llama-cpp/default.nix { inherit system; };
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "llama-cpp-oci-image";
+  tag = "latest";
+
+  contents = [
+    pkgs.dockerTools.caCertificates
+    pkgs.dockerTools.usrBinEnv
+    llama-cpp
+  ];
+
+  config = {
+    Entrypoint = [ "${llama-cpp}/bin/ggml-rpc-server" ];
+    Cmd = [
+      "--host"
+      "0.0.0.0"
+      "--port"
+      "50052"
+    ];
+    ExposedPorts = {
+      "50052/tcp" = { };
+    };
+    Env = lib.optionals rocmSupport [ "HIP_VISIBLE_DEVICES=0" ];
+    User = "65532:65532";
+    WorkingDir = "/";
+  };
+
+  meta = with lib; {
+    description =
+      if rocmSupport then
+        "llama.cpp ROCm RPC server container"
+      else
+        "llama.cpp Vulkan RPC server container";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}

--- a/pkgs/llama-cpp/default.nix
+++ b/pkgs/llama-cpp/default.nix
@@ -1,49 +1,23 @@
 {
   pkgs,
-  lib,
   system,
   ...
 }:
 
 let
   rocmSupport = system == "x86_64-linux";
-  llama-cpp = pkgs.callPackage ./package.nix { inherit system; };
+  vulkanSupport = system == "aarch64-linux";
 in
-pkgs.dockerTools.buildLayeredImage {
-  name = "llama-cpp";
-  tag = "latest";
-
-  contents = [
-    pkgs.dockerTools.caCertificates
-    pkgs.dockerTools.usrBinEnv
-    llama-cpp
-  ];
-
-  config = {
-    Entrypoint = [ "${llama-cpp}/bin/ggml-rpc-server" ];
-    Cmd = [
-      "--host"
-      "0.0.0.0"
-      "--port"
-      "50052"
-    ];
-    ExposedPorts = {
-      "50052/tcp" = { };
+(pkgs.llama-cpp.override {
+  inherit rocmSupport vulkanSupport;
+  rpcSupport = true;
+}).overrideAttrs
+  (_old: {
+    version = "0.4.0-glm5next";
+    src = pkgs.fetchFromGitHub {
+      owner = "unslothai";
+      repo = "llama.cpp";
+      rev = "b9b8207fcfc2962093b9466df7af4ff29c2a81ef";
+      hash = "sha256-V8a8OzIKeFBBJGAIiyIuRdT215mLTmGBLHWzfU8If4o=";
     };
-    Env = lib.optionals rocmSupport [ "HIP_VISIBLE_DEVICES=0" ];
-    User = "65532:65532";
-    WorkingDir = "/";
-  };
-
-  meta = with lib; {
-    description =
-      if rocmSupport then
-        "llama.cpp ROCm RPC server container"
-      else
-        "llama.cpp Vulkan RPC server container";
-    platforms = [
-      "x86_64-linux"
-      "aarch64-linux"
-    ];
-  };
-}
+  })


### PR DESCRIPTION
## What

Split the llama-cpp package: pkgs/llama-cpp now holds the glm5next llama.cpp server derivation (what the NixOS module needs), and pkgs/llama-cpp-oci-image holds the container image. The flake llama-cpp attribute keeps resolving to the published image, so the skaffold artifacts and ghcr.io registry names stay unchanged; sashina's host service consumes the server derivation by path.

## Why

services.llama-cpp on sashina consumed the dockerTools image package, so systemd tried to exec from the tarball store path and the unit failed with status 203/EXEC (Not a directory), leaving the host-floor router down. The module contract is a derivation with a bin/llama-server, not a container tarball.

## References

Related: https://github.com/shikanime-labs/machines/issues/1280

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>

Co-authored-by: Automata <automata@shikanime.studio>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a container image for the llama.cpp RPC server.
  * The image supports `x86_64-linux` and `aarch64-linux` platforms.
  * Added Vulkan support across supported platforms, with ROCm support on x86_64 Linux.
  * The RPC server is available on TCP port 50052 and listens on all network interfaces.

* **Updates**
  * Updated the llama.cpp package build to use a pinned upstream revision and enable RPC support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->