### PR TITLE
Add kushira and sashina to distributed build and SSH rosters

### DIFF
--- a/modules/darwin/profiles/distributed.nix
+++ b/modules/darwin/profiles/distributed.nix
@@ -36,8 +36,10 @@ in
   nix = {
     buildMachines = mkBuildMachines [
       (mkBeelinkBuildMachine "ashira")
+      (mkBeelinkBuildMachine "kushira")
       (mkBeelinkBuildMachine "manash")
       (mkBeelinkBuildMachine "nalsha")
+      (mkBeelinkBuildMachine "sashina")
       (mkRpiBuildMachine "fushi")
       (mkRpiBuildMachine "minish")
       (mkRpiBuildMachine "nemishi")

--- a/modules/home/workstation.nix
+++ b/modules/home/workstation.nix
@@ -96,11 +96,13 @@ in
         "ashira.taila659a.ts.net" = mkSshHeadlessHost "nishir";
         "catbox.taila659a.ts.net" = mkSshHeadlessHost "shika";
         "fushi.taila659a.ts.net" = mkSshHeadlessHost "nishir";
+        "kushira.taila659a.ts.net" = mkSshHeadlessHost "nishir";
         "manash.taila659a.ts.net" = mkSshHeadlessHost "nishir";
         "minish.taila659a.ts.net" = mkSshHeadlessHost "nishir";
         "nalsha.taila659a.ts.net" = mkSshHeadlessHost "nishir";
         "nemishi.taila659a.ts.net" = mkSshHeadlessHost "nishir";
         "nixtar.taila659a.ts.net" = mkSshWorkstationHost "shika";
+        "sashina.taila659a.ts.net" = mkSshHeadlessHost "nishir";
         "thinkcentre-m710t.tailfb4bb2.ts.net" = mkSshWorkstationHost "william-phetsinorath";
       };
     };

--- a/modules/nixos/profiles/distributed.nix
+++ b/modules/nixos/profiles/distributed.nix
@@ -55,8 +55,10 @@ in
   nix = {
     buildMachines = mkBuildMachines [
       (mkBeelinkBuildMachine "ashira")
+      (mkBeelinkBuildMachine "kushira")
       (mkBeelinkBuildMachine "manash")
       (mkBeelinkBuildMachine "nalsha")
+      (mkBeelinkBuildMachine "sashina")
       (mkRpiBuildMachine "fushi")
       (mkRpiBuildMachine "minish")
       (mkRpiBuildMachine "nemishi")
@@ -90,6 +92,14 @@ in
     (mkSshKnownHost {
       hostName = "nalsha";
       publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGAFFXlS4bbJnvo2CaPdKPHX2EFyrfF/KHfcwsVgOffE";
+    })
+    (mkSshKnownHost {
+      hostName = "kushira";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGFPJ7GiWGH7MpJDlRz2Y+38U9AMnWELE/h7oGO6ec4K";
+    })
+    (mkSshKnownHost {
+      hostName = "sashina";
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIII1QSdrWGafRNTuyBxRhm8NNLG+37Zfk3+i42sUbEB3";
     })
   ];
 }


### PR DESCRIPTION
## What

Registers kushira and sashina in the distributed build rosters and workstation SSH settings.

- Both nodes added as x86_64 build machines in the nixos and darwin distributed profiles
- SSH host keys published to the fleet knownHosts
- Tailnet SSH settings entries for both hostnames on the workstation

## Why

Both MS-S1 hosts existed as flake configurations but were absent from the build rosters, so distributed builds never offloaded to them, and workstation SSH to their tailnet names fell back to defaults instead of the fleet headless settings.

## References

Related: https://github.com/shikanime-labs/machines/issues/1310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added two Beelink machines to the distributed build pool.
  - Added secure remote access configuration for the new headless build host.
  - Updated an existing host to operate as a headless machine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->