### PR TITLE
Add k9s plugins for log tailing and Flux kustomizations

### DIFF
--- a/modules/home/cloud.nix
+++ b/modules/home/cloud.nix
@@ -7,10 +7,74 @@
 
   catppuccin.k9s.enable = false;
 
+  home.packages = with pkgs; [
+    fluxcd
+    stern
+  ];
+
   programs = {
     k9s = {
       enable = true;
       settings.k9s.ui.skin = "transparent";
+
+      plugins = {
+        logs = {
+          shortCut = "Ctrl-L";
+          description = "Tail pod logs with stern";
+          scopes = [ "po" ];
+          command = "stern";
+          background = false;
+          args = [
+            "$NAME"
+            "-n"
+            "$NAMESPACE"
+            "--context"
+            "$CONTEXT"
+          ];
+        };
+
+        flux-reconcile = {
+          shortCut = "Ctrl-R";
+          description = "Reconcile Flux Kustomization";
+          scopes = [
+            "ks"
+            "kustomizations"
+          ];
+          command = "flux";
+          background = true;
+          args = [
+            "reconcile"
+            "kustomization"
+            "$NAME"
+            "-n"
+            "$NAMESPACE"
+            "--context"
+            "$CONTEXT"
+          ];
+        };
+
+        flux-suspend = {
+          shortCut = "Ctrl-S";
+          description = "Suspend Flux Kustomization";
+          scopes = [
+            "ks"
+            "kustomizations"
+          ];
+          command = "flux";
+          background = false;
+          confirm = true;
+          args = [
+            "suspend"
+            "kustomization"
+            "$NAME"
+            "-n"
+            "$NAMESPACE"
+            "--context"
+            "$CONTEXT"
+          ];
+        };
+
+      };
     };
 
     ssh.settings."ssh.dev.azure.com" = {


### PR DESCRIPTION
## What

Add three k9s plugins to the shared home-manager cloud profile: stern log tails (`Ctrl-L` on pods), Flux Kustomization reconcile (`Ctrl-R`), and suspend with confirmation (`Ctrl-S`); plus the `stern` binary (`flux` is already on PATH).

## Why

stern tails logs across multiple pods with a single selector, which plain `kubectl logs` cannot do; the Flux actions cover the reconcile/suspend loop used on the fleet. Scope narrowed during review to the plugins without shortcut conflicts or missing upstream precedent.

## References

- Design: shikanime-labs/machines#1286
