### PR TITLE
Enable Hermes session auto-prune across the fleet

### DIFF
--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -209,6 +209,8 @@ in
           rtk-rewrite.allow_tool_override = true;
         };
       };
+
+      sessions.auto_prune = true;
     };
   };
 

--- a/modules/nixos/profiles/ai.nix
+++ b/modules/nixos/profiles/ai.nix
@@ -320,6 +320,7 @@ in
           ];
         };
         memory.provider = "honcho";
+        sessions.auto_prune = true;
         model = {
           default = "qwen/qwen3.8-27b";
           provider = "custom:shikanime-anthropic";


### PR DESCRIPTION
## What

- Set `sessions.auto_prune = true` in `services.hermes-agent.settings` for both config surfaces: `modules/nixos/profiles/ai.nix` (fleet NixOS hosts) and `modules/home/workstation.nix` (darwin workstation).
- Ended sessions inactive past `sessions.retention_days` (default 90) are pruned at CLI/gateway/cron startup; `vacuum_after_prune` stays at its default.

## Why

`hermes doctor` flags the workstation `state.db` as large and recommends enabling `sessions.auto_prune`; session history currently grows unbounded. The upstream docs ship auto-prune as default-on, but the Nix-generated config never sets the key, so the effective live value resolves to `false` on every fleet host.

## References

- https://hermes-agent.nousresearch.com/docs/user-guide/sessions#automatic-cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled automatic pruning of agent sessions in workstation and AI system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->