### PR TITLE
Restore bond0 uplink and drop the br1 peer link

### DIFF
--- a/hosts/kushira/configuration.nix
+++ b/hosts/kushira/configuration.nix
@@ -25,12 +25,6 @@
     ];
   };
 
-  # Direct peer link to sashina (.1); Multus pods pin .3-.5.
-  systemd.network.networks."40-kushira-br1" = {
-    matchConfig.Name = "br1";
-    address = [ "10.66.0.2/29" ];
-  };
-
   services = {
     knix = {
       nodeIP = "192.168.1.91,2a02:8424:7899:f201:94eb:8d1:325a:c6e9";

--- a/hosts/sashina/configuration.nix
+++ b/hosts/sashina/configuration.nix
@@ -29,12 +29,6 @@
     ];
   };
 
-  # Direct peer link to kushira (.2); Multus pods pin .3-.5.
-  systemd.network.networks."40-sashina-br1" = {
-    matchConfig.Name = "br1";
-    address = [ "10.66.0.1/29" ];
-  };
-
   services = {
     knix = {
       nodeIP = "192.168.1.79,2a02:8424:7899:f201:94eb:8d1:325a:e4a0";

--- a/modules/nixos/hardware/minisforum-ms-s1.nix
+++ b/modules/nixos/hardware/minisforum-ms-s1.nix
@@ -69,15 +69,23 @@
   ];
 
   networking = {
-    # Realtek RTL8127 ports, one bridge each.
-    bridges = {
-      # br0: LAN uplink.
-      br0.interfaces = [ "enp97s0" ];
-      # br1: direct node-to-node peer link to kushira for llama.cpp RPC
-      # (10.66.0.0/29, pods .3-.5); covered by the profile's br+ glob.
-      br1.interfaces = [ "enp98s0" ];
+    bonds.bond0 = {
+      # Realtek RTL8127. Names assumed to match the Beelink enumeration —
+      # confirm with `ip -br link` on first boot before install.
+      interfaces = [
+        "enp97s0"
+        "enp98s0"
+      ];
+      driverOptions = {
+        mode = "balance-alb";
+        miimon = "100";
+      };
     };
 
+    bridges.br0.interfaces = [ "bond0" ];
+
+    # balance-alb (mode 6): aggregates both 10G NICs without switch-side LACP,
+    # same reason as the Beelinks — the NETGEAR MS308 is unmanaged.
     useNetworkd = true;
   };
 


### PR DESCRIPTION
## What

- Restores the `bond0` balance-alb bond of both RTL8127 ports bridged into `br0` on the MS-S1 hosts.
- Removes the `br1` bridge and the per-host `40-*-br1` /29 address units on sashina and kushira.

## Why

Cross-node pod traffic is currently blackholed between the control plane and the workers, and the br1 peer link only exists to carry llama.cpp RPC traffic that #2279 already moved to the headless service over the cluster network. Reverting to the bonded uplink removes the unused direct path and the pinning it imposes on the two inference nodes.

## References

Related: https://github.com/shikanime-labs/machines/issues/1323
Related: https://github.com/shikanime-labs/manifests/issues/2283


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Networking**
  - Updated Minisforum systems to combine two network ports into a single bonded connection for improved link handling.
  - Updated the primary network bridge to use the bonded connection.
  - Removed the dedicated direct peer-link bridge and its static addresses from the affected hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->