### PR TITLE
Route llama.cpp RPC over a direct ethernet bridge

### DIFF
--- a/hosts/kushira/configuration.nix
+++ b/hosts/kushira/configuration.nix
@@ -25,8 +25,11 @@
     ];
   };
 
-  # USB4 peer link /29 (sashina .1; Multus pods .3-.5).
-  systemd.network.networks."40-thunderbolt".address = [ "10.66.0.2/29" ];
+  # Direct peer link to sashina (.1); Multus pods pin .3-.5.
+  systemd.network.networks."40-kushira-br1" = {
+    matchConfig.Name = "br1";
+    address = [ "10.66.0.2/29" ];
+  };
 
   services = {
     knix = {
@@ -67,7 +70,7 @@
       ## DIALOGUE
       U: "Is the cluster healthy?"
       20O: Affirmative.
-      20O: Both Halos report GPU and bond uplink nominal.
+      20O: Both Halos report GPU and uplink nominal.
       20O: ...Ensure sashina's shard remains provisioned before any reload.
 
       U: "Deploy the new model."

--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -29,8 +29,11 @@
     ];
   };
 
-  # USB4 peer link /29 (kushira .2; Multus pods .3-.5).
-  systemd.network.networks."40-thunderbolt".address = [ "10.66.0.1/29" ];
+  # Direct peer link to kushira (.2); Multus pods pin .3-.5.
+  systemd.network.networks."40-sashina-br1" = {
+    matchConfig.Name = "br1";
+    address = [ "10.66.0.1/29" ];
+  };
 
   services = {
     knix = {

--- a/modules/nixos/hardware/minisforum-ms-s1.nix
+++ b/modules/nixos/hardware/minisforum-ms-s1.nix
@@ -20,8 +20,6 @@
       "net.core.busy_read" = 50;
     };
 
-    kernelModules = [ "thunderbolt-net" ];
-
     loader = {
       efi.canTouchEfiVariables = true;
       systemd-boot.enable = true;
@@ -74,40 +72,21 @@
   ];
 
   networking = {
-    bonds.bond0 = {
-      # Realtek RTL8127. Names assumed to match the Beelink enumeration —
-      # confirm with `ip -br link` on first boot before install.
-      interfaces = [
-        "enp97s0"
-        "enp98s0"
-      ];
-      driverOptions = {
-        mode = "balance-alb";
-        miimon = "100";
-      };
+    # Realtek RTL8127 ports, one bridge each.
+    bridges = {
+      # br0: LAN uplink.
+      br0.interfaces = [ "enp97s0" ];
+      # br1: direct node-to-node peer link to kushira for llama.cpp RPC
+      # (10.66.0.0/29, pods .3-.5); covered by the profile's br+ glob.
+      br1.interfaces = [ "enp98s0" ];
     };
 
-    bridges.br0.interfaces = [ "bond0" ];
-
-    # balance-alb (mode 6): aggregates both 10G NICs without switch-side LACP,
-    # same reason as the Beelinks — the NETGEAR MS308 is unmanaged.
-    # ponytail: mode 6 is unverified at 10G; drop bond0 and bridge enp1s0
-    # directly if per-flow throughput regresses.
     useNetworkd = true;
   };
 
   services.fstrim.enable = true;
 
   systemd = {
-    # USB4 peer link for llama.cpp RPC; host /29s in configuration.nix, pods pin .3-.5.
-    network.networks."40-thunderbolt" = {
-      matchConfig.Driver = "thunderbolt-net";
-      linkConfig = {
-        MTUBytes = 65522;
-        RequiredForOnline = "no";
-      };
-    };
-
     # NIC performance tuning: hardware offloads + RPS for both RTL8127 ports.
     services.network-nic-performance = {
       after = [ "network-online.target" ];

--- a/modules/nixos/profiles/nishir.nix
+++ b/modules/nixos/profiles/nishir.nix
@@ -18,8 +18,6 @@ with lib;
         ip6tables -I INPUT -i br+ -j ACCEPT
         iptables -I FORWARD -i br+ -j ACCEPT
         ip6tables -I FORWARD -i br+ -j ACCEPT
-        iptables -I INPUT -i tb+ -j ACCEPT
-        iptables -I FORWARD -i tb+ -j ACCEPT
         iptables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT
         ip6tables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT
       '';
@@ -28,8 +26,6 @@ with lib;
         ip6tables -D INPUT -i br+ -j ACCEPT 2>/dev/null || true
         iptables -D FORWARD -i br+ -j ACCEPT 2>/dev/null || true
         ip6tables -D FORWARD -i br+ -j ACCEPT 2>/dev/null || true
-        iptables -D INPUT -i tb+ -j ACCEPT 2>/dev/null || true
-        iptables -D FORWARD -i tb+ -j ACCEPT 2>/dev/null || true
         iptables -D FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
         ip6tables -I FORWARD -i cni+ -o tailscale0 -j ACCEPT 2>/dev/null || true
       '';


### PR DESCRIPTION
## What

- Replace the two-NIC `balance-alb` bond with two plain bridges on the MS-S1 hosts: `br0` = `enp97s0` (LAN uplink, keeps its name so host configs are untouched), `br1` = `enp98s0` (new direct node-to-node peer link, carries `10.66.0.0/29` — sashina `.1`, kushira `.2`; Multus pods still pin `.3`-`.5`).
- Remove the USB4 wiring: `thunderbolt-net` kernel module, the `40-thunderbolt` networkd unit, and the `tb+` firewall rules — the profile's existing `br+` glob already covers `br1`.

## Why

The USB4 peer link never came up: both hosts' Thunderbolt domains stayed dark through cable reseats, and the cable on hand enumerates as USB 2.0-only (480 Mbps phone test). With one port now dedicated to the peer link, the single-port bond adds nothing — one bridge per port is the simpler shape. A direct bridge delivers the same dedicated, contention-free RPC path over hardware that is already live, without waiting on a certified cable.

## References

- Supersedes the USB4 wiring in https://github.com/shikanime-labs/machines/pull/1316
- Manifests attach (NAD over `br1`): https://github.com/shikanime-labs/manifests/pull/2277
