### PR TITLE
Document Nix attribute style convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,9 @@ full directory layout.
 - sops-nix — encrypted secrets (`secrets/*.enc.yaml`)
 - devenv — repository dev shell
 - treefmt-nix — formatting (`nix fmt`)
-- Nix style: prefer dotted-attribute assignment (`a.b.c = v;`) over nested
-  record literals (`a = { b = { c = v; }; };`) when setting a single leaf under
-  a shared parent key. Run `nix fmt` before committing.
+- Nix style: dotted assignment (`a.b.c = v;`) for a single leaf under a shared
+  parent key; a record literal (`a = { b = …; c = …; };`) once two or more keys
+  share that parent, with keys sorted. Run `nix fmt` before committing.
 - comin — declarative remote deployment
 
 ## Common Commands


### PR DESCRIPTION
## What

Documents the Nix attribute-style rule in AGENTS.md: dotted assignment (`a.b.c = v;`) for a single leaf under a shared parent key; a record literal once two or more keys share that parent, with keys sorted.

## Why

The convention previously lived only in the machines repo and drove review churn elsewhere; every Nix-touching repo now carries the same rule.

## References

Related: https://github.com/shikanime-labs/machines/pull/1315

Co-authored-by: Automata <automata@shikanime.studio>
