### PR TITLE
Repin llama.cpp to upstream master to fix sharded-MoE RPC warmup crash

### DIFF
--- a/pkgs/llama-cpp/default.nix
+++ b/pkgs/llama-cpp/default.nix
@@ -8,11 +8,11 @@
   rpcSupport = true;
 }).overrideAttrs
   (_old: {
-    version = "0.4.0-glm5next";
+    version = "0.4.0";
     src = pkgs.fetchFromGitHub {
-      owner = "unslothai";
+      owner = "ggml-org";
       repo = "llama.cpp";
-      rev = "d94f44e79aa219d8057e8de21f95360a187ebf41";
-      hash = "sha256-Z4OGKjsegqMu0Bj/EtPDkZuf4URCqvGvA4egEz52WmE=";
+      rev = "8ea290247c87ced2ab245b056ffe96dbcf90d36c";
+      hash = "sha256-xfYNmpyXP/Uhg2zetwcBSMwvM5dK807K4dpdzonBlKA=";
     };
   })


### PR DESCRIPTION
## What
- Repins `pkgs/llama-cpp` from the unslothai fork (`d94f44e7`, diverged 33/43 from master) to upstream master `8ea290247`.
- Drops the fork pin entirely — no patch carry, single 8-line source swap.

## Why
qwen3.8-flash (`qwen4_exp`) deterministically aborts at warmup over RPC with `GGML_ASSERT(offset + size <= ggml_nbytes(tensor))` at ggml-backend.cpp:283 (evidence: manifests #2320). The fix ("skip 0-sized ids tensor when offloading selected experts", ggml-org #28739) landed upstream after the fork's last sync; repinning brings it plus 32 more upstream commits. GLM-5.3-Flash (`glm5next` arch) is not in upstream master yet — serving it waits on a later sync, accepted trade-off per operator.

## References
- Evidence matrix and lineage analysis: https://github.com/shikanime-labs/manifests/issues/2320
- The fix commit: https://github.com/ggml-org/llama.cpp/commit/43f3dda62
- Upstream PR: https://github.com/ggml-org/llama.cpp/pull/28739
Related: https://github.com/shikanime-labs/manifests/issues/2320