### PR TITLE
Pin hermes-plugin-rtk-rewrite source to v0.45.0

### DIFF
--- a/pkgs/hermes-plugin-rtk-rewrite/default.nix
+++ b/pkgs/hermes-plugin-rtk-rewrite/default.nix
@@ -7,8 +7,8 @@ pkgs.symlinkJoin {
       pkgs.fetchFromGitHub {
         owner = "rtk-ai";
         repo = "rtk";
-        rev = "v0.44.0";
-        hash = "sha256-Ev6w0Gi2y48DYi55GSciCoPgkUFaX44aH3UWGhs1OGk=";
+        rev = "v0.45.0";
+        hash = "sha256-weAyHM0nWLrM8JRbbXIfjUsHtAep3DOFyTO+M3BZ/iU=";
       }
     }/hooks/hermes/rtk-rewrite"
   ];


### PR DESCRIPTION
## What
Pin `pkgs/hermes-plugin-rtk-rewrite` source from v0.44.0 to v0.45.0, matching the deployed rtk binary version.

## Why
Two-month evaluation (2026-07-06 .. 2026-09-09) of the rtk-rewrite Hermes plugin concluded **keep**:

- Verified compression: `kubectl get pods -A` 50,688 → 98 bytes (99%), `git status` −83%, `ls -la` −72%; `git log` byte-identical parity.
- Format-aware: `--porcelain`, `--pretty=format:%H`, `kubectl -o json` outputs byte/structure-identical under rtk.
- Hook latency ~0.02s; fail-open; zero `rtk:` warnings in local agent.log and 7-day fleet journal on manash.
- Only defect found: pin drift (plugin source v0.44.0 vs binary 0.45.0). Hook source byte-identical across both tags, so this is hygiene, not behavior.

## References
Related: https://github.com/rtk-ai/rtk/releases/tag/v0.45.0
