### PR TITLE
Split llama.cpp OCI image into CPU and GPU RPC variants

### DIFF
--- a/modules/flake/packages.nix
+++ b/modules/flake/packages.nix
@@ -20,6 +20,9 @@
         llama-cpp-oci-image = pkgs.callPackage ../../pkgs/llama-cpp-oci-image/default.nix {
           inherit system;
         };
+        llama-cpp-rpc-oci-image = pkgs.callPackage ../../pkgs/llama-cpp-rpc-oci-image/default.nix {
+          inherit system;
+        };
       };
     };
 }

--- a/pkgs/llama-cpp-oci-image/default.nix
+++ b/pkgs/llama-cpp-oci-image/default.nix
@@ -6,8 +6,11 @@
 }:
 
 let
-  rocmSupport = system == "x86_64-linux";
-  llama-cpp = pkgs.callPackage ../llama-cpp/default.nix { inherit system; };
+  llama-cpp = pkgs.callPackage ../llama-cpp/default.nix {
+    inherit system;
+    rocmSupport = false;
+    vulkanSupport = false;
+  };
 in
 pkgs.dockerTools.buildLayeredImage {
   name = "llama-cpp-oci-image";
@@ -20,27 +23,16 @@ pkgs.dockerTools.buildLayeredImage {
   ];
 
   config = {
-    Entrypoint = [ "${llama-cpp}/bin/ggml-rpc-server" ];
-    Cmd = [
-      "--host"
-      "0.0.0.0"
-      "--port"
-      "50052"
-    ];
+    Entrypoint = [ "${llama-cpp}/bin/llama-server" ];
     ExposedPorts = {
-      "50052/tcp" = { };
+      "8080/tcp" = { };
     };
-    Env = lib.optionals rocmSupport [ "HIP_VISIBLE_DEVICES=0" ];
     User = "65532:65532";
     WorkingDir = "/";
   };
 
   meta = with lib; {
-    description =
-      if rocmSupport then
-        "llama.cpp ROCm RPC server container"
-      else
-        "llama.cpp Vulkan RPC server container";
+    description = "llama.cpp server container";
     platforms = [
       "x86_64-linux"
       "aarch64-linux"

--- a/pkgs/llama-cpp-rpc-oci-image/default.nix
+++ b/pkgs/llama-cpp-rpc-oci-image/default.nix
@@ -1,0 +1,52 @@
+{
+  pkgs,
+  lib,
+  system,
+  ...
+}:
+
+let
+  rocmSupport = system == "x86_64-linux";
+  vulkanSupport = system == "aarch64-linux";
+  llama-cpp = pkgs.callPackage ../llama-cpp/default.nix {
+    inherit system rocmSupport vulkanSupport;
+  };
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "llama-cpp-rpc-oci-image";
+  tag = "latest";
+
+  contents = [
+    pkgs.dockerTools.caCertificates
+    pkgs.dockerTools.usrBinEnv
+    llama-cpp
+  ];
+
+  config = {
+    Entrypoint = [ "${llama-cpp}/bin/ggml-rpc-server" ];
+    Cmd = [
+      "--host"
+      "0.0.0.0"
+      "--port"
+      "50052"
+    ];
+    ExposedPorts = {
+      "50052/tcp" = { };
+    };
+    Env = lib.optionals rocmSupport [ "HIP_VISIBLE_DEVICES=0" ];
+    User = "65532:65532";
+    WorkingDir = "/";
+  };
+
+  meta = with lib; {
+    description =
+      if rocmSupport then
+        "llama.cpp ROCm RPC server container"
+      else
+        "llama.cpp Vulkan RPC server container";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+  };
+}

--- a/pkgs/llama-cpp/default.nix
+++ b/pkgs/llama-cpp/default.nix
@@ -1,13 +1,11 @@
 {
   pkgs,
   system,
+  rocmSupport ? system == "x86_64-linux",
+  vulkanSupport ? system == "aarch64-linux",
   ...
 }:
 
-let
-  rocmSupport = system == "x86_64-linux";
-  vulkanSupport = system == "aarch64-linux";
-in
 (pkgs.llama-cpp.override {
   inherit rocmSupport vulkanSupport;
   rpcSupport = true;

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -14,6 +14,11 @@ build:
           nix run github:shikanime-labs/wharf/0059c49 -- skaffold build --flake
           .#llama-cpp-oci-image --option accept-flake-config=true
       image: ghcr.io/shikanime-labs/machines/llama-cpp
+    - custom:
+        buildCommand:
+          nix run github:shikanime-labs/wharf/0059c49 -- skaffold build --flake
+          .#llama-cpp-rpc-oci-image --option accept-flake-config=true
+      image: ghcr.io/shikanime-labs/machines/llama-cpp-rpc
   tagPolicy:
     customTemplate:
       template: latest


### PR DESCRIPTION
## What
Splits the llama.cpp OCI image into two independent packages:

- `pkgs/llama-cpp-oci-image` — CPU inference image: `llama-server` entrypoint, port 8080, no ROCm/Vulkan in the closure.
- `pkgs/llama-cpp-rpc-oci-image` — GPU RPC image: `ggml-rpc-server` entrypoint, port 50052, ROCm on x86_64 and Vulkan on aarch64 (HIP_VISIBLE_DEVICES=0).

`skaffold.yaml` now publishes both: `ghcr.io/shikanime-labs/machines/llama-cpp` (CPU) and `ghcr.io/shikanime-labs/machines/llama-cpp-rpc` (GPU). `pkgs/llama-cpp` exposes `rocmSupport`/`vulkanSupport` overrides so the CPU image builds without the GPU stack.

## Why
The image was all-or-nothing: the RPC/GPU entrypoint was baked in for every consumer, so a plain inference server image had to carry the ROCm closure and could not serve `llama-server`. Two concrete packages keep each image self-explanatory — no flag plumbing between the package layer and the image — while sharing the one llama.cpp expression underneath, and they match the two-node RPC topology where kushira runs the server and sashina exports its GPU over :50052.

Verified by dumping the built config of all four conf derivations (x86_64 + aarch64): entrypoints, ports, and HIP env land on the right variants; the RPC closure pulls rocblas/hipblas, the CPU one does not.

## References
Related: https://github.com/shikanime-labs/machines/pull/1300