### PR TITLE
Ship vlagent to the native VictoriaLogs ingest path

### DIFF
--- a/modules/darwin/profiles/base.nix
+++ b/modules/darwin/profiles/base.nix
@@ -75,7 +75,7 @@ in
         ${pkgs.bash}/bin/bash -c 'mkdir -p /var/lib/vlagent && exec ${pkgs.vlagent}/bin/vlagent \
           -fileCollector.glob=/var/log/**/*.log \
           -remoteWrite.tmpDataPath=/var/lib/vlagent \
-          -remoteWrite.url=https://logs.i.shikanime.studio/insert/0/logs'
+          -remoteWrite.url=https://logs.i.shikanime.studio/insert/native'
       '';
       serviceConfig = {
         Label = "org.nixos.vlagent";

--- a/modules/nixos/profiles/base.nix
+++ b/modules/nixos/profiles/base.nix
@@ -137,7 +137,7 @@
 
   services.vlagent = {
     enable = true;
-    remoteWrite.url = "https://logs.i.shikanime.studio/insert/0/logs";
+    remoteWrite.url = "https://logs.i.shikanime.studio/insert/native";
   };
 
   systemd = {


### PR DESCRIPTION
## What

Ship vlagent to `https://logs.i.shikanime.studio/insert/native` in both base
profiles (nixos + darwin). The old URL used the vmagent-style multitenant
shape `/insert/0/logs`, which VictoriaLogs does not route — vlinsert rejects
every request (`unsupported path requested: "/insert/0/logs"`) and the store
has received zero fleet log rows.

## Why

`/insert/<format>` is the single-node ingest path and `/insert/multitenant/<format>`
the tenant path; `/insert/0/logs` is neither. `/insert/native` is the
documented vlagent `-remoteWrite.url` for file collection. Ingestion pipeline
verified healthy end-to-end on nishir: a probe row posted to
`/insert/jsonline` round-trips through vlselect.

## References

Closes: https://github.com/shikanime-labs/machines/issues/1307
Related: https://github.com/shikanime-labs/manifests/issues/2254
