### PR TITLE
Keep only official ROCm tools on MS-S1 hosts

### DIFF
--- a/docs/inference.md
+++ b/docs/inference.md
@@ -35,8 +35,8 @@ GPU/ROCm acceleration lives entirely in
 - `hardware.graphics.enable = true` + `enable32Bit` (inherited from
   nixos-hardware `common-gpu-amd`) — Mesa/ROCm userspace (RADV default).
 - `hardware.amdgpu.opencl.enable = true` — OpenCL via the ROCm runtime ICD.
-- `clinfo`, `nvtop`, `radeontop`, `rocminfo`, `rocm-smi` in
-  `environment.systemPackages` for verification and observability.
+- `rocminfo`, `rocm-smi` in `environment.systemPackages` for verification and
+  observability.
 - `boot.kernelParams = [ "amdgpu.gttsize=131072" "ttm.pages_limit=33554432" ]` —
   full 128 GiB GTT ceiling for the unified-memory iGPU.
 

--- a/modules/nixos/hardware/minisforum-ms-s1.nix
+++ b/modules/nixos/hardware/minisforum-ms-s1.nix
@@ -64,9 +64,6 @@
 
   # GPU observability and compute-verification tooling.
   environment.systemPackages = with pkgs; [
-    clinfo
-    nvtopPackages.amd
-    radeontop
     rocmPackages.rocminfo
     rocmPackages.rocm-smi
   ];


### PR DESCRIPTION
## What

Removes the non-official GPU tooling from the MS-S1 hosts: the interactive monitors (nvtop, radeontop) and clinfo are dropped from environment.systemPackages; only the official ROCm tools (rocminfo, rocm-smi) remain.

## Why

The layer should carry only official software; compute verification and observability are fully covered by rocminfo and rocm-smi.

## References

Related: https://github.com/shikanime-labs/machines/pull/1315
