### PR TITLE
Collect fleet host logs with the vlagent file collector

### DIFF
--- a/modules/nixos/profiles/base.nix
+++ b/modules/nixos/profiles/base.nix
@@ -138,6 +138,11 @@
   services.vlagent = {
     enable = true;
     remoteWrite.url = "https://logs.i.shikanime.studio/insert/native";
+    # Collect host logs incl. /var/log/pods/** (k8s container stdout: envoy
+    # dataplane, controllers). Without a glob the file collector ingests nothing.
+    extraArgs = [
+      "-fileCollector.glob=/var/log/**/*.log"
+    ];
   };
 
   systemd = {


### PR DESCRIPTION
## What

Add `-fileCollector.glob=/var/log/**/*.log` to `services.vlagent` in the NixOS base profile via `extraArgs`.

## Why

The NixOS profile passed no glob, so the vlagent file collector ingested nothing: container stdout under `/var/log/pods/**` (Envoy dataplane, controllers) and host service logs never reached VictoriaLogs. Verified live on `sashina`: `flag{name="fileCollector.glob", value="", is_set="false"}` and an empty store. The darwin profile already carried the glob; this mirrors it so incident windows have data (the Sep 9-10 outage was unreconstructable from logs).

## References

- https://github.com/shikanime-labs/manifests/issues/2255
- Verified: `nix eval .#nixosConfigurations.sashina.config.services.vlagent.extraArgs` resolves; all 9 hosts eval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Host log collection now includes system logs and Kubernetes container output from standard log paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->