### PR TITLE
Realign flake packages on the perSystem pattern

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -163,7 +163,6 @@
       with flake-parts-lib;
       let
         darwinFlakeModule = importApply ./modules/flake/darwin.nix { inherit self; };
-        nixosFlakeModule = importApply ./modules/flake/nixos.nix { inherit self; };
       in
       {
         imports = [
@@ -173,7 +172,7 @@
           devlib.flakeModule
           darwinFlakeModule
           git-hooks.flakeModule
-          nixosFlakeModule
+          ./modules/flake/nixos.nix
           treefmt-nix.flakeModule
         ];
         systems = [

--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -1,4 +1,3 @@
-{ self, ... }:
 { inputs, ... }:
 
 let
@@ -240,22 +239,17 @@ in
       kushira = mkKushiraNixosConfiguration "x86_64-linux";
     };
 
-    packages = {
-      x86_64-linux = {
-        ashira = self.nixosConfigurations.ashira.config.system.build.toplevel;
-        catbox = mkCatboxPackage "x86_64-linux";
-        kushira = self.nixosConfigurations.kushira.config.system.build.toplevel;
-        manash = self.nixosConfigurations.manash.config.system.build.toplevel;
-        nalsha = self.nixosConfigurations.nalsha.config.system.build.toplevel;
-        nixtar = self.nixosConfigurations.nixtar.config.system.build.toplevel;
-        sashina = self.nixosConfigurations.sashina.config.system.build.toplevel;
-      };
-      aarch64-linux = {
-        catbox = mkCatboxPackage "aarch64-linux";
-        fushi = self.nixosConfigurations.fushi.config.system.build.toplevel;
-        minish = self.nixosConfigurations.minish.config.system.build.toplevel;
-        nemishi = self.nixosConfigurations.nemishi.config.system.build.toplevel;
+  };
+
+  perSystem =
+    {
+      lib,
+      system,
+      ...
+    }:
+    {
+      packages = lib.optionalAttrs (system == "x86_64-linux" || system == "aarch64-linux") {
+        catbox-oci-image = mkCatboxPackage system;
       };
     };
-  };
 }

--- a/modules/flake/packages.nix
+++ b/modules/flake/packages.nix
@@ -13,8 +13,13 @@
       };
     }
     // lib.optionalAttrs (system == "x86_64-linux" || system == "aarch64-linux") {
-      packages.llama-cpp = pkgs.callPackage ../../pkgs/llama-cpp-oci-image/default.nix {
-        inherit system;
+      packages = {
+        llama-cpp = pkgs.callPackage ../../pkgs/llama-cpp-oci-image/default.nix {
+          inherit system;
+        };
+        llama-cpp-oci-image = pkgs.callPackage ../../pkgs/llama-cpp-oci-image/default.nix {
+          inherit system;
+        };
       };
     };
 }


### PR DESCRIPTION
## What

Realign the flake packages on the perSystem packages = { } pattern: llama-cpp (server derivation) and llama-cpp-oci-image (container) as one attrset, catbox containerdisk renamed to packages.catbox-oci-image for both arches, and the useless per-host system.build.toplevel entries dropped (nixosConfigurations remain the canonical entry points).

## Why

The llama-cpp restructure left the package set inconsistent: per-attr assignments mixed with per-system literal maps, the catbox image attr name diverged from its -oci-image sibling, and duplicate toplevel entries shadowed nixosConfigurations without adding a consumer.

## References

Related: https://github.com/shikanime-labs/machines/issues/1280

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>

Co-authored-by: Automata <automata@shikanime.studio>