### PR TITLE
Point skaffold artifacts at explicit flake attributes

### DIFF
--- a/modules/flake/packages.nix
+++ b/modules/flake/packages.nix
@@ -14,7 +14,7 @@
     }
     // lib.optionalAttrs (system == "x86_64-linux" || system == "aarch64-linux") {
       packages = {
-        llama-cpp = pkgs.callPackage ../../pkgs/llama-cpp-oci-image/default.nix {
+        llama-cpp = pkgs.callPackage ../../pkgs/llama-cpp/default.nix {
           inherit system;
         };
         llama-cpp-oci-image = pkgs.callPackage ../../pkgs/llama-cpp-oci-image/default.nix {

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -12,8 +12,7 @@ build:
     - custom:
         buildCommand:
           nix run github:shikanime-labs/wharf/0059c49 -- skaffold build --flake
-          .#llama-cpp-oci-image --platforms linux/amd64 --option
-          accept-flake-config=true
+          .#llama-cpp-oci-image --option accept-flake-config=true
       image: ghcr.io/shikanime-labs/machines/llama-cpp
   tagPolicy:
     customTemplate:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -6,13 +6,14 @@ build:
   artifacts:
     - custom:
         buildCommand:
-          nix run github:shikanime-labs/wharf/d1faf2b6 -- skaffold build --flake
-          . --accept-flake-config
+          nix run github:shikanime-labs/wharf/0059c49 -- skaffold build --flake
+          .#catbox-oci-image --option accept-flake-config=true
       image: ghcr.io/shikanime-labs/machines/catbox
     - custom:
         buildCommand:
-          nix run github:shikanime-labs/wharf/d1faf2b6 -- skaffold build --flake
-          . --accept-flake-config
+          nix run github:shikanime-labs/wharf/0059c49 -- skaffold build --flake
+          .#llama-cpp-oci-image --platforms linux/amd64 --option
+          accept-flake-config=true
       image: ghcr.io/shikanime-labs/machines/llama-cpp
   tagPolicy:
     customTemplate:


### PR DESCRIPTION
## What

Point both skaffold artifacts at explicit flake attributes (`catbox-oci-image`, `llama-cpp-oci-image`) via the wharf `#fragment` attr override, keeping the ghcr image names (`.../catbox`, `.../llama-cpp`) untouched. Bump the wharf pin `d1faf2b` → `8abf1a9` (adds #fragment attr override; also switches `--accept-flake-config` to `--option accept-flake-config=true`). The llama-cpp artifact keeps its `--platforms linux/amd64` pin.

## Why

Wharf always derived `packages.<system>.<image-last-segment>`, so the `catbox` image broke when the flake attribute became `catbox-oci-image` (Release 34351534565: `does not provide attribute 'packages.aarch64-linux.catbox'`). With the explicit attr, image name and flake attribute no longer have to match.

## References

Related: https://github.com/shikanime-labs/wharf/pull/104
Related: https://github.com/shikanime-labs/machines/pull/1287
