### PR TITLE
Ship the RADV ICD so the Vulkan backend actually engages

### DIFF
--- a/pkgs/llama-cpp-oci-image/default.nix
+++ b/pkgs/llama-cpp-oci-image/default.nix
@@ -15,7 +15,12 @@ pkgs.dockerTools.buildLayeredImage {
     pkgs.dockerTools.caCertificates
     pkgs.dockerTools.usrBinEnv
     llama-cpp
-  ];
+  ] ++ lib.optional pkgs.stdenv.hostPlatform.isx86_64 pkgs.mesa;
+
+  extraCommands = lib.optionalString pkgs.stdenv.hostPlatform.isx86_64 ''
+    mkdir -p etc/vulkan/icd.d
+    ln -sf ${pkgs.mesa}/share/vulkan/icd.d/*.json etc/vulkan/icd.d/
+  '';
 
   config = {
     Entrypoint = [ "${llama-cpp}/bin/llama-server" ];
@@ -25,6 +30,8 @@ pkgs.dockerTools.buildLayeredImage {
       "--port"
       "9931"
     ];
+    Env = lib.optional pkgs.stdenv.hostPlatform.isx86_64
+      "VK_DRIVER_FILES=${pkgs.mesa}/share/vulkan/icd.d/radeon_icd.${pkgs.stdenv.hostPlatform.parsed.cpu.name}.json";
     ExposedPorts = {
       "9931/tcp" = { };
     };

--- a/pkgs/llama-cpp/default.nix
+++ b/pkgs/llama-cpp/default.nix
@@ -3,9 +3,8 @@
   ...
 }:
 
-(pkgs.llama-cpp.override {
-  vulkanSupport = true;
-  rpcSupport = true;
+(pkgs.llama-cpp-vulkan.override {
+  llama-cpp = pkgs.llama-cpp.override { rpcSupport = true; };
 }).overrideAttrs
   (_old: {
     version = "0.4.0";


### PR DESCRIPTION
## What

Ship RADV with the llama-cpp image: `mesa` in the closure (x86_64 only) plus `VK_DRIVER_FILES`, and install the ICD under `/etc/vulkan/icd.d` as well so discovery does not rest on the env var alone.

## Why

The image ships `vulkan-loader` with no driver. `libggml-vulkan.so` is mapped in every child and `/dev/kfd` + `/dev/dri` are mounted on both the leader and the RPC worker, yet ggml enumerates zero devices — the worker banner reads `Devices: CPU: AMD RYZEN AI MAX+ 395 (126433 MiB free)`, so all compute falls back to `libggml-cpu-zen4.so`. Every throughput number collected to date is therefore a CPU-only measurement, not a GPU one.

Measured on the deployed pair (`0aa31db2`), dense qwen3.8-27B, server-side print_timing: prefill 25.5 t/s, decode 7.81 t/s, with the RPC worker pinned at 14.6 cores and the leader idle at 4m. Splitting layers across both nodes (`n-gpu-layers`) moved it only +9% / +4%, because layers execute serially through the chain — the wall is per-node CPU GEMM, not the fabric.

Mounting the hosts' `/run/opengl-driver` is not an alternative: it carries the ROCm/CLR stack (clr-7.2.3) and no Vulkan ICD (verified on-node; the image's `llama-server --list-devices` prints none).

aarch64 is deliberately unchanged: no AMD GPU there, and it avoids a multi-hundred-MB closure.

## Verification

- `nix eval .#packages.x86_64-linux.llama-cpp-oci-image.name` → ok
- `nix eval .#packages.aarch64-linux.llama-cpp-oci-image.name` → ok
- CI is the arbiter of whether RADV builds for x86_64 (Vulkan compiles run ~30 min, background).
- Post-deploy: confirm the `Devices:` banner lists a Vulkan device, then re-bench — the MTP ladder baseline (17.5 t/s) is CPU-era and must be re-measured. The sharded-MoE RPC retest follows that, since the wedge is a buffer-bounds rejection whose behaviour is layout-dependent.

## References

- shikanime-labs/machines#1328 — the Vulkan switch this completes
- shikanime-labs/machines#1314 — host-side GPU stack
- shikanime-labs/manifests#2320 — MoE RPC verdict; a live GPU gates the retest


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - x86_64 OCI images now include Mesa and Vulkan Radeon driver support.
  - Vulkan is configured to use the architecture-specific Radeon driver on x86_64 systems.
- **Compatibility**
  - aarch64 images retain their existing contents and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->