### PR TITLE
Add Flux HelmRelease, trace, and suspended-view k9s plugins

### DIFF
--- a/modules/home/cloud.nix
+++ b/modules/home/cloud.nix
@@ -33,15 +33,35 @@
           ];
         };
 
-        flux-reconcile = {
-          shortCut = "Ctrl-R";
-          description = "Reconcile Flux Kustomization";
+        ks-toggle = {
+          shortCut = "Shift-T";
+          description = "Toggle Kustomization suspend";
+          scopes = [
+            "ks"
+            "kustomizations"
+          ];
+          command = "bash";
+          background = false;
+          confirm = true;
+          args = [
+            "-c"
+            ''
+              suspended=$(kubectl --context $CONTEXT get kustomizations -n $NAMESPACE $NAME -o=custom-columns=TYPE:.spec.suspend | tail -1);
+              verb=$([ $suspended = "true" ] && echo resume || echo suspend);
+              flux $verb kustomization --context $CONTEXT -n $NAMESPACE $NAME | less -K
+            ''
+          ];
+        };
+
+        ks-reconcile = {
+          shortCut = "Shift-R";
+          description = "Reconcile Kustomization";
           scopes = [
             "ks"
             "kustomizations"
           ];
           command = "flux";
-          background = true;
+          background = false;
           args = [
             "reconcile"
             "kustomization"
@@ -53,24 +73,78 @@
           ];
         };
 
-        flux-suspend = {
-          shortCut = "Ctrl-S";
-          description = "Suspend Flux Kustomization";
-          scopes = [
-            "ks"
-            "kustomizations"
-          ];
-          command = "flux";
+        hr-toggle = {
+          shortCut = "Shift-T";
+          description = "Toggle HelmRelease suspend";
+          scopes = [ "helmreleases" ];
+          command = "bash";
           background = false;
           confirm = true;
           args = [
-            "suspend"
-            "kustomization"
+            "-c"
+            ''
+              suspended=$(kubectl --context $CONTEXT get helmreleases -n $NAMESPACE $NAME -o=custom-columns=TYPE:.spec.suspend | tail -1);
+              verb=$([ $suspended = "true" ] && echo resume || echo suspend);
+              flux $verb helmrelease --context $CONTEXT -n $NAMESPACE $NAME | less -K
+            ''
+          ];
+        };
+
+        hr-reconcile = {
+          shortCut = "Shift-R";
+          description = "Reconcile HelmRelease";
+          scopes = [ "helmreleases" ];
+          command = "flux";
+          background = false;
+          args = [
+            "reconcile"
+            "helmrelease"
             "$NAME"
             "-n"
             "$NAMESPACE"
             "--context"
             "$CONTEXT"
+          ];
+        };
+
+        trace = {
+          shortCut = "Shift-Q";
+          description = "Flux trace";
+          scopes = [ "all" ];
+          command = "bash";
+          background = false;
+          args = [
+            "-c"
+            ''
+              if [ -n "$RESOURCE_GROUP" ]; then api_endpoint="/apis/$RESOURCE_GROUP/$RESOURCE_VERSION"; else api_endpoint="/api/$RESOURCE_VERSION"; fi;
+              api_resource=$(kubectl get --raw "$api_endpoint" | jq -r ".resources[] | select(.name==\"$RESOURCE_NAME\")");
+              kind=$(echo $api_resource | jq -r ".kind");
+              namespace_arg=$(echo $api_resource | jq -r "if .namespaced == true then \"--namespace $NAMESPACE\" else \"\" end");
+              [ -n "$RESOURCE_GROUP" ] && api_version=$RESOURCE_GROUP/;
+              api_version=$api_version$RESOURCE_VERSION;
+              flux trace --context $CONTEXT --kind $kind --api-version $api_version $namespace_arg $NAME |& less -K
+            ''
+          ];
+        };
+
+        suspended = {
+          shortCut = "Shift-S";
+          description = "List suspended Flux resources";
+          scopes = [
+            "ks"
+            "hr"
+            "kustomizations"
+            "helmreleases"
+          ];
+          command = "bash";
+          background = false;
+          args = [
+            "-c"
+            ''
+              for kind in kustomizations.kustomize.toolkit.fluxcd.io helmreleases.helm.toolkit.fluxcd.io; do
+                kubectl get --context $CONTEXT --all-namespaces $kind -o json 2>/dev/null;
+              done | jq -s -r 'map(.items[]?) | .[] | select(.spec.suspend==true) | [.kind,.metadata.namespace,.metadata.name] | @tsv' | less -K
+            ''
           ];
         };
 


### PR DESCRIPTION
## What

- HelmRelease plugin set: Shift-T suspend/resume toggle (state-aware), Shift-R reconcile
- Universal Flux trace (Shift-Q, all views): resolves resource → owning Kustomization/HelmRelease path
- Suspended inventory view (Shift-S): all suspended Kustomizations + HelmReleases across namespaces

## Why

Backports sofka's remaining native gaps (HelmRelease actions, explain-why trace, suspended inventory) into k9s instead of adopting an early-stage single-author TUI, per the #1284 parity analysis. Complements the Kustomization plugins from #1288.

## References

- #1284
- #1288
- https://github.com/derailed/k9s/blob/master/plugins/flux.yaml

Co-authored-by: Automata <automata@shikanime.studio>