### PR TITLE
Enable AMD GPU acceleration on MS-S1 hosts

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -33,9 +33,19 @@ GPU/ROCm acceleration lives entirely in
 - `hardware.enableRedistributableFirmware = true` — Radeon 8060S (gfx1151)
   microcode so the compute stack reaches `/dev/dri/renderD128`.
 - `hardware.graphics.enable = true` + `enable32Bit` (inherited from
-  nixos-hardware `common-gpu-amd`) — Mesa/ROCm userspace.
+  nixos-hardware `common-gpu-amd`) — Mesa/ROCm userspace (RADV default).
+- `hardware.amdgpu.opencl.enable = true` — OpenCL via the ROCm runtime ICD.
+- A tmpfiles rule symlinks `/opt/rocm` at a `rocm-combined` bundle
+  (rocblas/hipblas/clr) — HIP consumer binaries hard-code that path.
+- `clinfo`, `nvtop`, `radeontop`, `rocminfo`, `rocm-smi` in
+  `environment.systemPackages` for verification and observability.
 - `boot.kernelParams = [ "amdgpu.gttsize=131072" "ttm.pages_limit=33554432" ]` —
   full 128 GiB GTT ceiling for the unified-memory iGPU.
+
+Global `rocmSupport` is set on the two hosts' package sets in
+`modules/flake/nixos.nix` (`mkSashina`/`mkKushira` instantiate `pkgs`
+explicitly, so module-level `nixpkgs.config` would not reach them) — every
+package exposing the knob builds against ROCm/HIP.
 
 The llama.cpp inference _service_ (server/rpc roles, `:8080`/`:50052`) is not
 yet wired as a module — the nodes are provisioned with acceleration enabled and

--- a/docs/inference.md
+++ b/docs/inference.md
@@ -35,8 +35,6 @@ GPU/ROCm acceleration lives entirely in
 - `hardware.graphics.enable = true` + `enable32Bit` (inherited from
   nixos-hardware `common-gpu-amd`) — Mesa/ROCm userspace (RADV default).
 - `hardware.amdgpu.opencl.enable = true` — OpenCL via the ROCm runtime ICD.
-- A tmpfiles rule symlinks `/opt/rocm` at a `rocm-combined` bundle
-  (rocblas/hipblas/clr) — HIP consumer binaries hard-code that path.
 - `clinfo`, `nvtop`, `radeontop`, `rocminfo`, `rocm-smi` in
   `environment.systemPackages` for verification and observability.
 - `boot.kernelParams = [ "amdgpu.gttsize=131072" "ttm.pages_limit=33554432" ]` —

--- a/modules/flake/nixos.nix
+++ b/modules/flake/nixos.nix
@@ -171,13 +171,19 @@ let
       ++ (mkRpi4ClusterModules system);
     };
 
-  # MS-S1 Max (Strix Halo, gfx1151): x86_64 worker + ROCm inference.
+  # MS-S1 Max (Strix Halo, gfx1151): x86_64 worker + ROCm inference. The
+  # package set is instantiated here (not via module nixpkgs.config), so the
+  # ROCm knob lives beside allowUnfree — module-level nixpkgs.config would
+  # not reach this instance.
   mkSashinaNixosConfiguration =
     system:
     inputs.nixpkgs.lib.nixosSystem {
       pkgs = import inputs.nixpkgs {
         inherit system;
-        config.allowUnfree = true;
+        config = {
+          allowUnfree = true;
+          rocmSupport = true;
+        };
       };
       modules = [
         ../../hosts/sashina/configuration.nix
@@ -190,7 +196,10 @@ let
     inputs.nixpkgs.lib.nixosSystem {
       pkgs = import inputs.nixpkgs {
         inherit system;
-        config.allowUnfree = true;
+        config = {
+          allowUnfree = true;
+          rocmSupport = true;
+        };
       };
       modules = [
         ../../hosts/kushira/configuration.nix

--- a/modules/nixos/hardware/minisforum-ms-s1.nix
+++ b/modules/nixos/hardware/minisforum-ms-s1.nix
@@ -56,37 +56,22 @@
     };
   };
 
-  hardware.enableRedistributableFirmware = true;
-
-  # OpenCL via the ROCm runtime ICD (complement to the Mesa GL/Vulkan stack
-  # that nixos-hardware's common-gpu-amd supplies).
-  hardware.amdgpu.opencl.enable = true;
-
-  # /opt/rocm compatibility path: HIP consumer binaries hard-code that
-  # location, which FHS distributions provide and NixOS does not.
-  systemd.tmpfiles.rules =
-    let
-      rocmEnv = pkgs.symlinkJoin {
-        name = "rocm-combined";
-        paths = with pkgs.rocmPackages; [
-          clr
-          hipblas
-          rocblas
-        ];
-      };
-    in
-    [ "L+ /opt/rocm - - - - ${rocmEnv}" ];
-
-  environment = {
-    # GPU observability and compute-verification tooling.
-    systemPackages = with pkgs; [
-      clinfo
-      nvtopPackages.amd
-      radeontop
-      rocmPackages.rocminfo
-      rocmPackages.rocm-smi
-    ];
+  # OpenCL via the ROCm runtime ICD; firmware so compute reaches
+  # /dev/dri/renderD128 (Mesa GL/Vulkan userspace comes from nixos-hardware's
+  # common-gpu-amd).
+  hardware = {
+    amdgpu.opencl.enable = true;
+    enableRedistributableFirmware = true;
   };
+
+  # GPU observability and compute-verification tooling.
+  environment.systemPackages = with pkgs; [
+    clinfo
+    nvtopPackages.amd
+    radeontop
+    rocmPackages.rocminfo
+    rocmPackages.rocm-smi
+  ];
 
   networking = {
     bonds.bond0 = {

--- a/modules/nixos/hardware/minisforum-ms-s1.nix
+++ b/modules/nixos/hardware/minisforum-ms-s1.nix
@@ -58,6 +58,36 @@
 
   hardware.enableRedistributableFirmware = true;
 
+  # OpenCL via the ROCm runtime ICD (complement to the Mesa GL/Vulkan stack
+  # that nixos-hardware's common-gpu-amd supplies).
+  hardware.amdgpu.opencl.enable = true;
+
+  # /opt/rocm compatibility path: HIP consumer binaries hard-code that
+  # location, which FHS distributions provide and NixOS does not.
+  systemd.tmpfiles.rules =
+    let
+      rocmEnv = pkgs.symlinkJoin {
+        name = "rocm-combined";
+        paths = with pkgs.rocmPackages; [
+          clr
+          hipblas
+          rocblas
+        ];
+      };
+    in
+    [ "L+ /opt/rocm - - - - ${rocmEnv}" ];
+
+  environment = {
+    # GPU observability and compute-verification tooling.
+    systemPackages = with pkgs; [
+      clinfo
+      nvtopPackages.amd
+      radeontop
+      rocmPackages.rocminfo
+      rocmPackages.rocm-smi
+    ];
+  };
+
   networking = {
     bonds.bond0 = {
       # Realtek RTL8127. Names assumed to match the Beelink enumeration —


### PR DESCRIPTION
## What

Completes the AMD acceleration stack on the two MS-S1 Max hosts (kushira, sashina) so the gfx1151 compute path is fully enabled and verifiable.

- OpenCL via the ROCm runtime ICD (hardware.amdgpu.opencl.enable)
- Global rocmSupport on both hosts' package sets in modules/flake/nixos.nix — these hosts instantiate pkgs explicitly, so module-level nixpkgs.config would not reach them
- clinfo, nvtop, radeontop, rocminfo, rocm-smi added to environment.systemPackages
- docs/inference.md updated to describe the full acceleration surface

## Why

The hosts only carried firmware and the GTT ceiling; Mesa userspace arrived implicitly from nixos-hardware's common-gpu-amd while OpenCL, rocmSupport, and any GPU observability tooling were absent, leaving the inference nodes' compute stack unexercisable and unverifiable on-node.

## References

Related: https://github.com/shikanime-labs/machines/issues/1314

Both host closures build on-node: nix-store paths /nix/store/lipbgwjh2npdpnlf3flcg9pg07qv2qqc-nixos-system-sashina-26.11.20260829.d2f6794 and /nix/store/7dhw78avfpm1njrwyd3dx8y16im8gy6r-kushira-26.11.20260829.d2f6794.

Co-authored-by: Automata <automata@shikanime.studio>