### PR TITLE
Route llama.cpp RPC over the USB4 peer link

### DIFF
--- a/hosts/kushira/configuration.nix
+++ b/hosts/kushira/configuration.nix
@@ -25,9 +25,7 @@
     ];
   };
 
-  # Static address on the USB4 peer link (see
-  # modules/nixos/hardware/minisforum-ms-s1.nix "40-thunderbolt"); sashina
-  # holds 10.66.0.1/29 and the Multus pod attachments pin 10.66.0.3-.5.
+  # USB4 peer link /29 (sashina .1; Multus pods .3-.5).
   systemd.network.networks."40-thunderbolt".address = [ "10.66.0.2/29" ];
 
   services = {

--- a/hosts/kushira/configuration.nix
+++ b/hosts/kushira/configuration.nix
@@ -25,6 +25,11 @@
     ];
   };
 
+  # Static address on the USB4 peer link (see
+  # modules/nixos/hardware/minisforum-ms-s1.nix "40-thunderbolt"); sashina
+  # holds 10.66.0.1/29 and the Multus pod attachments pin 10.66.0.3-.5.
+  systemd.network.networks."40-thunderbolt".address = [ "10.66.0.2/29" ];
+
   services = {
     knix = {
       nodeIP = "192.168.1.91,2a02:8424:7899:f201:94eb:8d1:325a:c6e9";

--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -29,9 +29,7 @@
     ];
   };
 
-  # Static address on the USB4 peer link (see
-  # modules/nixos/hardware/minisforum-ms-s1.nix "40-thunderbolt"); kushira
-  # holds 10.66.0.2/29 and the Multus pod attachments pin 10.66.0.3-.5.
+  # USB4 peer link /29 (kushira .2; Multus pods .3-.5).
   systemd.network.networks."40-thunderbolt".address = [ "10.66.0.1/29" ];
 
   services = {

--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -29,6 +29,11 @@
     ];
   };
 
+  # Static address on the USB4 peer link (see
+  # modules/nixos/hardware/minisforum-ms-s1.nix "40-thunderbolt"); kushira
+  # holds 10.66.0.2/29 and the Multus pod attachments pin 10.66.0.3-.5.
+  systemd.network.networks."40-thunderbolt".address = [ "10.66.0.1/29" ];
+
   services = {
     knix = {
       nodeIP = "192.168.1.79,2a02:8424:7899:f201:94eb:8d1:325a:e4a0";

--- a/modules/nixos/hardware/minisforum-ms-s1.nix
+++ b/modules/nixos/hardware/minisforum-ms-s1.nix
@@ -1,4 +1,4 @@
-{ pkgs, config, ... }:
+{ pkgs, ... }:
 
 {
   boot = {
@@ -85,24 +85,17 @@
 
   systemd = {
     # Direct USB4 peer link (kushira <-> sashina) carrying the llama.cpp
-    # ggml RPC traffic (~8 us vs ~65 us over the 10G bond). Static /29 —
-    # no DHCP server exists on a bare cable. sashina .1, kushira .2;
-    # 10.66.0.3-.5 are pinned for the Multus pod attachments (manifests
-    # apps/llama-cpp*). MTU 65522 is the thunderbolt-net driver max
-    # (TBNET_MAX_MTU - ETH_HLEN). The address block is keyed by hostName
-    # so this single unit serves both peers; networkd binds the first
-    # matching .network exclusively, so hosts/sashina must not add a
-    # second tb-matching unit.
+    # ggml RPC traffic (~8 us vs ~65 us over the 10G bond). IPv4LL keeps
+    # the link self-configuring; the routable /29 addresses live in each
+    # host's configuration.nix on this same unit. 10.66.0.3-.5 are pinned
+    # for the Multus pod attachments (manifests apps/llama-cpp*). MTU
+    # 65522 is the thunderbolt-net driver max (TBNET_MAX_MTU - ETH_HLEN).
     network.networks."40-thunderbolt" = {
       matchConfig.Driver = "thunderbolt-net";
       linkConfig = {
         MTUBytes = 65522;
         RequiredForOnline = "no";
       };
-      networkConfig.LinkLocalAddressing = "no";
-      address = [
-        (if config.networking.hostName == "sashina" then "10.66.0.1/29" else "10.66.0.2/29")
-      ];
     };
 
     # NIC performance tuning: hardware offloads + RPS for both RTL8127 ports.

--- a/modules/nixos/hardware/minisforum-ms-s1.nix
+++ b/modules/nixos/hardware/minisforum-ms-s1.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, config, ... }:
 
 {
   boot = {
@@ -84,16 +84,25 @@
   services.fstrim.enable = true;
 
   systemd = {
-    # Direct USB4 peer link (kushira <-> sashina). IPv4LL keeps it
-    # config-free; no DHCP server exists on a bare cable. MTU 65522 is
-    # the thunderbolt-net driver max (TBNET_MAX_MTU - ETH_HLEN).
+    # Direct USB4 peer link (kushira <-> sashina) carrying the llama.cpp
+    # ggml RPC traffic (~8 us vs ~65 us over the 10G bond). Static /29 —
+    # no DHCP server exists on a bare cable. sashina .1, kushira .2;
+    # 10.66.0.3-.5 are pinned for the Multus pod attachments (manifests
+    # apps/llama-cpp*). MTU 65522 is the thunderbolt-net driver max
+    # (TBNET_MAX_MTU - ETH_HLEN). The address block is keyed by hostName
+    # so this single unit serves both peers; networkd binds the first
+    # matching .network exclusively, so hosts/sashina must not add a
+    # second tb-matching unit.
     network.networks."40-thunderbolt" = {
       matchConfig.Driver = "thunderbolt-net";
       linkConfig = {
         MTUBytes = 65522;
         RequiredForOnline = "no";
       };
-      networkConfig.LinkLocalAddressing = "ipv4";
+      networkConfig.LinkLocalAddressing = "no";
+      address = [
+        (if config.networking.hostName == "sashina" then "10.66.0.1/29" else "10.66.0.2/29")
+      ];
     };
 
     # NIC performance tuning: hardware offloads + RPS for both RTL8127 ports.

--- a/modules/nixos/hardware/minisforum-ms-s1.nix
+++ b/modules/nixos/hardware/minisforum-ms-s1.nix
@@ -84,12 +84,7 @@
   services.fstrim.enable = true;
 
   systemd = {
-    # Direct USB4 peer link (kushira <-> sashina) carrying the llama.cpp
-    # ggml RPC traffic (~8 us vs ~65 us over the 10G bond). IPv4LL keeps
-    # the link self-configuring; the routable /29 addresses live in each
-    # host's configuration.nix on this same unit. 10.66.0.3-.5 are pinned
-    # for the Multus pod attachments (manifests apps/llama-cpp*). MTU
-    # 65522 is the thunderbolt-net driver max (TBNET_MAX_MTU - ETH_HLEN).
+    # USB4 peer link for llama.cpp RPC; host /29s in configuration.nix, pods pin .3-.5.
     network.networks."40-thunderbolt" = {
       matchConfig.Driver = "thunderbolt-net";
       linkConfig = {

--- a/modules/nixos/profiles/nishir.nix
+++ b/modules/nixos/profiles/nishir.nix
@@ -18,6 +18,8 @@ with lib;
         ip6tables -I INPUT -i br+ -j ACCEPT
         iptables -I FORWARD -i br+ -j ACCEPT
         ip6tables -I FORWARD -i br+ -j ACCEPT
+        iptables -I INPUT -i tb+ -j ACCEPT
+        iptables -I FORWARD -i tb+ -j ACCEPT
         iptables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT
         ip6tables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT
       '';
@@ -26,8 +28,10 @@ with lib;
         ip6tables -D INPUT -i br+ -j ACCEPT 2>/dev/null || true
         iptables -D FORWARD -i br+ -j ACCEPT 2>/dev/null || true
         ip6tables -D FORWARD -i br+ -j ACCEPT 2>/dev/null || true
+        iptables -D INPUT -i tb+ -j ACCEPT 2>/dev/null || true
+        iptables -D FORWARD -i tb+ -j ACCEPT 2>/dev/null || true
         iptables -D FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
-        ip6tables -D FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
+        ip6tables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
       '';
     };
 


### PR DESCRIPTION
## What

- Keep IPv4LL attribution on the shared `40-thunderbolt` networkd unit and let each host pin its routable address on that same unit: `10.66.0.1/29` on sashina, `10.66.0.2/29` on kushira (host `configuration.nix`).
- Accept `tb+` ingress and forward in the nishir cluster firewall profile, mirroring the existing `br+` rules.

## Why

The llama.cpp leader pod (sashina) dials its ggml RPC workers over the 10G bond today (~65 us hop). The direct USB4 cable between the MS-S1 nodes measures ~8 us in community benchmarks and `docs/inference.md` already names the USB4 ring as the first move if RPC latency binds. This lands the host side: a deterministic, DHCP-free /29 segment on tb0 so the Multus pod attachments in manifests can pin `10.66.0.3-.5` for the leader and both RPC servers.

The MTU stays at the committed 65522 (thunderbolt-net driver max); the routable addresses ride the same unit as the MTU config because networkd binds the first matching `.network` exclusively. `10.66.0.0/29` is collision-free across the fleet config.

## References

- Depends-on consumer: shikanime-labs/manifests#2267 attaches pods to this link via Multus (merge after this PR).
- `docs/inference.md` USB4 guidance: ~8 us vs ~65 us RPC hop.
