### PR TITLE
Split llama.cpp OCI image into CPU and GPU RPC variants

### DIFF
--- a/pkgs/llama-cpp-rpc-oci-image/default.nix
+++ b/pkgs/llama-cpp-rpc-oci-image/default.nix
@@ -7,9 +7,8 @@
 
 let
   rocmSupport = system == "x86_64-linux";
-  vulkanSupport = system == "aarch64-linux";
-  llama-cpp = pkgs.callPackage ../llama-cpp/default.nix {
-    inherit system rocmSupport vulkanSupport;
+  llama-cpp-rpc = pkgs.callPackage ../llama-cpp-rpc/default.nix {
+    inherit system;
   };
 in
 pkgs.dockerTools.buildLayeredImage {
@@ -19,11 +18,11 @@ pkgs.dockerTools.buildLayeredImage {
   contents = [
     pkgs.dockerTools.caCertificates
     pkgs.dockerTools.usrBinEnv
-    llama-cpp
+    llama-cpp-rpc
   ];
 
   config = {
-    Entrypoint = [ "${llama-cpp}/bin/ggml-rpc-server" ];
+    Entrypoint = [ "${llama-cpp-rpc}/bin/ggml-rpc-server" ];
     Cmd = [
       "--host"
       "0.0.0.0"

--- a/pkgs/llama-cpp-rpc/default.nix
+++ b/pkgs/llama-cpp-rpc/default.nix
@@ -3,12 +3,12 @@
   system,
   rocmSupport ? system == "x86_64-linux",
   vulkanSupport ? system == "aarch64-linux",
-  rpcSupport ? false,
   ...
 }:
 
 (pkgs.llama-cpp.override {
-  inherit rocmSupport vulkanSupport rpcSupport;
+  inherit rocmSupport vulkanSupport;
+  rpcSupport = true;
 }).overrideAttrs
   (_old: {
     version = "0.4.0-glm5next";


### PR DESCRIPTION
## What

Split the llama.cpp packaging into a plain CPU server image and a dedicated RPC server image, and wire both as flake packages plus skaffold artifacts.

- Move the ROCm/Vulkan llama.cpp override to pkgs/llama-cpp-rpc (rpcSupport enabled, pinned unslothai GLM5next source) and build llama-cpp-rpc-oci-image on top of it: ROCm on x86_64-linux, Vulkan on aarch64-linux, non-root user, port 50052 exposed.
- Slim pkgs/llama-cpp-oci-image down to a CPU-only llama-server image (no GPU backends, no RPC flags).
- Register llama-cpp, llama-cpp-oci-image and llama-cpp-rpc-oci-image in modules/flake/packages.nix for the Linux platforms, and point skaffold.yaml artifacts at the explicit flake attributes.

## Why

Two-node distributed inference needs a ggml-rpc-server worker image with GPU backends while the router side stays CPU-only; today a single image shape cannot express both roles without shipping unused backends everywhere. The test record for that setup is already on record, and GLM5next loading requires the aggregated VRAM that the RPC split provides, so the images are the missing packaging piece.

## References

Related: https://github.com/shikanime-labs/machines/issues/1299
Related: https://github.com/shikanime-labs/machines/issues/1280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an RPC-enabled llama.cpp package and container image for supported x86_64 and aarch64 platforms.
  - Added the RPC image to the available build artifacts.
  - The RPC container runs the server on port 50052.

- **Changes**
  - Updated the standard llama.cpp container to use the `llama-server` entrypoint and expose port 8080.
  - Standardized hardware acceleration support configuration across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->