### PR TITLE
Restore catbox flake attr as wharf image-name alias

### DIFF
--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -249,6 +249,7 @@ in
     }:
     {
       packages = lib.optionalAttrs (system == "x86_64-linux" || system == "aarch64-linux") {
+        catbox = mkCatboxPackage system;
         catbox-oci-image = mkCatboxPackage system;
       };
     };


### PR DESCRIPTION
## What

- Restore `packages.<system>.catbox` as an alias of `catbox-oci-image` in `modules/flake/nixos.nix` (one line).

## Why

PR #1289 renamed `packages.catbox` → `packages.catbox-oci-image`, but wharf derives the flake attribute from the image name's last segment (`ghcr.io/shikanime-labs/machines/catbox` → `packages.<sys>.catbox`). Since that rename, every `skaffold / Build & Render` run fails with:

```
flake does not provide attribute 'packages.aarch64-linux.catbox'
```

main's skaffold workflow has been red since #1289 landed, and the red inherits into every open PR's merge ref, blocking landings. The published image tag stays `ghcr.io/shikanime-labs/machines/catbox` — registry names are frozen, KubeVirt pulls it.

Verified locally: `nix eval ...packages.aarch64-linux.catbox.name` → `docker-image-catbox.tar.gz`.

## References

Related: https://github.com/shikanime-labs/machines/pull/1289
