### PR TITLE
Grant hermes read-only journal access for node health checks

### DIFF
--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -210,6 +210,12 @@ in
     rtk
   ];
 
+  # Fleet agents self-check node health (journalctl -u, dmesg). Read-only
+  # journal access only — deliberately NOT wheel (no sudo for agents).
+  users.users.hermes.extraGroups = [
+    "adm"
+    "systemd-journal"
+  ];
   networking.firewall.allowedTCPPorts = [
     9900
     8642
@@ -464,6 +470,15 @@ in
       ];
     };
   };
+
+  # SupplementaryGroups on the unit (not just users.users.hermes.extraGroups):
+  # extraGroups updates /etc/group but the switch does not restart services for
+  # it, so the running agent keeps its old groups. A unit-file attribute makes
+  # the switch restart hermes-agent.service with adm/systemd-journal applied.
+  systemd.services.hermes-agent.serviceConfig.SupplementaryGroups = [
+    "adm"
+    "systemd-journal"
+  ];
 
   # Expose the A2A agent over Tailscale. The agent serves plain HTTP on :9900;
   # `serve --https` terminates TLS at the funnel and forwards to local HTTP,

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -216,6 +216,7 @@ in
     "adm"
     "systemd-journal"
   ];
+
   networking.firewall.allowedTCPPorts = [
     9900
     8642


### PR DESCRIPTION
Grant hermes read-only journal access for node health checks

Add hermes to adm and systemd-journal (read-only journal). Deliberately
not wheel (no sudo for agents) and not docker (RKE2 nodes run containerd).

The unit also sets SupplementaryGroups= so nixos-rebuild switch restarts
hermes-agent.service with the groups applied: extraGroups alone updates
/etc/group without restarting the service, leaving the running agent
with stale group memberships.

Closes #1281 (journal half; A2A half landed in #1282).

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved journal access for the AI service, enabling it to read relevant system logs.
  - Service restarts now consistently apply the required supplementary group permissions, improving reliability when accessing journal data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->