### PR TITLE
Align ai.nix model routing with skills profiles

### DIFF
--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -168,38 +168,6 @@ in
             "deepseek/deepseek-v4-flash"
           ];
         }
-        {
-          name = "aperture-anthropic";
-          base_url = "https://ai.taila659a.ts.net/v1";
-          api_mode = "anthropic_messages";
-          model = "glm-4.7";
-          models = [
-            "glm-4.7"
-            "glm-5.2"
-          ];
-        }
-        {
-          name = "aperture-openai";
-          base_url = "https://ai.taila659a.ts.net/v1";
-          api_mode = "chat_completions";
-          model = "tencent/hy3:free";
-          models = [
-            "deepseek/deepseek-v4-flash"
-            "gemini-2.5-flash"
-            "gemini-2.5-flash-lite"
-            "gemini-2.5-pro"
-            "gemini-3-flash-preview"
-            "google/gemma-4-e2b"
-            "inclusionai/ling-3.0-flash:free"
-            "labs-leanstral-1-5"
-            "nvidia/nemotron-3-ultra-550b-a55b:free"
-            "openrouter/openrouter/free"
-            "poolside/laguna-xs-2.1:free"
-            "qwen/qwen3-8b"
-            "stepfun/step-3.7-flash:free"
-            "tencent/hy3:free"
-          ];
-        }
       ];
 
       fallback_providers = [
@@ -207,16 +175,6 @@ in
           api_mode = "anthropic_messages";
           model = "z-ai/glm-5.3";
           provider = "custom:shikanime-anthropic";
-        }
-        {
-          api_mode = "chat_completions";
-          model = "deepseek/deepseek-v4-flash";
-          provider = "custom:aperture-openai";
-        }
-        {
-          api_mode = "chat_completions";
-          model = "stepfun/step-3.7-flash:free";
-          provider = "custom:aperture-openai";
         }
         {
           api_mode = "anthropic_messages";
@@ -229,11 +187,6 @@ in
         default = "qwen/qwen3.8-27b";
         provider = "custom:shikanime-anthropic";
         base_url = "https://inference.i.shikanime.studio/anthropic";
-      };
-
-      mcp_servers.aperture = {
-        url = "https://ai.taila659a.ts.net/v1/mcp";
-        enabled = true;
       };
 
       display = {

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -249,35 +249,30 @@ in
         context.engine = "lcm";
         custom_providers = [
           {
-            name = "aperture-anthropic";
-            base_url = "https://ai.taila659a.ts.net/v1";
+            name = "shikanime-anthropic";
             api_mode = "anthropic_messages";
-            model = "glm-4.7";
+            base_url = "https://inference.i.shikanime.studio/anthropic";
+            key_env = "SKS_API_KEY";
+            model = "z-ai/glm-5.3-flash";
             models = [
-              "glm-4.7"
-              "glm-5.2"
+              "z-ai/glm-5.3-flash"
+              "z-ai/glm-5.3"
+              "qwen/qwen3.8-27b"
+              "qwen/qwen3.8-flash"
+              "deepseek/deepseek-v4-flash"
             ];
           }
           {
-            name = "aperture-openai";
-            base_url = "https://ai.taila659a.ts.net/v1";
+            name = "shikanime-openai";
             api_mode = "chat_completions";
-            model = "tencent/hy3:free";
+            base_url = "https://inference.i.shikanime.studio/v1";
+            key_env = "SKS_API_KEY";
+            model = "poolside/laguna-s-2.1:free";
             models = [
+              "poolside/laguna-s-2.1:free"
+              "qwen/qwen3.8-flash"
+              "qwen/qwen3.8-27b"
               "deepseek/deepseek-v4-flash"
-              "gemini-2.5-flash"
-              "gemini-2.5-flash-lite"
-              "gemini-2.5-pro"
-              "gemini-3-flash-preview"
-              "google/gemma-4-e2b"
-              "inclusionai/ling-3.0-flash:free"
-              "labs-leanstral-1-5"
-              "nvidia/nemotron-3-ultra-550b-a55b:free"
-              "openrouter/openrouter/free"
-              "poolside/laguna-xs-2.1:free"
-              "qwen/qwen3-8b"
-              "stepfun/step-3.7-flash:free"
-              "tencent/hy3:free"
             ];
           }
         ];
@@ -300,29 +295,14 @@ in
         };
         fallback_providers = [
           {
-            api_mode = "chat_completions";
-            model = "inclusionai/ling-3.0-flash:free";
-            provider = "custom:aperture-openai";
+            api_mode = "anthropic_messages";
+            model = "z-ai/glm-5.3";
+            provider = "custom:shikanime-anthropic";
           }
           {
-            api_mode = "chat_completions";
-            model = "poolside/laguna-s-2.1:free";
-            provider = "custom:aperture-openai";
-          }
-          {
-            api_mode = "chat_completions";
-            model = "labs-leanstral-1-5";
-            provider = "custom:aperture-openai";
-          }
-          {
-            api_mode = "chat_completions";
-            model = "stepfun/step-3.7-flash:free";
-            provider = "custom:aperture-openai";
-          }
-          {
-            api_mode = "chat_completions";
-            model = "tencent/hy3:free";
-            provider = "custom:aperture-openai";
+            api_mode = "anthropic_messages";
+            model = "deepseek/deepseek-v4-flash";
+            provider = "custom:shikanime-anthropic";
           }
         ];
         matrix = {
@@ -334,80 +314,9 @@ in
         };
         memory.provider = "honcho";
         model = {
-          default = "tencent/hy3:free";
-          provider = "custom:aperture-openai";
-          base_url = "https://ai.taila659a.ts.net/v1";
-        };
-        auxiliary = {
-          vision = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          web_extract = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          compression = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          skills_hub = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          approval = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          mcp = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          title_generation = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          memory_query_rewrite = {
-            provider = "custom:aperture-anthropic:openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          tts_audio_tags = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          triage_specifier = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          kanban_decomposer = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          profile_describer = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-          curator = {
-            provider = "custom:aperture-openai";
-            model = "tencent/hy3:free";
-            base_url = "https://ai.taila659a.ts.net/v1";
-          };
-        };
-        mcp_servers.aperture = {
-          url = "https://ai.taila659a.ts.net/v1/mcp";
-          enabled = true;
+          default = "qwen/qwen3.8-27b";
+          provider = "custom:shikanime-anthropic";
+          base_url = "https://inference.i.shikanime.studio/anthropic";
         };
         # Bare `hermes`/`hermes chat` launches the Ink TUI by default; token
         # streaming on for live agent output. Explicit --cli/--tui still wins.
@@ -415,7 +324,7 @@ in
           interface = "tui";
           streaming = true;
         };
-        # Inbound: serves Agent Card + JSON-RPC on 0.0.0.0:9900. Per-peer
+        # Inbound: serves Agent Card + JSON-RPC on the loopback bind (:9900). Per-peer
         # tokens (A2A_PEER_TOKENS) authenticate each fleet member by name.
         platforms.a2a.enabled = true;
         # Outbound: every host dials only non-self cluster nodes.


### PR DESCRIPTION
## What

Align `modules/nixos/profiles/ai.nix` Hermes model routing with the profile distributions landed in shikanime-labs/skills#240: add the `shikanime-anthropic` (anthropic_messages, `SKS_API_KEY`, GLM flash default) and `shikanime-openai` (chat_completions) custom providers and rebase the fallback chain on the same models (`z-ai/glm-5.3`, `deepseek/deepseek-v4-flash`). Retire the `ai.taila659a.ts.net` aperture inference endpoint in both fleet (`ai.nix`) and workstation (`workstation.nix`) profiles: drop the `auxiliary` task overrides, the `aperture-anthropic`/`aperture-openai` providers, their fallback entries, and the `mcp_servers.aperture` server. Keep the A2A server on its loopback bind default (drop `A2A_HOST=0.0.0.0` — `tailscale serve` already proxies `127.0.0.1:9900`, so the wider bind only exposed the plaintext port past the tailnet proxy).

## Why

The fleet profile previously defaulted to `tencent/hy3:free` via `aperture-openai` and referenced an `inclusionai/ling-3.0-flash:free` fallback no longer present in the shared provider surface. The skills repo profiles now define the canonical shikanime inference routing; agent surfaces should match it so a single model set is maintained. The old tailnet endpoint has no remaining consumer, and its free-tier model list is retired upstream.

## References

Related: https://github.com/shikanime-labs/skills/pull/240