### PR TITLE
Grant hermes read-only journal access for node health checks

### DIFF
--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -210,6 +210,12 @@ in
     rtk
   ];
 
+  # Fleet agents self-check node health (journalctl -u, dmesg). Read-only
+  # journal access only — deliberately NOT wheel (no sudo for agents).
+  users.users.hermes.extraGroups = [
+    "adm"
+    "systemd-journal"
+  ];
   networking.firewall.allowedTCPPorts = [
     9900
     8642
@@ -464,6 +470,15 @@ in
       ];
     };
   };
+
+  # SupplementaryGroups on the unit (not just users.users.hermes.extraGroups):
+  # extraGroups updates /etc/group but the switch does not restart services for
+  # it, so the running agent keeps its old groups. A unit-file attribute makes
+  # the switch restart hermes-agent.service with adm/systemd-journal applied.
+  systemd.services.hermes-agent.serviceConfig.SupplementaryGroups = [
+    "adm"
+    "systemd-journal"
+  ];
 
   # Expose the A2A agent over Tailscale. The agent serves plain HTTP on :9900;
   # `serve --https` terminates TLS at the funnel and forwards to local HTTP,


### PR DESCRIPTION
## What

- `users.users.hermes.extraGroups = [ "adm" "systemd-journal" ];` in the shared fleet `ai.nix` profile.

## Why

Fleet agents self-check node health but cannot read the journal: the `hermes` system user has only its own group (`id hermes` on `minish` → `uid=992 groups=990(hermes)`), so `journalctl -u`, `dmesg`, and OOM/kill investigations come back permission-denied, and agent self-checks report UNKNOWN instead of real state.

- `adm` + `systemd-journal` = read-only journal access. Deliberately **not** `wheel` — agents must not hold sudo.
- No `docker` group: RKE2 nodes run containerd, there is no docker daemon, and `docker ps` cannot work there. Container state is visible through the Kubernetes plane instead.
- No `systemd-journal-remote`: that is a log **receiver**, not a reader.
- Kubernetes-level metrics already flow via the node_exporter → vmagent pipeline in `base.nix`; this only fixes the agent's *local* diagnostic reach.

Rebase note: the A2A loopback half of the original stack landed separately (#1282), and a follow-up (#1291) removes `A2A_HOST` entirely.

Verified: `nix eval .#nixosConfigurations.fushi.config.users.users.hermes.extraGroups` → `["adm","systemd-journal"]`.

## References

Related: https://github.com/shikanime-labs/machines/issues/1281


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Access Controls**
  - Granted the Hermes service read-only access to system logs and kernel messages for node health checks.
  - Hermes remains without administrative or sudo privileges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
