### PR TITLE
Drop the sashina host-floor llama-cpp service

### DIFF
--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -1,5 +1,4 @@
 {
-  pkgs,
   ...
 }:
 
@@ -15,53 +14,6 @@
     ../../modules/nixos/users/builder.nix
     ../../modules/nixos/users/nishir.nix
   ];
-
-  # llama.cpp router — ROCm (gfx1151) + RPC backend, mirroring the runtime
-  # flags the in-cluster LWS used. The Envoy AI Gateway's local-floor Backend
-  # points at this host on the service port.
-  services.llama-cpp = {
-    enable = true;
-    package = pkgs.callPackage ../../pkgs/llama-cpp/default.nix {
-      inherit (pkgs) system;
-    };
-    openFirewall = true;
-    settings = {
-      host = "0.0.0.0";
-      # 8080 is taken by k3s node-local-dns (node-cache on 169.254.20.10)
-      # on every cluster node; use 18080 for the host-level service.
-      port = 18080;
-      # Router preset: section names MUST equal the gateway's
-      # modelNameOverride route keys.
-      models-preset = "/etc/llama-cpp/models-preset.ini";
-      models-dir = "/var/lib/llama-cpp/models";
-      models-max = 5;
-      models-autoload = true;
-      embeddings = true;
-      ctx-size = 32768;
-      flash-attn = "on";
-      cache-type-k = "q8_0";
-      cache-type-v = "q8_0";
-      n-gpu-layers = 999;
-      mmap = false;
-    };
-  };
-
-  environment.etc."llama-cpp/models-preset.ini".text = ''
-    [deepseek/deepseek-v4-flash-0731]
-    hf = unsloth/DeepSeek-V4-Flash-0731-GGUF:UD-Q3_K_M
-
-    [z-ai/glm-5.3-flash]
-    hf = unsloth/GLM-5.3-Flash-GGUF:UD-IQ3_XXS
-
-    [qwen/qwen3.8-27b]
-    hf = unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_XL
-
-    [qwen/qwen3.8-flash]
-    hf = unsloth/Qwen3.8-Flash-Next-GGUF:UD-Q4_K_XL
-
-    [qwen/qwen3-embedding-8b]
-    hf = Qwen/Qwen3-Embedding-8B-GGUF:Q6_K
-  '';
 
   networking = {
     hostName = "sashina";


### PR DESCRIPTION
## What

Remove services.llama-cpp and its models-preset from the sashina NixOS host configuration. Inference serves uniquely from the in-cluster llama-cpp LWS; the Envoy AI Gateway local-floor Backend retargets to the in-cluster service in shikanime-labs/manifests#2213.

## Why

Two inference paths (host-floor router on 18080 + in-cluster LWS) split the model cache, compete for the same UMA memory, and double the maintenance surface. Serving uniquely from the cluster leaves one pool, one cache, and lets llama.cpp claim the node's memory without a host service fighting it.

## References

Related: https://github.com/shikanime-labs/machines/issues/1299

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>

Co-authored-by: Automata <automata@shikanime.studio>
